### PR TITLE
fix: resolve all CI failures (PYTHONPATH + lint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           pip install pytest pytest-asyncio httpx
 
       - name: Run tests
+        env:
+          PYTHONPATH: .
         run: pytest tests/ -v --tb=short
 
   lint:

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -369,8 +369,10 @@ async def create_session_from_plan(
 
     def rep_bracket(reps: int) -> int:
         """Same brackets as the in-workout drop-off."""
-        if reps >= 15: return 3
-        if reps >= 10: return 2
+        if reps >= 15:
+            return 3
+        if reps >= 10:
+            return 2
         return 1
 
     def epley_weight_for_reps(weight: float, done_reps: int, target_reps: int) -> float:

--- a/app/models/body_weight.py
+++ b/app/models/body_weight.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Float, Integer, String, Text
+from sqlalchemy import DateTime, Float, Integer, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base

--- a/app/models/exercise.py
+++ b/app/models/exercise.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 """Shared test fixtures."""
-import json
-import pytest
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -12,7 +12,6 @@ Key invariants:
   - Per-set progression: set 1 tracks set 1, set 2 tracks set 2, etc.
 """
 import pytest
-import pytest_asyncio
 from httpx import AsyncClient
 
 from tests.conftest import (
@@ -235,7 +234,7 @@ class TestPerSetIndependence:
         await log_set(client, sess1["id"], sets_by_num[2]["id"], 100.0, 7)
 
         # Week 2: 3 sets (added a set)
-        plan2 = await create_plan(client, ex["id"], sets=3, reps=8, name="Plan v2")
+        await create_plan(client, ex["id"], sets=3, reps=8, name="Plan v2")
         # We need sessions for THIS plan, so create a prior session under plan2
         # (In practice, user stays on same plan — simulate by using same plan but
         # pointing to ex data. Here we just verify no crash and set 3 gets something.)


### PR DESCRIPTION
## Summary
- **Test job**: add `PYTHONPATH: .` env var so pytest can resolve the `app` module on the runner
- **Lint job**: fix all ruff errors
  - Remove unused imports: `String`, `Float`, `json`, `pytest`, `pytest_asyncio`
  - E701: expand inline `if ...: return` in `sessions.py`
  - F841: drop unused `plan2` variable in tests

## Test plan
- [ ] CI `test` job goes green (24 tests pass)
- [ ] CI `lint` job goes green (ruff clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)