### PR TITLE
fix: add missing WorkoutPlan import in exercises.py

### DIFF
--- a/app/api/exercises.py
+++ b/app/api/exercises.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models.exercise import Exercise
-from app.models.workout import ExerciseSet, WorkoutSession
+from app.models.workout import ExerciseSet, WorkoutPlan, WorkoutSession
 from app.schemas.requests import ExerciseCreate, ExerciseResponse
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- Fixes `NameError: name 'WorkoutPlan' is not defined` when calling the exercise history endpoint
- `WorkoutPlan` was used in a SQLAlchemy query on line 154 but never imported

## Test plan
- [ ] `GET /exercises/{id}/history` no longer crashes with NameError
- [ ] All existing tests pass (`pytest tests/`)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)