### PR TITLE
tech-debt: add indexes on frequently-queried columns

### DIFF
--- a/alembic/versions/d4f7a1b2c3e8_add_indexes.py
+++ b/alembic/versions/d4f7a1b2c3e8_add_indexes.py
@@ -1,0 +1,38 @@
+"""add_indexes
+
+Add indexes on frequently-queried columns for exercise_sets and
+workout_sessions to avoid full-table scans as data grows.
+
+Revision ID: d4f7a1b2c3e8
+Revises: c5e8f3a91d2b
+Create Date: 2026-03-20 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4f7a1b2c3e8'
+down_revision: Union[str, Sequence[str], None] = 'c5e8f3a91d2b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add missing indexes for performance-critical foreign keys and filter columns."""
+    op.create_index("ix_exercise_sets_session",  "exercise_sets",     ["workout_session_id"])
+    op.create_index("ix_exercise_sets_exercise", "exercise_sets",     ["exercise_id"])
+    op.create_index("ix_workout_sessions_date",  "workout_sessions",  ["date"])
+    op.create_index("ix_workout_sessions_status","workout_sessions",  ["status"])
+    op.create_index("ix_workout_sessions_plan",  "workout_sessions",  ["workout_plan_id"])
+
+
+def downgrade() -> None:
+    """Drop indexes."""
+    op.drop_index("ix_exercise_sets_session",  table_name="exercise_sets")
+    op.drop_index("ix_exercise_sets_exercise", table_name="exercise_sets")
+    op.drop_index("ix_workout_sessions_date",  table_name="workout_sessions")
+    op.drop_index("ix_workout_sessions_status",table_name="workout_sessions")
+    op.drop_index("ix_workout_sessions_plan",  table_name="workout_sessions")

--- a/app/models/workout.py
+++ b/app/models/workout.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, Date, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Date, DateTime, Float, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.database import Base
@@ -27,6 +27,11 @@ class ExerciseSet(Base):
     """A single set of an exercise during a workout session."""
 
     __tablename__ = "exercise_sets"
+    __table_args__ = (
+        # History and progress queries filter by session and exercise frequently
+        Index("ix_exercise_sets_session", "workout_session_id"),
+        Index("ix_exercise_sets_exercise", "exercise_id"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     workout_session_id: Mapped[int] = mapped_column(
@@ -65,6 +70,12 @@ class WorkoutSession(Base):
     """An actual workout session (performed workout)."""
 
     __tablename__ = "workout_sessions"
+    __table_args__ = (
+        # Dashboard and progress queries filter by date and status
+        Index("ix_workout_sessions_date", "date"),
+        Index("ix_workout_sessions_status", "status"),
+        Index("ix_workout_sessions_plan", "workout_plan_id"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True)


### PR DESCRIPTION
## Summary
Without indexes, all filtering queries on session date, status, plan ID, and set foreign keys are O(n) full-table scans. As workout history grows this becomes noticeably slow.

**Indexes added:**

| Table | Column | Query type |
|-------|--------|-----------|
| `exercise_sets` | `workout_session_id` | Every set load (joins on this) |
| `exercise_sets` | `exercise_id` | History/progress endpoint filter |
| `workout_sessions` | `date` | Date-range progress queries |
| `workout_sessions` | `status` | In-progress guard + progress filter |
| `workout_sessions` | `workout_plan_id` | Next-workout resolution |

Migration `d4f7a1b2c3e8` creates all indexes on the live DB.

## Test plan
- [ ] `alembic upgrade head` applies cleanly
- [ ] All 50 tests pass
- [ ] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)