### PR TITLE
tech-debt: remove deprecated day_of_week column from WorkoutPlan

### DIFF
--- a/alembic/versions/77f39af0983d_remove_day_of_week_column.py
+++ b/alembic/versions/77f39af0983d_remove_day_of_week_column.py
@@ -1,0 +1,32 @@
+"""remove_day_of_week_column
+
+Revision ID: 77f39af0983d
+Revises: ba352aa05e2d
+Create Date: 2026-03-20 12:53:53.861107
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '77f39af0983d'
+down_revision: Union[str, Sequence[str], None] = 'ba352aa05e2d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Drop the deprecated day_of_week column from workout_plans.
+
+    Uses raw DDL instead of batch_alter_table to avoid SQLite's restriction
+    on non-constant DEFAULT expressions when the table is recreated.
+    SQLite 3.35.0+ supports DROP COLUMN directly.
+    """
+    op.execute("ALTER TABLE workout_plans DROP COLUMN day_of_week")
+
+
+def downgrade() -> None:
+    """Re-add day_of_week column (nullable so existing rows are unaffected)."""
+    op.execute("ALTER TABLE workout_plans ADD COLUMN day_of_week VARCHAR(10)")

--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -190,7 +190,6 @@ async def create_plan(
         block_type=plan_data.block_type.value,
         duration_weeks=plan_data.duration_weeks,
         current_week=1,  # Start at week 1
-        day_of_week=None,  # Deprecated in favor of multi-day structure
         planned_exercises=planned_exercises_json,
         auto_progression=plan_data.auto_progression,
     )

--- a/app/models/workout.py
+++ b/app/models/workout.py
@@ -119,8 +119,6 @@ class WorkoutPlan(Base):
     block_type: Mapped[str] = mapped_column(String(50), default="other")
     duration_weeks: Mapped[int] = mapped_column(Integer, default=4)
     current_week: Mapped[int] = mapped_column(Integer, default=1)
-    day_of_week: Mapped[str | None] = mapped_column(String(10), nullable=True)
-
     # Planned exercises as JSON
     planned_exercises: Mapped[str] = mapped_column(Text, nullable=False)
 


### PR DESCRIPTION
## Summary
- Removes `day_of_week` column from `WorkoutPlan` SQLAlchemy model (was always `None` after multi-day structure was introduced)
- Removes `day_of_week=None` from the API create call
- Adds Alembic migration `77f39af0983d` to drop the column from the live DB using raw `ALTER TABLE DROP COLUMN` (avoids SQLite batch-alter issue with non-constant DEFAULT expressions)

Closes #10

## Test plan
- [ ] All 50 existing tests pass
- [ ] `ruff check` clean
- [ ] `alembic upgrade head` applies successfully on a live DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)