### PR TITLE
fix: unilateral exercise history shows L/R reps separately (#9)

### DIFF
--- a/app/api/exercises.py
+++ b/app/api/exercises.py
@@ -107,10 +107,14 @@ async def get_exercise_history(
     db: Annotated[AsyncSession, Depends(get_db)] = None,
 ) -> list[dict]:
     """Get the most recent completed sessions for a given exercise."""
-    # Subquery: sessions that have at least one completed set
+    # Subquery: sessions that have at least one completed set (bilateral or unilateral)
     sessions_with_data = (
         select(ExerciseSet.workout_session_id)
-        .where(ExerciseSet.actual_reps.is_not(None))
+        .where(
+            (ExerciseSet.actual_reps.is_not(None))
+            | (ExerciseSet.reps_left.is_not(None))
+            | (ExerciseSet.reps_right.is_not(None))
+        )
     )
 
     result = await db.execute(
@@ -118,7 +122,10 @@ async def get_exercise_history(
         .join(WorkoutSession, ExerciseSet.workout_session_id == WorkoutSession.id)
         .where(
             ExerciseSet.exercise_id == exercise_id,
-            ExerciseSet.actual_reps.is_not(None),
+            ExerciseSet.workout_session_id.in_(sessions_with_data),
+            (ExerciseSet.actual_reps.is_not(None))
+            | (ExerciseSet.reps_left.is_not(None))
+            | (ExerciseSet.reps_right.is_not(None)),
         )
         .order_by(desc(WorkoutSession.date), desc(WorkoutSession.id), ExerciseSet.set_number)
     )
@@ -139,6 +146,8 @@ async def get_exercise_history(
         sessions_dict[session.id]["sets"].append({
             "set_number": exercise_set.set_number,
             "actual_reps": exercise_set.actual_reps,
+            "reps_left": exercise_set.reps_left,
+            "reps_right": exercise_set.reps_right,
             "actual_weight_kg": exercise_set.actual_weight_kg,
             "notes": exercise_set.notes,
         })

--- a/app/models/workout.py
+++ b/app/models/workout.py
@@ -45,6 +45,10 @@ class ExerciseSet(Base):
     actual_reps: Mapped[int | None] = mapped_column(Integer, nullable=True)
     actual_weight_kg: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # Unilateral rep tracking (left/right independently)
+    reps_left: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    reps_right: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Notes and timestamps
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -230,6 +230,8 @@ export interface ExerciseHistorySession {
   sets: {
     set_number: number;
     actual_reps: number | null;
+    reps_left: number | null;
+    reps_right: number | null;
     actual_weight_kg: number | null;
     notes: string | null;
   }[];

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -1555,8 +1555,12 @@
                     <span class="text-sm font-mono text-right {dispW != null ? 'text-white' : 'text-gray-600'}">
                       {dispW != null ? dispW : '—'}
                     </span>
-                    <span class="text-sm font-mono text-right {s.actual_reps != null ? 'text-white' : 'text-gray-600'}">
-                      {s.actual_reps ?? '—'}
+                    <span class="text-sm font-mono text-right {(s.actual_reps != null || s.reps_left != null || s.reps_right != null) ? 'text-white' : 'text-gray-600'}">
+                      {#if s.actual_reps == null && (s.reps_left != null || s.reps_right != null)}
+                        L:{s.reps_left ?? '—'}/R:{s.reps_right ?? '—'}
+                      {:else}
+                        {s.actual_reps ?? '—'}
+                      {/if}
                     </span>
                   </div>
                 {/each}


### PR DESCRIPTION
## Summary
- Add `reps_left` and `reps_right` columns to `ExerciseSet` model for per-side rep tracking on unilateral exercises (e.g. single-leg press, single-arm row)
- Update the exercise history endpoint to treat a set as completed if `actual_reps`, `reps_left`, or `reps_right` is set (not just `actual_reps`)
- Include `reps_left`/`reps_right` in the history API response payload
- Update `ExerciseHistorySession` TypeScript type in `api.ts`
- Active workout history panel now shows `L:N/R:N` for unilateral sets instead of `—`

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `pytest tests/ -v` — 49 passed, 0 failed

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)