### PR TITLE
fix: prevent 'Create a plan' flash on dashboard load (#51)

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -13,9 +13,15 @@
   }
 
   let allSessions    = $state<WorkoutSession[]>([]);
-  let nextWorkout    = $state<NextWorkout | null>(null);
   let loading        = $state(true);
   let archiving      = $state(false);
+
+  // Derived so it re-evaluates whenever allSessions or workoutPlans changes —
+  // this prevents the "Create a plan" flash that occurred when the layout's
+  // getPlans() resolved after the dashboard's getSessions() completed.
+  let nextWorkout = $derived(
+    loading ? null : resolveNextWorkout(allSessions, $workoutPlans)
+  );
 
   // ── Calendar state ────────────────────────────────────────────────────
   const today      = new Date();
@@ -29,10 +35,15 @@
 
   onMount(async () => {
     try {
-      // Pull enough sessions to fill several months of calendar
-      const sessions = await getSessions({ limit: 200 });
+      // Fetch sessions and plans in parallel. Plans may not have resolved
+      // from the layout yet, so we fetch them here too to guarantee the
+      // nextWorkout derived value has both by the time loading = false.
+      const [sessions, plans] = await Promise.all([
+        getSessions({ limit: 200 }),
+        getPlans(),
+      ]);
       allSessions = sessions;
-      nextWorkout = resolveNextWorkout(sessions, $workoutPlans);
+      workoutPlans.set(plans);
     } catch (e) {
       console.error('Failed to load dashboard:', e);
     } finally {
@@ -96,7 +107,7 @@
       const [sessions, plans] = await Promise.all([getSessions({ limit: 200 }), getPlans()]);
       allSessions = sessions;
       workoutPlans.set(plans);
-      nextWorkout = resolveNextWorkout(sessions, plans);
+      // nextWorkout is $derived — no manual assignment needed
     } catch (e) {
       console.error('Failed to archive plan:', e);
     } finally {


### PR DESCRIPTION
## Summary
The layout's `getPlans()` and dashboard's `getSessions()` run concurrently. When sessions resolved first, `nextWorkout` was computed from an empty `$workoutPlans` store, briefly showing the "Create a plan" empty state.

**Root cause:** `nextWorkout` was a `$state` set once in `onMount`, not reactive to later plan data.

**Fix:**
- Convert `nextWorkout` to `$derived` — re-evaluates automatically whenever `allSessions` or `$workoutPlans` changes
- Dashboard `onMount` now fetches plans alongside sessions (`Promise.all`) so both are guaranteed to be populated before `loading = false`
- During load, `$derived` returns `null` (the `loading ? null` guard), so the skeleton card is shown — not the empty state

## Test plan
- [ ] Hard-reload the dashboard — no "Create a plan" flash before the next workout card appears
- [ ] Archive a plan → next workout card updates correctly without manual state
- [ ] CI passes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)