### PR TITLE
fix: proper Pydantic schema for body weight API (#13)

### DIFF
--- a/app/api/body_weight.py
+++ b/app/api/body_weight.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models.body_weight import BodyWeightEntry
+from app.schemas.requests import BodyWeightCreate
 
 router = APIRouter()
 
@@ -52,17 +53,16 @@ async def get_latest(
 
 @router.post("/", response_model=dict, status_code=status.HTTP_201_CREATED)
 async def add_entry(
-    data: dict,
+    data: BodyWeightCreate,
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     """Log a new weigh-in."""
-    weight_kg = data.get("weight_kg")
-    if not weight_kg or weight_kg <= 0:
+    if not data.weight_kg or data.weight_kg <= 0:
         raise HTTPException(status_code=400, detail="weight_kg must be a positive number")
     entry = BodyWeightEntry(
-        weight_kg=float(weight_kg),
-        recorded_at=datetime.fromisoformat(data["recorded_at"]) if data.get("recorded_at") else datetime.now(timezone.utc),
-        notes=data.get("notes"),
+        weight_kg=data.weight_kg,
+        recorded_at=datetime.fromisoformat(data.recorded_at) if data.recorded_at else datetime.now(timezone.utc),
+        notes=data.notes,
     )
     db.add(entry)
     await db.flush()

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -208,3 +208,15 @@ class ProgressionRecommendation(BaseModel):
     recommended_weight: float
     reason: str
     confidence: float
+
+
+# Body weight schemas
+class BodyWeightCreate(BaseModel):
+    weight_kg: float
+    recorded_at: str | None = None  # ISO datetime string, optional
+    notes: str | None = None
+
+
+class BodyWeightUpdate(BaseModel):
+    weight_kg: float | None = None
+    notes: str | None = None


### PR DESCRIPTION
## Summary
- Add `BodyWeightCreate` and `BodyWeightUpdate` Pydantic schemas to `app/schemas/requests.py`
- Replace raw `dict` input in the `POST /body-weight/` endpoint with the typed `BodyWeightCreate` schema for proper validation

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `pytest tests/ -v` — 48 passed, 0 failed

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)