### PR TITLE
fix: duplicate-session guard crashes with MultipleResultsFound on dirty data

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -148,7 +148,7 @@ async def start_session(
             WorkoutSession.id != session_id,
         )
     )
-    existing = existing_result.scalar_one_or_none()
+    existing = existing_result.scalars().first()
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -341,11 +341,13 @@ async def create_session_from_plan(
 
     day_name = day.get("day_name", f"Day {day_number}")
 
-    # Guard: only one in-progress session at a time
+    # Guard: only one in-progress session at a time.
+    # Use .scalars().first() (not scalar_one_or_none) so pre-existing dirty data
+    # with multiple in-progress sessions doesn't cause a MultipleResultsFound crash.
     existing_result = await db.execute(
         select(WorkoutSession).where(WorkoutSession.status == WorkoutStatus.IN_PROGRESS)
     )
-    existing = existing_result.scalar_one_or_none()
+    existing = existing_result.scalars().first()
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,7 +1,11 @@
 """Tests for workout session lifecycle API."""
+from datetime import date
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.workout import WorkoutSession, WorkoutStatus
 from tests.conftest import create_exercise, create_plan, start_session_from_plan
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
@@ -88,6 +92,39 @@ class TestSessionLifecycle:
         data = r.json()
         assert data["actual_weight_kg"] == 80.0
         assert data["actual_reps"] == 10
+
+    async def test_guard_survives_multiple_in_progress_sessions(
+        self, client: AsyncClient, db: AsyncSession
+    ):
+        """Guard uses .scalars().first() so pre-existing dirty data (multiple
+        in-progress sessions) does not cause a MultipleResultsFound 500 crash.
+
+        Why this wasn't caught before: tests use a fresh DB per run and
+        always complete sessions before creating new ones, so there is never
+        more than one in-progress row.  This test simulates the real-world
+        scenario where a user has orphaned in-progress sessions in their DB.
+        """
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        # Bypass the guard by inserting two IN_PROGRESS sessions directly into the DB
+        for i in range(2):
+            db.add(WorkoutSession(
+                name=f"Orphaned Session {i}",
+                date=date.today(),
+                status=WorkoutStatus.IN_PROGRESS,
+                workout_plan_id=plan["id"],
+            ))
+        await db.commit()
+
+        # Now calling from-plan must return 409 (not 500) even with 2 in-progress rows
+        r = await client.post(
+            f"/api/sessions/from-plan/{plan['id']}",
+            params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+        )
+        assert r.status_code == 409, (
+            f"Expected 409 (duplicate guard), got {r.status_code}: {r.text}"
+        )
 
     async def test_pagination_cap(self, client: AsyncClient):
         """GET /sessions/?limit=9999 returns at most 500 results."""


### PR DESCRIPTION
## Summary
Both `create_session_from_plan` and `start_session` used `scalar_one_or_none()` to look for an existing in-progress session. If the DB had **two or more** in-progress sessions (e.g. from a prior bug or manual edit), this raised `MultipleResultsFound` → HTTP 500 instead of 409.

**Fix:** change both guards to `.scalars().first()` which safely returns the first matching row regardless of how many exist.

## Why existing tests didn't catch this
- Tests use a fresh in-memory DB per run with no pre-existing data
- The `start_session_from_plan` helper completes any in-progress session before creating a new one, so the test DB never had more than one in-progress row
- The new test `test_guard_survives_multiple_in_progress_sessions` injects two `IN_PROGRESS` rows directly via the `db` fixture (bypassing the API guard) and verifies the endpoint returns 409, not 500

## Test plan
- [x] `ruff check app/ tests/` — clean
- [x] `pytest tests/ -v` — 50 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)