### PR TITLE
fix: prevent multiple simultaneous in-progress sessions

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -142,6 +142,19 @@ async def start_session(
             detail=f"Workout session {session_id} not found",
         )
 
+    existing_result = await db.execute(
+        select(WorkoutSession).where(
+            WorkoutSession.status == WorkoutStatus.IN_PROGRESS,
+            WorkoutSession.id != session_id,
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Session '{existing.name}' is already in progress (id={existing.id}). Complete or delete it first.",
+        )
+
     workout_session.status = WorkoutStatus.IN_PROGRESS
     workout_session.started_at = datetime.now(timezone.utc)
     await db.flush()
@@ -327,6 +340,17 @@ async def create_session_from_plan(
         )
 
     day_name = day.get("day_name", f"Day {day_number}")
+
+    # Guard: only one in-progress session at a time
+    existing_result = await db.execute(
+        select(WorkoutSession).where(WorkoutSession.status == WorkoutStatus.IN_PROGRESS)
+    )
+    existing = existing_result.scalar_one_or_none()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Session '{existing.name}' is already in progress (id={existing.id}). Complete or delete it first.",
+        )
 
     # ── Look up most recent prior session for the same plan + same day ────────
     # Require at least one set with actual_reps filled in — this is the real

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,14 @@ async def create_plan(client: AsyncClient, exercise_id: int, sets: int = 3,
 
 async def start_session_from_plan(client: AsyncClient, plan_id: int,
                                    day: int = 1, body_weight_kg: float = 0) -> dict:
+    # Complete any in-progress session before creating a new one (mirrors real workflow)
+    r_list = await client.get("/api/sessions/", params={"limit": 500})
+    assert r_list.status_code == 200, r_list.text
+    for s in r_list.json():
+        if s.get("status") == "in_progress":
+            rc = await client.post(f"/api/sessions/{s['id']}/complete")
+            assert rc.status_code == 200, rc.text
+
     r = await client.post(
         f"/api/sessions/from-plan/{plan_id}",
         params={"day_number": day, "overload_style": "rep", "body_weight_kg": body_weight_kg},

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -372,6 +372,7 @@ class TestWeightOverloadStyle:
         sess1 = await start_session_from_plan(client, plan["id"])
         for s in sess1["sets"]:
             await log_set(client, sess1["id"], s["id"], 100.0, 8)
+        await client.post(f"/api/sessions/{sess1['id']}/complete")
 
         r = await client.post(
             f"/api/sessions/from-plan/{plan['id']}",


### PR DESCRIPTION
## Summary
- Adds a 409 Conflict guard in `create_session_from_plan` to block creating a new session when one is already IN_PROGRESS
- Adds a 409 Conflict guard in `start_session` to block starting a session when a different session is already IN_PROGRESS
- Updates `start_session_from_plan` test helper to complete any in-progress session before creating a new one (reflecting the enforced real-world workflow)
- Fixes one inline test call that directly used the from-plan endpoint without the helper

## Test plan
- [ ] Verify all 24 existing tests pass
- [ ] Verify that attempting to start a second session while one is in progress returns 409 with a descriptive error message

Closes #7