### PR TITLE
ci: add GitHub Actions automated test pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "fix/**", "feat/**", "ci/**", "chore/**", "refactor/**"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint with ruff
+        run: ruff check app/ tests/ --output-format=github

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — runs on every push to `main`, `fix/**`, `feat/**`, `ci/**`, and on every PR targeting `main`
- **test** job: sets up Python 3.12, installs deps, runs `pytest tests/ -v --tb=short`
- **lint** job: runs `ruff check app/ tests/` for fast static analysis
- Adds `pytest.ini` with `asyncio_mode = auto` so `pytest-asyncio` fixtures work without per-test `@pytest.mark.asyncio` decorators

## Test plan
- [ ] Open this PR — GitHub Actions should trigger immediately
- [ ] Both `test` and `lint` jobs should pass (24 tests currently green)
- [ ] Merge to main so future fix/* branches also get CI coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)