### PR TITLE
perf: eliminate N+1 queries in progress API

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -34,8 +34,7 @@ async def get_progress(
     if not end_date:
         end_date = date.today()
 
-    # Fetch completed sessions in the requested date range, oldest first
-    # so the chart x-axis is naturally ordered.
+    # ── Batch fetch all completed sessions in range ──────────────────────────
     session_result = await db.execute(
         select(WorkoutSession)
         .where(
@@ -46,60 +45,77 @@ async def get_progress(
         .order_by(WorkoutSession.date, WorkoutSession.id)
     )
     sessions = session_result.scalars().all()
+    if not sessions:
+        return []
 
-    progress_list: list[dict] = []
+    session_ids = [s.id for s in sessions]
+    session_map = {s.id: s for s in sessions}
 
-    for session in sessions:
-        # Fetch all completed sets for this session (optionally filtered)
-        sets_query = select(ExerciseSet).where(
-            ExerciseSet.workout_session_id == session.id,
+    # ── Batch fetch all completed sets for these sessions ────────────────────
+    sets_query = (
+        select(ExerciseSet)
+        .where(
+            ExerciseSet.workout_session_id.in_(session_ids),
             ExerciseSet.actual_reps.is_not(None),
         )
-        if exercise_id:
-            sets_query = sets_query.where(ExerciseSet.exercise_id == exercise_id)
+    )
+    if exercise_id:
+        sets_query = sets_query.where(ExerciseSet.exercise_id == exercise_id)
 
-        sets_result = await db.execute(sets_query)
-        sets = sets_result.scalars().all()
+    sets_result = await db.execute(sets_query)
+    all_sets = sets_result.scalars().all()
 
-        # Group sets by exercise
-        exercise_sets: dict[int, list[ExerciseSet]] = {}
-        for s in sets:
-            exercise_sets.setdefault(s.exercise_id, []).append(s)
+    # ── Batch fetch all referenced exercises ─────────────────────────────────
+    exercise_ids = {s.exercise_id for s in all_sets}
+    if not exercise_ids:
+        return []
 
-        for ex_id, ex_sets in exercise_sets.items():
-            exercise = await db.get(Exercise, ex_id)
-            if not exercise:
-                continue
+    exercises_result = await db.execute(
+        select(Exercise).where(Exercise.id.in_(exercise_ids))
+    )
+    exercise_map = {e.id: e for e in exercises_result.scalars().all()}
 
-            # Volume for this session = Σ(weight × reps) across all sets
-            volume = sum(
-                (s.actual_reps or 0) * (s.actual_weight_kg or 0)
-                for s in ex_sets
-            )
+    # ── Group sets by (session_id, exercise_id) ──────────────────────────────
+    grouped: dict[tuple[int, int], list[ExerciseSet]] = {}
+    for s in all_sets:
+        key = (s.workout_session_id, s.exercise_id)
+        grouped.setdefault(key, []).append(s)
 
-            # Best Epley 1RM across sets: max(weight × (1 + reps/30))
-            # Use per-set reps — NOT the total reps sum, which produces
-            # wildly inflated estimates.
-            estimated_1rm: float | None = None
-            max_weight: float = 0.0
-            for s in ex_sets:
-                w = s.actual_weight_kg or 0.0
-                r = s.actual_reps or 0
-                max_weight = max(max_weight, w)
-                if w > 0 and r > 0:
-                    one_rm = w * (1 + r / 30)
-                    if estimated_1rm is None or one_rm > estimated_1rm:
-                        estimated_1rm = one_rm
+    # ── Build one progress row per (session, exercise) pair ──────────────────
+    progress_list: list[dict] = []
+    for (sess_id, ex_id), ex_sets in grouped.items():
+        exercise = exercise_map.get(ex_id)
+        if not exercise:
+            continue
+        session = session_map[sess_id]
 
-            progress_list.append({
-                "exercise_id": ex_id,
-                "exercise_name": exercise.display_name,
-                "date": session.date.isoformat(),
-                "estimated_1rm": round(estimated_1rm, 1) if estimated_1rm else None,
-                "volume_load": round(volume, 1),
-                "recommended_weight": round(max_weight * 1.05, 1),
-            })
+        volume = sum(
+            (s.actual_reps or 0) * (s.actual_weight_kg or 0)
+            for s in ex_sets
+        )
 
+        estimated_1rm: float | None = None
+        max_weight: float = 0.0
+        for s in ex_sets:
+            w = s.actual_weight_kg or 0.0
+            r = s.actual_reps or 0
+            max_weight = max(max_weight, w)
+            if w > 0 and r > 0:
+                one_rm = w * (1 + r / 30)
+                if estimated_1rm is None or one_rm > estimated_1rm:
+                    estimated_1rm = one_rm
+
+        progress_list.append({
+            "exercise_id": ex_id,
+            "exercise_name": exercise.display_name,
+            "date": session.date.isoformat(),
+            "estimated_1rm": round(estimated_1rm, 1) if estimated_1rm else None,
+            "volume_load": round(volume, 1),
+            "recommended_weight": round(max_weight * 1.05, 1),
+        })
+
+    # Sort by date then exercise name for stable output
+    progress_list.sort(key=lambda x: (x["date"], x["exercise_name"]))
     return progress_list
 
 
@@ -112,52 +128,64 @@ async def get_recommendations(
 
     start_date = date.today() - timedelta(days=days_back)
 
-    result = await db.execute(
+    # ── Batch fetch sessions ──────────────────────────────────────────────────
+    sessions_result = await db.execute(
         select(WorkoutSession).where(
             WorkoutSession.status == "completed",
             WorkoutSession.date >= start_date,
         )
     )
-    sessions = result.scalars().all()
-
+    sessions = sessions_result.scalars().all()
     if not sessions:
         return []
 
-    # Collect best performance per exercise across all sessions
-    exercise_performance: dict[int, dict] = {}
+    session_ids = [s.id for s in sessions]
 
-    for session in sessions:
-        sets_result = await db.execute(
-            select(ExerciseSet).where(
-                ExerciseSet.workout_session_id == session.id,
-                ExerciseSet.actual_reps.is_not(None),
-            )
+    # ── Batch fetch all completed sets for these sessions ────────────────────
+    sets_result = await db.execute(
+        select(ExerciseSet).where(
+            ExerciseSet.workout_session_id.in_(session_ids),
+            ExerciseSet.actual_reps.is_not(None),
         )
-        sets = sets_result.scalars().all()
+    )
+    all_sets = sets_result.scalars().all()
 
-        for exercise_set in sets:
-            ex_id = exercise_set.exercise_id
-            if ex_id not in exercise_performance:
-                exercise_performance[ex_id] = {
-                    "best_weight": 0.0,
-                    "best_reps": 0,
-                    "total_volume": 0.0,
-                    "set_count": 0,
-                }
+    # ── Batch fetch all referenced exercises ─────────────────────────────────
+    exercise_ids = {s.exercise_id for s in all_sets}
+    if not exercise_ids:
+        return []
 
-            weight = exercise_set.actual_weight_kg or 0.0
-            reps = exercise_set.actual_reps or 0
+    exercises_result = await db.execute(
+        select(Exercise).where(Exercise.id.in_(exercise_ids))
+    )
+    exercise_map = {e.id: e for e in exercises_result.scalars().all()}
 
-            if weight > exercise_performance[ex_id]["best_weight"]:
-                exercise_performance[ex_id]["best_weight"] = weight
-                exercise_performance[ex_id]["best_reps"] = reps
+    # ── Collect best performance per exercise ─────────────────────────────────
+    exercise_performance: dict[int, dict] = {}
+    for exercise_set in all_sets:
+        ex_id = exercise_set.exercise_id
+        if ex_id not in exercise_performance:
+            exercise_performance[ex_id] = {
+                "best_weight": 0.0,
+                "best_reps": 0,
+                "total_volume": 0.0,
+                "set_count": 0,
+            }
 
-            exercise_performance[ex_id]["total_volume"] += weight * reps
-            exercise_performance[ex_id]["set_count"] += 1
+        weight = exercise_set.actual_weight_kg or 0.0
+        reps = exercise_set.actual_reps or 0
 
+        if weight > exercise_performance[ex_id]["best_weight"]:
+            exercise_performance[ex_id]["best_weight"] = weight
+            exercise_performance[ex_id]["best_reps"] = reps
+
+        exercise_performance[ex_id]["total_volume"] += weight * reps
+        exercise_performance[ex_id]["set_count"] += 1
+
+    # ── Build recommendations ─────────────────────────────────────────────────
     recommendations = []
     for ex_id, perf in exercise_performance.items():
-        exercise = await db.get(Exercise, ex_id)
+        exercise = exercise_map.get(ex_id)
         if not exercise:
             continue
 
@@ -185,4 +213,4 @@ async def get_recommendations(
             "confidence": min(perf["set_count"] / 5, 1.0),
         })
 
-    return recommendations
+    return sorted(recommendations, key=lambda r: r["exercise_name"])


### PR DESCRIPTION
## Summary

- `get_progress()` and `get_recommendations()` each used O(sessions × exercises) DB round-trips — one query per session for sets, one query per exercise for the Exercise row
- Rewrote both endpoints to use **3 total batch queries** each (sessions → sets via `.in_()` → exercises via `.in_()`) and aggregate in Python
- DB I/O is now constant regardless of date range or exercise count

## Test plan

- [ ] All 61 existing tests pass (`pytest` green)
- [ ] `ruff check` clean
- [ ] Manual check: `/api/progress/` and `/api/progress/recommendations` return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)