### PR TITLE
fix: chest-supported row muscle groups + reject primary/secondary overlap

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -127,7 +127,7 @@ async def seed_exercises() -> None:
             {"name": "dumbbell_row", "display_name": "Dumbbell Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},
             {"name": "cable_row", "display_name": "Cable Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},
             {"name": "seated_cable_row", "display_name": "Seated Cable Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},
-            {"name": "chest_supported_row", "display_name": "Chest Supported Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},
+            {"name": "chest_supported_row", "display_name": "Chest Supported Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["mid_back"], "secondary_muscles": ["lats", "biceps"]},
             {"name": "machine_row", "display_name": "Machine Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},
             {"name": "t_bar_row", "display_name": "T-Bar Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},
             {"name": "meadows_row", "display_name": "Meadows Row", "movement_type": "compound", "body_region": "upper", "primary_muscles": ["back"], "secondary_muscles": ["biceps"]},

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -3,7 +3,7 @@
 from datetime import date, datetime
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 # Enums (mirroring model enums)
@@ -63,6 +63,15 @@ class ExerciseCreate(BaseModel):
     description: str | None = None
     primary_muscles: list[str] = []
     secondary_muscles: list[str] = []
+
+    @model_validator(mode="after")
+    def no_overlap_between_primary_and_secondary(self) -> "ExerciseCreate":
+        overlap = set(self.primary_muscles) & set(self.secondary_muscles)
+        if overlap:
+            raise ValueError(
+                f"A muscle cannot be both primary and secondary: {sorted(overlap)}"
+            )
+        return self
 
 
 class ExerciseResponse(BaseModel):

--- a/tests/test_exercises.py
+++ b/tests/test_exercises.py
@@ -60,6 +60,20 @@ class TestExercisesCRUD:
         data = r.json()
         assert data["is_unilateral"] is True
 
+    async def test_create_exercise_rejects_overlapping_muscles(self, client: AsyncClient):
+        """Creating an exercise where a muscle appears in both primary and secondary is rejected."""
+        r = await client.post(
+            "/api/exercises/",
+            json={
+                "name": "overlap_test",
+                "display_name": "Overlap Test",
+                "primary_muscles": ["back"],
+                "secondary_muscles": ["back", "biceps"],
+            },
+        )
+        assert r.status_code == 422
+        assert "primary and secondary" in r.text
+
     async def test_get_exercise_by_id(self, client: AsyncClient):
         """GET /exercises/{id} returns correct exercise."""
         ex = await create_exercise(client, name="squat", display_name="Squat")


### PR DESCRIPTION
## Summary
- **Chest Supported Row**: corrected muscle categorisation — `primary_muscles: [mid_back]`, `secondary_muscles: [lats, biceps]`. The lats are a secondary mover on this exercise; the rhomboids/mid-traps are the target.
- **Validation**: added a `model_validator` on `ExerciseCreate` that returns HTTP 422 if any muscle appears in both `primary_muscles` and `secondary_muscles`.

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `pytest tests/ -v` — 49 passed, 0 failed
- [x] New test: `test_create_exercise_rejects_overlapping_muscles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)