### PR TITLE
feat: rep bracket explanation in settings (#19)

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -225,6 +225,24 @@
         </button>
       {/each}
     </div>
+
+    <!-- Rep bracket explanation — shown when "Rep first" style is active -->
+    {#if $settings.progressionStyle === 'rep'}
+      <div class="text-xs text-gray-400 bg-gray-800 rounded-lg p-3 space-y-1">
+        <p class="font-medium text-gray-300">How rep brackets work</p>
+        <p>Your rep range is split into three brackets:</p>
+        <ul class="list-disc list-inside space-y-0.5 pl-1">
+          <li><span class="text-white font-mono">Bracket 1</span> — 1–9 reps</li>
+          <li><span class="text-white font-mono">Bracket 2</span> — 10–14 reps</li>
+          <li><span class="text-white font-mono">Bracket 3</span> — 15+ reps</li>
+        </ul>
+        <p class="pt-0.5">
+          Each session you add 1 rep. When the next rep would push you into a higher bracket,
+          weight increases instead (via the Epley 1RM formula) and reps reset to the bottom of
+          the new bracket range.
+        </p>
+      </div>
+    {/if}
   </div>
 
   <!-- ── Rest Timer ──────────────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
When the "Rep first" progression style is selected in Settings, show a compact info box that explains the three rep brackets (1–9, 10–14, 15+) and describes how weight increases are triggered at bracket boundaries.

## Test plan
- [x] `ruff check app/ tests/` — clean (no Python changes)
- [x] `pytest tests/ -v` — 50 passed, 0 failed
- Info box appears only when "Rep first" is the active style

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)