### PR TITLE
fix: validate exercise IDs exist when creating a plan

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -166,6 +166,24 @@ async def create_plan(
     }
     planned_exercises_json = json.dumps(planned_data)
 
+    # Validate all exercise IDs exist
+    all_exercise_ids = {
+        ex.exercise_id
+        for day in plan_data.days
+        for ex in day.exercises
+    }
+    if all_exercise_ids:
+        result = await db.execute(
+            select(Exercise.id).where(Exercise.id.in_(all_exercise_ids))
+        )
+        found_ids = {row[0] for row in result.all()}
+        missing = all_exercise_ids - found_ids
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Exercise IDs not found: {sorted(missing)}",
+            )
+
     plan = WorkoutPlan(
         name=plan_data.name,
         description=plan_data.description,


### PR DESCRIPTION
## Summary
- In `create_plan`, after converting days to JSON, collects all referenced exercise IDs across all days and verifies each exists in the database
- Returns HTTP 422 with the list of missing IDs if any are not found
- `Exercise` was already imported in `plans.py`, so no import changes were needed

## Test plan
- [ ] Verify all 24 existing tests pass
- [ ] Verify that creating a plan with a non-existent exercise ID returns 422 with a descriptive error listing the missing IDs

Closes #6