### PR TITLE
fix: use .is_not(None) for SQLAlchemy NULL comparisons

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -48,7 +48,7 @@ async def get_progress(
         sets_result = await db.execute(
             select(ExerciseSet).where(
                 ExerciseSet.workout_session_id == session.id,
-                ExerciseSet.actual_reps != None,
+                ExerciseSet.actual_reps.is_not(None),
             )
         )
         sets = sets_result.scalars().all()
@@ -122,7 +122,7 @@ async def get_recommendations(
         sets_result = await db.execute(
             select(ExerciseSet).where(
                 ExerciseSet.workout_session_id == session.id,
-                ExerciseSet.actual_reps != None,
+                ExerciseSet.actual_reps.is_not(None),
             )
         )
         sets = sets_result.scalars().all()


### PR DESCRIPTION
## Summary
- Replaces `ExerciseSet.actual_reps != None` with `ExerciseSet.actual_reps.is_not(None)` in both queries in `progress.py`
- `!= None` triggers `SAWarning: Comparison to None using '!='` in SQLAlchemy 2 and can produce incorrect SQL; `.is_not(None)` compiles to proper `IS NOT NULL`

## Test plan
- [ ] `GET /progress/` returns results without SQLAlchemy warnings
- [ ] `GET /progress/recommendations` returns results without warnings
- [ ] All existing tests pass (`pytest tests/`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)