### PR TITLE
fix: UX improvements (#15 calendar, #16 nav warning, #18 recommendations)

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -284,6 +284,8 @@
         {@const isToday   = key === todayStr}
         {@const isSelected = key === selectedDay}
         {@const hasWorkout = hits.length > 0}
+        {@const hasCompleted = hits.some(s => s.status === 'completed')}
+        {@const hasAbandoned = hits.some(s => s.status !== 'completed' && s.status !== 'skipped')}
 
         <button
           onclick={() => hasWorkout && selectDay(key)}
@@ -297,8 +299,14 @@
           <span class="{isToday ? 'text-primary-400 font-bold' : ''}">{day}</span>
           {#if hasWorkout}
             <div class="flex gap-0.5">
-              {#each { length: Math.min(hits.length, 3) } as _}
-                <div class="w-1.5 h-1.5 rounded-full {isSelected ? 'bg-primary-300' : 'bg-primary-500'}"></div>
+              {#each hits.slice(0, 3) as s}
+                <div class="w-1.5 h-1.5 rounded-full {
+                  isSelected
+                    ? 'bg-primary-300'
+                    : s.status === 'completed'
+                      ? 'bg-green-500'
+                      : 'bg-gray-500'
+                }"></div>
               {/each}
             </div>
           {/if}

--- a/frontend/src/routes/progress/+page.svelte
+++ b/frontend/src/routes/progress/+page.svelte
@@ -138,9 +138,9 @@
   </div>
 
   <!-- Recommendations -->
+  <div class="card">
+    <h3 class="text-lg font-semibold mb-4">Progression Recommendations</h3>
   {#if recommendations.length > 0}
-    <div class="card">
-      <h3 class="text-lg font-semibold mb-4">Progression Recommendations</h3>
       <div class="overflow-x-auto">
         <table class="w-full text-left">
           <thead>
@@ -167,8 +167,12 @@
           </tbody>
         </table>
       </div>
-    </div>
+  {:else}
+    <p class="text-gray-400 text-center py-6">
+      No recommendations yet — complete at least one workout in the selected time range and the engine will suggest next weights based on your performance.
+    </p>
   {/if}
+  </div>
 
   <!-- Detailed Stats -->
   <div class="card">

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte';
+  import { beforeNavigate } from '$app/navigation';
   import { currentSession, exercises as exerciseStore, latestBodyWeight, settings } from '$lib/stores';
   import {
     getExercises, getPlan, getPlans, getRecentExercises, getSession,
@@ -169,6 +170,18 @@
   onDestroy(() => {
     if (clockInterval) clearInterval(clockInterval);
     if (restInterval) clearInterval(restInterval);
+  });
+
+  // Warn before leaving the page if there's an active session with incomplete sets
+  beforeNavigate(({ cancel }) => {
+    if (!$currentSession) return;
+    const hasUnsaved = uiExercises.some(ex => ex.sets.some(s => !s.done));
+    if (hasUnsaved) {
+      const confirmed = confirm(
+        'You have an active workout with unfinished sets. Leave anyway? Your progress so far is saved.'
+      );
+      if (!confirmed) cancel();
+    }
   });
 
   // ─── Start helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

### #15 — Calendar distinguishes completed vs abandoned workouts
- Completed session dots → green (`bg-green-500`)
- Abandoned/in-progress dots → gray (`bg-gray-500`)
- Makes it immediately obvious which days you actually finished

### #16 — Warn before navigating away from active workout
- Uses SvelteKit's `beforeNavigate` hook
- If there's an active session with any incomplete sets, shows a confirm dialog: *"You have an active workout with unfinished sets. Leave anyway? Your progress so far is saved."*
- Cancels navigation if user declines

### #18 — Empty recommendations panel shows explanation
- Panel is now always rendered (not hidden when empty)
- When no recommendations exist, shows: *"No recommendations yet — complete at least one workout in the selected time range..."*

## Test plan
- [ ] Calendar: complete a workout → green dot; abandon one → gray dot
- [ ] Active workout: tap back/nav link mid-workout → confirmation dialog appears; cancel stays on page
- [ ] Progress page with no data → recommendations card shows explanation text

Closes #15
Closes #16
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)