### PR TITLE
feat: reliable autofocus on exercise search modal

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { currentSession, exercises as exerciseStore, latestBodyWeight, settings } from '$lib/stores';
   import {
     getExercises, getPlan, getPlans, getRecentExercises, getSession,
@@ -678,15 +678,16 @@
     })()
   );
 
-  function openAddModal() {
+  async function openAddModal() {
     searchQuery = '';
     pickingExercise = null;
     pendingSets = 3;
     filterRegion = 'all';
     filterType = 'all';
     showAddModal = true;
-    // Focus the search box on the next frame once the modal is in the DOM
-    setTimeout(() => searchInputEl?.focus(), 50);
+    // Wait for Svelte to flush DOM updates, then focus immediately — no setTimeout needed
+    await tick();
+    searchInputEl?.focus();
   }
 
   function confirmAdd() {


### PR DESCRIPTION
## Summary
- Replaces `setTimeout(() => searchInputEl?.focus(), 50)` with `await tick(); searchInputEl?.focus()`
- `tick()` is Svelte's built-in way to wait for the DOM to flush after a reactive state change — it's synchronous and guaranteed, unlike an arbitrary 50ms delay
- Users can now immediately type in the search box the moment the modal opens, without having to tap/click the input field first

## Test plan
- [ ] Tap "Add Exercise" — keyboard should appear immediately on mobile
- [ ] On desktop, start typing the moment the modal opens — characters go into the search box
- [ ] Closing and reopening the modal still autofocuses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)