### PR TITLE
refactor: extract progression logic into app/services/progression.py (#12)

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from app.database import get_db
 from app.models.exercise import Exercise
 from app.models.workout import ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutStatus
+from app.services.progression import compute_overload
 from app.schemas.requests import (
     SetCreate,
     SetResponse,
@@ -74,7 +75,6 @@ async def list_sessions(
 ) -> list[dict]:
     """List workout sessions, most recent first."""
     limit = min(limit, 500)
-    from sqlalchemy import desc
     result = await db.execute(
         select(WorkoutSession)
         .options(selectinload(WorkoutSession.sets))
@@ -392,76 +392,28 @@ async def create_session_from_plan(
                 "planned_reps": s.planned_reps,
             }
 
-    def rep_bracket(reps: int) -> int:
-        """Same brackets as the in-workout drop-off."""
-        if reps >= 15:
-            return 3
-        if reps >= 10:
-            return 2
-        return 1
-
-    def epley_weight_for_reps(weight: float, done_reps: int, target_reps: int) -> float:
-        """Use Epley 1RM to find the weight equivalent to having done done_reps at `weight`,
-        expressed at target_reps.  Rounds to nearest 2.5 kg (~5 lbs)."""
-        one_rm = weight * (1 + done_reps / 30)
-        new_w  = one_rm / (1 + target_reps / 30)
-        return round(new_w / 2.5) * 2.5
-
-    def progressive_overload(exercise_id: int, set_number: int, target_reps: int, ex_model) -> tuple[float | None, int | None]:
-        """Return (suggested_weight_kg, suggested_reps) for a specific set.
-        Looks up the corresponding set from the prior session so each set
-        is overloaded from its own history. Falls back to None if no data."""
+    def _overload_for_set(
+        exercise_id: int, set_number: int, target_reps: int, ex_model
+    ) -> tuple[float | None, int | None]:
+        """Resolve prior-session data for this set and delegate to compute_overload()."""
         ex_sets = prior_set_data.get(exercise_id)
         if not ex_sets:
             return None, None
 
-        # Use the matching set from the prior session; fall back to the closest
-        # set number if the session had fewer sets (e.g. prior had 3, now doing 4).
-        prior_set = ex_sets.get(set_number)
-        if prior_set is None:
-            # Fall back: use the last available set (handles added sets gracefully)
-            last_set_num = max(ex_sets.keys())
-            prior_set = ex_sets[last_set_num]
-
+        prior_set = ex_sets.get(set_number) or ex_sets[max(ex_sets.keys())]
         prior_weight = prior_set["weight"]
-        prior_reps   = prior_set["reps"]
+        prior_reps = prior_set["reps"]
         planned_reps = prior_set.get("planned_reps") or target_reps
 
-        if prior_reps <= 0:
-            return None, None
-
-        is_assisted = ex_model and ex_model.is_assisted
-
-        # Assisted: prior_weight is the NET effective weight (body - assist).
-        # Convert back to assist amount so the frontend can pre-fill directly.
-        if is_assisted:
-            new_reps = prior_reps + 1 if prior_reps >= planned_reps else prior_reps
-            if body_weight_kg > 0 and prior_weight > 0:
-                assist_kg = max(0.0, round((body_weight_kg - prior_weight) / 1.25) * 1.25)
-                return assist_kg, new_reps
-            return None, new_reps
-
-        # Bodyweight exercise: no weight to suggest, but still apply rep progression
-        if prior_weight <= 0:
-            if prior_reps >= planned_reps:
-                return None, prior_reps + 1
-            return None, prior_reps
-
-        # Didn't hit planned reps → retry same weight / same reps
-        if prior_reps < planned_reps:
-            return prior_weight, prior_reps
-
-        # ── Hit target: apply progression ─────────────────────────────────────
-        if overload_style == "weight":
-            new_weight = epley_weight_for_reps(prior_weight, prior_reps + 1, prior_reps)
-            return new_weight, prior_reps
-        else:
-            projected_reps = prior_reps + 1
-            if rep_bracket(projected_reps) <= rep_bracket(prior_reps):
-                return prior_weight, projected_reps
-            else:
-                new_weight = epley_weight_for_reps(prior_weight, prior_reps + 1, prior_reps)
-                return new_weight, prior_reps
+        return compute_overload(
+            prior_weight=prior_weight,
+            prior_reps=prior_reps,
+            planned_reps=planned_reps,
+            overload_style=overload_style,
+            is_assisted=bool(ex_model and ex_model.is_assisted),
+            is_bodyweight=prior_weight <= 0,
+            body_weight_kg=body_weight_kg,
+        )
 
     # Create session
     workout_session = WorkoutSession(
@@ -486,7 +438,7 @@ async def create_session_from_plan(
         for set_num in range(1, sets + 1):
             # Compute progression individually per set so each set uses
             # its own history from the prior session.
-            weight_kg, suggested_reps = progressive_overload(exercise_id, set_num, reps, ex_model)
+            weight_kg, suggested_reps = _overload_for_set(exercise_id, set_num, reps, ex_model)
             planned_reps_val = suggested_reps if suggested_reps is not None else None
 
             exercise_set = ExerciseSet(

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -10,6 +10,13 @@ from pydantic import BaseModel, Field
 class MovementType(str, Enum):
     COMPOUND = "compound"
     ISOLATION = "isolation"
+    PUSH = "push"
+    PULL = "pull"
+    HINGE = "hinge"
+    SQUAT = "squat"
+    LUNGE = "lunge"
+    CARRY = "carry"
+    ROTATION = "rotation"
 
 
 class BodyRegion(str, Enum):

--- a/app/services/progression.py
+++ b/app/services/progression.py
@@ -1,0 +1,107 @@
+"""Progressive overload calculation helpers.
+
+These are pure (stateless) functions extracted from create_session_from_plan
+so they can be tested and reused independently.
+"""
+
+from __future__ import annotations
+
+
+def rep_bracket(reps: int) -> int:
+    """Map a rep count to a bracket tier (1, 2, or 3).
+
+    Brackets:
+      1 → 1–9 reps
+      2 → 10–14 reps
+      3 → 15+ reps
+
+    A weight increase is triggered when the projected rep count would
+    cross into a higher bracket.
+    """
+    if reps >= 15:
+        return 3
+    if reps >= 10:
+        return 2
+    return 1
+
+
+def epley_weight_for_reps(weight: float, done_reps: int, target_reps: int) -> float:
+    """Estimate the weight needed to achieve *target_reps* given that
+    *weight* was lifted for *done_reps*, using the Epley 1RM formula.
+
+    Result is rounded to the nearest 2.5 kg (~5 lb plate increment).
+    """
+    one_rm = weight * (1 + done_reps / 30)
+    new_w = one_rm / (1 + target_reps / 30)
+    return round(new_w / 2.5) * 2.5
+
+
+def compute_overload(
+    *,
+    prior_weight: float,
+    prior_reps: int,
+    planned_reps: int,
+    overload_style: str = "rep",
+    is_assisted: bool = False,
+    is_bodyweight: bool = False,
+    body_weight_kg: float = 0.0,
+) -> tuple[float | None, int | None]:
+    """Return ``(suggested_weight_kg, suggested_reps)`` for the next session.
+
+    Args:
+        prior_weight:   Actual weight used in the previous session's set.
+                        For assisted exercises this is the *net* load
+                        (body_weight − assist_amount).
+        prior_reps:     Actual reps completed in the previous session's set.
+        planned_reps:   The target rep count from the programme.
+        overload_style: ``"rep"`` (default) — add a rep first, bump weight
+                        at bracket boundary.  ``"weight"`` — immediately
+                        convert the extra rep into equivalent weight via Epley.
+        is_assisted:    True for exercises where the machine *reduces* the load
+                        (e.g. assisted pull-up/dip).  The returned weight is
+                        the *assist amount* (not the net load) so the frontend
+                        can pre-fill directly.
+        is_bodyweight:  True for pure bodyweight moves (weight == 0 / not tracked).
+        body_weight_kg: Required when *is_assisted* is True to back-calculate
+                        the assist amount.
+
+    Returns:
+        A ``(weight, reps)`` tuple.  Either component may be ``None`` when
+        there is no meaningful suggestion (e.g. first session, bodyweight with
+        no weight tracked).
+    """
+    if prior_reps <= 0:
+        return None, None
+
+    # ── Assisted exercises ─────────────────────────────────────────────────
+    if is_assisted:
+        new_reps = prior_reps + 1 if prior_reps >= planned_reps else prior_reps
+        if body_weight_kg > 0 and prior_weight > 0:
+            # prior_weight is the net load; convert back to assist amount
+            assist_kg = max(0.0, round((body_weight_kg - prior_weight) / 1.25) * 1.25)
+            return assist_kg, new_reps
+        return None, new_reps
+
+    # ── Pure bodyweight ────────────────────────────────────────────────────
+    if is_bodyweight:
+        if prior_reps >= planned_reps:
+            return None, prior_reps + 1
+        return None, prior_reps
+
+    # ── Weighted exercises ─────────────────────────────────────────────────
+
+    # Didn't hit planned reps → retry same weight / same reps
+    if prior_reps < planned_reps:
+        return prior_weight, prior_reps
+
+    # Hit target: apply progression
+    if overload_style == "weight":
+        new_weight = epley_weight_for_reps(prior_weight, prior_reps + 1, prior_reps)
+        return new_weight, prior_reps
+    else:
+        projected_reps = prior_reps + 1
+        if rep_bracket(projected_reps) <= rep_bracket(prior_reps):
+            return prior_weight, projected_reps
+        else:
+            new_weight = epley_weight_for_reps(prior_weight, prior_reps + 1, prior_reps)
+            return new_weight, prior_reps

--- a/tests/test_exercises.py
+++ b/tests/test_exercises.py
@@ -1,0 +1,99 @@
+"""Tests for the exercises CRUD API."""
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_exercise, create_plan, start_session_from_plan, log_set
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestExercisesCRUD:
+    async def test_list_exercises_empty(self, client: AsyncClient):
+        """GET /exercises/ returns empty list when no exercises exist."""
+        r = await client.get("/api/exercises/")
+        assert r.status_code == 200
+        assert r.json() == []
+
+    async def test_create_exercise(self, client: AsyncClient):
+        """POST creates exercise, returns 201 with correct fields."""
+        r = await client.post(
+            "/api/exercises/",
+            json={
+                "name": "bench_press",
+                "display_name": "Bench Press",
+                "movement_type": "compound",
+                "body_region": "upper",
+                "is_unilateral": False,
+                "is_assisted": False,
+                "primary_muscles": ["chest"],
+                "secondary_muscles": ["triceps"],
+            },
+        )
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "bench_press"
+        assert data["display_name"] == "Bench Press"
+        assert data["movement_type"] == "compound"
+        assert data["body_region"] == "upper"
+        assert data["is_unilateral"] is False
+        assert data["is_assisted"] is False
+        assert data["primary_muscles"] == ["chest"]
+        assert data["secondary_muscles"] == ["triceps"]
+        assert "id" in data
+
+    async def test_create_exercise_sets_is_unilateral(self, client: AsyncClient):
+        """is_unilateral=True is persisted correctly."""
+        r = await client.post(
+            "/api/exercises/",
+            json={
+                "name": "single_leg_rdl",
+                "display_name": "Single Leg RDL",
+                "movement_type": "hinge",
+                "body_region": "lower",
+                "is_unilateral": True,
+                "is_assisted": False,
+                "primary_muscles": ["hamstrings"],
+                "secondary_muscles": [],
+            },
+        )
+        assert r.status_code == 201
+        data = r.json()
+        assert data["is_unilateral"] is True
+
+    async def test_get_exercise_by_id(self, client: AsyncClient):
+        """GET /exercises/{id} returns correct exercise."""
+        ex = await create_exercise(client, name="squat", display_name="Squat")
+        r = await client.get(f"/api/exercises/{ex['id']}")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["id"] == ex["id"]
+        assert data["name"] == "squat"
+        assert data["display_name"] == "Squat"
+
+    async def test_get_exercise_not_found(self, client: AsyncClient):
+        """GET /exercises/9999 returns 404."""
+        r = await client.get("/api/exercises/9999")
+        assert r.status_code == 404
+
+    async def test_delete_exercise_not_used(self, client: AsyncClient):
+        """DELETE on unused exercise returns 204."""
+        ex = await create_exercise(client)
+        r = await client.delete(f"/api/exercises/{ex['id']}")
+        assert r.status_code == 204
+
+    async def test_delete_exercise_in_use(self, client: AsyncClient):
+        """DELETE on exercise used in a set returns 409."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess["id"], sess["sets"][0]["id"], 100.0, 8)
+
+        r = await client.delete(f"/api/exercises/{ex['id']}")
+        assert r.status_code == 409
+
+    async def test_exercise_history_empty(self, client: AsyncClient):
+        """GET /exercises/{id}/history returns [] when no completed sets."""
+        ex = await create_exercise(client)
+        r = await client.get(f"/api/exercises/{ex['id']}/history")
+        assert r.status_code == 200
+        assert r.json() == []

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,118 @@
+"""Tests for the workout plans CRUD API."""
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_exercise, create_plan
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestPlansCRUD:
+    async def test_create_plan(self, client: AsyncClient):
+        """POST /plans/ creates plan, returns 201."""
+        ex = await create_exercise(client)
+        r = await client.post(
+            "/api/plans/",
+            json={
+                "name": "Push Pull Legs",
+                "block_type": "hypertrophy",
+                "duration_weeks": 8,
+                "number_of_days": 1,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Day 1",
+                        "exercises": [
+                            {
+                                "exercise_id": ex["id"],
+                                "sets": 3,
+                                "reps": 8,
+                                "starting_weight_kg": 0,
+                                "progression_type": "linear",
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "Push Pull Legs"
+        assert data["block_type"] == "hypertrophy"
+        assert data["duration_weeks"] == 8
+        assert "id" in data
+
+    async def test_create_plan_invalid_exercise_id(self, client: AsyncClient):
+        """exercise_id that doesn't exist returns 422."""
+        r = await client.post(
+            "/api/plans/",
+            json={
+                "name": "Bad Plan",
+                "block_type": "hypertrophy",
+                "duration_weeks": 4,
+                "number_of_days": 1,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Day 1",
+                        "exercises": [
+                            {
+                                "exercise_id": 99999,
+                                "sets": 3,
+                                "reps": 8,
+                                "starting_weight_kg": 0,
+                                "progression_type": "linear",
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 422
+
+    async def test_list_plans(self, client: AsyncClient):
+        """GET /plans/ returns created plans."""
+        ex = await create_exercise(client)
+        plan1 = await create_plan(client, ex["id"], name="Plan Alpha")
+        plan2 = await create_plan(client, ex["id"], name="Plan Beta")
+
+        r = await client.get("/api/plans/")
+        assert r.status_code == 200
+        plans = r.json()
+        plan_ids = {p["id"] for p in plans}
+        assert plan1["id"] in plan_ids
+        assert plan2["id"] in plan_ids
+
+    async def test_archive_plan(self, client: AsyncClient):
+        """POST /plans/{id}/archive sets is_archived=True."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"])
+
+        r = await client.post(f"/api/plans/{plan['id']}/archive")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["is_archived"] is True
+
+    async def test_reuse_plan(self, client: AsyncClient):
+        """POST /plans/{id}/reuse creates new unarchived copy."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], name="Original Plan")
+
+        # Archive first
+        await client.post(f"/api/plans/{plan['id']}/archive")
+
+        # Reuse it
+        r = await client.post(f"/api/plans/{plan['id']}/reuse")
+        assert r.status_code == 201
+        data = r.json()
+        assert data["is_archived"] is False
+        assert data["name"] == "Original Plan"
+        assert data["id"] != plan["id"]
+
+    async def test_delete_plan(self, client: AsyncClient):
+        """DELETE /plans/{id} returns 204."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"])
+
+        r = await client.delete(f"/api/plans/{plan['id']}")
+        assert r.status_code == 204

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,67 @@
+"""Tests for the progress tracking API."""
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_exercise, create_plan, start_session_from_plan, log_set
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestProgressAPI:
+    async def test_progress_empty(self, client: AsyncClient):
+        """GET /progress/ with no completed sessions returns []."""
+        r = await client.get("/api/progress/")
+        assert r.status_code == 200
+        assert r.json() == []
+
+    async def test_progress_returns_per_session_rows(self, client: AsyncClient):
+        """Complete 2 sessions, GET /progress/ returns 2 rows with correct dates."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        # Session 1
+        sess1 = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess1["id"], sess1["sets"][0]["id"], 100.0, 8)
+        await client.post(f"/api/sessions/{sess1['id']}/complete")
+
+        # Session 2
+        sess2 = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess2["id"], sess2["sets"][0]["id"], 102.5, 8)
+        await client.post(f"/api/sessions/{sess2['id']}/complete")
+
+        r = await client.get("/api/progress/")
+        assert r.status_code == 200
+        rows = r.json()
+        assert len(rows) == 2
+        # Each row should have a date field
+        for row in rows:
+            assert "date" in row
+            assert "exercise_id" in row
+
+    async def test_recommendations_empty(self, client: AsyncClient):
+        """GET /progress/recommendations returns [] when no data."""
+        r = await client.get("/api/progress/recommendations")
+        assert r.status_code == 200
+        assert r.json() == []
+
+    async def test_recommendations_after_workout(self, client: AsyncClient):
+        """Complete a session, recommendations returns non-empty list."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=2, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        for s in sess["sets"]:
+            await log_set(client, sess["id"], s["id"], 100.0, 8)
+        await client.post(f"/api/sessions/{sess['id']}/complete")
+
+        r = await client.get("/api/progress/recommendations")
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data) > 0
+        # Verify the structure of a recommendation
+        rec = data[0]
+        assert "exercise_id" in rec
+        assert "exercise_name" in rec
+        assert "current_weight" in rec
+        assert "recommended_weight" in rec
+        assert "reason" in rec

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,105 @@
+"""Tests for workout session lifecycle API."""
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import create_exercise, create_plan, start_session_from_plan
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestSessionLifecycle:
+    async def test_create_session_from_plan(self, client: AsyncClient):
+        """POST /sessions/from-plan/{id} returns 201 with sets pre-filled."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=3, reps=8)
+
+        r = await client.post(
+            f"/api/sessions/from-plan/{plan['id']}",
+            params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+        )
+        assert r.status_code == 201
+        data = r.json()
+        assert "id" in data
+        assert len(data["sets"]) == 3
+
+    async def test_start_session(self, client: AsyncClient):
+        """POST /sessions/{id}/start transitions status to in_progress."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=2, reps=8)
+
+        r = await client.post(
+            f"/api/sessions/from-plan/{plan['id']}",
+            params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+        )
+        assert r.status_code == 201
+        session_id = r.json()["id"]
+
+        r2 = await client.post(f"/api/sessions/{session_id}/start")
+        assert r2.status_code == 200
+        assert r2.json()["status"] == "in_progress"
+
+    async def test_prevent_duplicate_in_progress(self, client: AsyncClient):
+        """Starting a second session while one is in_progress returns 409."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        # Create and start first session
+        r1 = await client.post(
+            f"/api/sessions/from-plan/{plan['id']}",
+            params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+        )
+        sess1_id = r1.json()["id"]
+        await client.post(f"/api/sessions/{sess1_id}/start")
+
+        # Create a second session and attempt to start it
+        r2 = await client.post(
+            f"/api/sessions/from-plan/{plan['id']}",
+            params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+        )
+        # from-plan also checks for in-progress; expect 409
+        assert r2.status_code == 409
+
+    async def test_complete_session(self, client: AsyncClient):
+        """POST /sessions/{id}/complete transitions to completed."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        r = await client.post(f"/api/sessions/{sess['id']}/complete")
+        assert r.status_code == 200
+        assert r.json()["status"] == "completed"
+
+    async def test_log_set(self, client: AsyncClient):
+        """PATCH /sessions/{id}/sets/{set_id} updates actual_reps/weight."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        set_id = sess["sets"][0]["id"]
+        r = await client.patch(
+            f"/api/sessions/{sess['id']}/sets/{set_id}",
+            json={
+                "actual_weight_kg": 80.0,
+                "actual_reps": 10,
+                "completed_at": "2024-01-01T10:00:00",
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["actual_weight_kg"] == 80.0
+        assert data["actual_reps"] == 10
+
+    async def test_pagination_cap(self, client: AsyncClient):
+        """GET /sessions/?limit=9999 returns at most 500 results."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        # Create 3 sessions
+        for _ in range(3):
+            await start_session_from_plan(client, plan["id"])
+
+        r = await client.get("/api/sessions/", params={"limit": 9999})
+        assert r.status_code == 200
+        data = r.json()
+        assert isinstance(data, list)
+        assert len(data) <= 500


### PR DESCRIPTION
## Summary
- Extract `rep_bracket()`, `epley_weight_for_reps()`, and the overload calculation out of the `create_session_from_plan()` route and into `app/services/progression.py` as pure stateless functions
- Replace the three inline inner-functions with a thin `_overload_for_set()` wrapper that resolves per-set prior history and delegates to `compute_overload()`
- Expand `MovementType` enum to include push/pull/hinge/squat/lunge/carry/rotation so exercises with pattern-based categorisation validate correctly
- Add extended test coverage: `test_exercises`, `test_plans`, `test_progress`, `test_sessions` (48 tests total, all passing)

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `pytest tests/ -v` — 48 passed, 0 failed

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)