### PR TITLE
tech-debt: migrate muscles columns from String(255) to JSON type

### DIFF
--- a/alembic/versions/c5e8f3a91d2b_muscles_json_type.py
+++ b/alembic/versions/c5e8f3a91d2b_muscles_json_type.py
@@ -1,0 +1,48 @@
+"""muscles_json_type
+
+Switch primary_muscles and secondary_muscles from VARCHAR(255) to TEXT so
+the columns can hold arbitrarily-long JSON arrays without a length cap.
+The stored format (a JSON string) is unchanged — SQLAlchemy's JSON type
+deserialises it automatically.
+
+Revision ID: c5e8f3a91d2b
+Revises: 77f39af0983d
+Create Date: 2026-03-20 13:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c5e8f3a91d2b'
+down_revision: Union[str, Sequence[str], None] = '77f39af0983d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Change muscle columns from VARCHAR(255) to TEXT.
+
+    SQLite ignores column type constraints at the storage level, so this
+    migration is primarily a schema-documentation change.  It also future-
+    proofs against databases (e.g. PostgreSQL) that do enforce VARCHAR limits.
+
+    Default any NULL muscle columns to an empty JSON array so reads always
+    return a list rather than None.
+    """
+    op.execute(
+        "UPDATE exercises SET primary_muscles = '[]' WHERE primary_muscles IS NULL"
+    )
+    op.execute(
+        "UPDATE exercises SET secondary_muscles = '[]' WHERE secondary_muscles IS NULL"
+    )
+    # SQLite stores both VARCHAR(255) and TEXT as the same TEXT affinity,
+    # so no DDL column-type change is needed for SQLite.
+    # (On PostgreSQL you would do an ALTER COLUMN here.)
+
+
+def downgrade() -> None:
+    """No-op: reverting TEXT → VARCHAR(255) is safe on SQLite."""
+    pass

--- a/app/api/exercises.py
+++ b/app/api/exercises.py
@@ -1,6 +1,5 @@
 """Exercise API endpoints."""
 
-import json
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -35,8 +34,8 @@ async def list_exercises(
             "is_unilateral": bool(getattr(ex, 'is_unilateral', False)),
             "is_assisted":   bool(getattr(ex, 'is_assisted',   False)),
             "description": ex.description,
-            "primary_muscles": json.loads(ex.primary_muscles) if ex.primary_muscles else [],
-            "secondary_muscles": json.loads(ex.secondary_muscles) if ex.secondary_muscles else [],
+            "primary_muscles": ex.primary_muscles or [],
+            "secondary_muscles": ex.secondary_muscles or [],
         })
     return responses
 
@@ -61,8 +60,8 @@ async def get_exercise(
         "movement_type": getattr(ex, 'movement_type', 'compound'),
         "body_region": getattr(ex, 'body_region', 'upper'),
         "description": ex.description,
-        "primary_muscles": json.loads(ex.primary_muscles) if ex.primary_muscles else [],
-        "secondary_muscles": json.loads(ex.secondary_muscles) if ex.secondary_muscles else [],
+        "primary_muscles": ex.primary_muscles or [],
+        "secondary_muscles": ex.secondary_muscles or [],
     }
 
 
@@ -80,8 +79,8 @@ async def create_exercise(
         is_unilateral=exercise_data.is_unilateral,
         is_assisted=exercise_data.is_assisted,
         description=exercise_data.description,
-        primary_muscles=json.dumps(exercise_data.primary_muscles),
-        secondary_muscles=json.dumps(exercise_data.secondary_muscles),
+        primary_muscles=exercise_data.primary_muscles,
+        secondary_muscles=exercise_data.secondary_muscles,
     )
     db.add(exercise)
     await db.flush()

--- a/app/database.py
+++ b/app/database.py
@@ -427,7 +427,6 @@ async def seed_exercises() -> None:
             {"name": "ez_bar_spider_curl", "display_name": "EZ Bar Spider Curl", "movement_type": "isolation", "body_region": "upper", "primary_muscles": ["biceps"], "secondary_muscles": []},
         ]
 
-        import json
         seeded_count = 0
         skipped_count = 0
 
@@ -445,8 +444,8 @@ async def seed_exercises() -> None:
                 display_name=ex_data["display_name"],
                 movement_type=ex_data["movement_type"],
                 body_region=ex_data["body_region"],
-                primary_muscles=json.dumps(ex_data["primary_muscles"]),
-                secondary_muscles=json.dumps(ex_data["secondary_muscles"]),
+                primary_muscles=ex_data["primary_muscles"],
+                secondary_muscles=ex_data["secondary_muscles"],
             )
             session.add(exercise)
             seeded_count += 1

--- a/app/models/exercise.py
+++ b/app/models/exercise.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Integer, JSON, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -45,9 +45,9 @@ class Exercise(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     technique_cues: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    # Primary and secondary muscle groups
-    primary_muscles: Mapped[str] = mapped_column(String(255), nullable=True)
-    secondary_muscles: Mapped[str] = mapped_column(String(255), nullable=True)
+    # Primary and secondary muscle groups (stored as JSON array)
+    primary_muscles: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    secondary_muscles: Mapped[list | None] = mapped_column(JSON, nullable=True)
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(


### PR DESCRIPTION
## Summary
- Replaces manual `json.loads`/`json.dumps` calls with SQLAlchemy's `JSON` type, which handles serialization automatically
- Removes the 255-character length cap on muscle group arrays  
- `JSON` maps to `TEXT` in SQLite — no data format change, existing rows stay valid
- Migration `c5e8f3a91d2b` sets NULL muscle columns to `'[]'` so reads always return a list

Closes #11

## Test plan
- [ ] All 50 tests pass
- [ ] `ruff check` clean
- [ ] `GET /api/exercises/` returns correct `primary_muscles` and `secondary_muscles` arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)