### PR TITLE
fix: remove double json.loads() on JSON-typed muscle columns in plans API

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -38,13 +38,13 @@ def serialize_plan(plan: WorkoutPlan) -> dict:
         "id": plan.id,
         "name": plan.name,
         "description": plan.description,
-        "block_type": getattr(plan, 'block_type', 'other'),
-        "duration_weeks": getattr(plan, 'duration_weeks', 4),
-        "current_week": getattr(plan, 'current_week', 1),
+        "block_type": plan.block_type,
+        "duration_weeks": plan.duration_weeks,
+        "current_week": plan.current_week,
         "number_of_days": number_of_days,
         "days": days,
         "auto_progression": plan.auto_progression,
-        "is_archived": getattr(plan, 'is_archived', False),
+        "is_archived": plan.is_archived,
         "created_at": plan.created_at,
     }
 
@@ -99,7 +99,7 @@ async def get_recent_exercises(
             "name": ex.name,
             "display_name": ex.display_name,
             "movement_type": ex.movement_type,
-            "primary_muscles": json.loads(ex.primary_muscles) if ex.primary_muscles else [],
+            "primary_muscles": ex.primary_muscles or [],
             "usage_count": ex.usage_count,
             "last_used": ex.last_used.isoformat() if ex.last_used else None,
         }
@@ -118,7 +118,7 @@ async def get_exercises_grouped(
     grouped: dict[str, list[dict]] = {}
 
     for ex in exercises:
-        primary_muscles = json.loads(ex.primary_muscles) if ex.primary_muscles else ["other"]
+        primary_muscles = ex.primary_muscles or ["other"]
 
         for muscle in primary_muscles:
             muscle = muscle.lower().replace(" ", "_")
@@ -128,8 +128,8 @@ async def get_exercises_grouped(
                 "id": ex.id,
                 "name": ex.name,
                 "display_name": ex.display_name,
-                "movement_type": getattr(ex, 'movement_type', 'compound'),
-                "body_region": getattr(ex, 'body_region', 'upper'),
+                "movement_type": ex.movement_type,
+                "body_region": ex.body_region,
                 "primary_muscles": primary_muscles,
             })
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -116,3 +116,84 @@ class TestPlansCRUD:
 
         r = await client.delete(f"/api/plans/{plan['id']}")
         assert r.status_code == 204
+
+    async def test_delete_plan_gone(self, client: AsyncClient):
+        """Deleted plan is no longer retrievable."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"])
+        await client.delete(f"/api/plans/{plan['id']}")
+
+        r = await client.get(f"/api/plans/{plan['id']}")
+        assert r.status_code == 404
+
+    async def test_recent_exercises_empty(self, client: AsyncClient):
+        """GET /plans/exercises/recent returns [] when no sets have been logged."""
+        r = await client.get("/api/plans/exercises/recent")
+        assert r.status_code == 200
+        assert r.json() == []
+
+    async def test_recent_exercises_returns_muscle_lists(self, client: AsyncClient):
+        """GET /plans/exercises/recent returns primary_muscles as a list, not a string."""
+        from tests.conftest import create_plan, start_session_from_plan, log_set
+
+        ex = await create_exercise(
+            client,
+            name="squat",
+            display_name="Squat",
+            body_region="lower",
+            primary_muscles=["quads", "glutes"],
+            secondary_muscles=["hamstrings"],
+        )
+        plan = await create_plan(client, ex["id"])
+        sess = await start_session_from_plan(client, plan["id"])
+
+        # Log one set so this exercise shows up in recent
+        set_id = sess["sets"][0]["id"]
+        await log_set(client, sess["id"], set_id, 100.0, 8)
+
+        r = await client.get("/api/plans/exercises/recent")
+        assert r.status_code == 200
+        exercises = r.json()
+        assert len(exercises) >= 1
+        found = next((e for e in exercises if e["id"] == ex["id"]), None)
+        assert found is not None
+        # primary_muscles must be a list, not a JSON string
+        assert isinstance(found["primary_muscles"], list)
+        assert "quads" in found["primary_muscles"]
+
+    async def test_grouped_exercises_empty(self, client: AsyncClient):
+        """GET /plans/exercises/grouped returns {} when no exercises exist."""
+        r = await client.get("/api/plans/exercises/grouped")
+        assert r.status_code == 200
+        assert r.json() == {}
+
+    async def test_grouped_exercises_structure(self, client: AsyncClient):
+        """GET /plans/exercises/grouped returns dict keyed by muscle, values are lists."""
+        await create_exercise(
+            client,
+            name="bench",
+            display_name="Bench Press",
+            primary_muscles=["chest"],
+            secondary_muscles=["triceps"],
+        )
+        await create_exercise(
+            client,
+            name="squat",
+            display_name="Squat",
+            body_region="lower",
+            primary_muscles=["quads"],
+            secondary_muscles=["glutes"],
+        )
+
+        r = await client.get("/api/plans/exercises/grouped")
+        assert r.status_code == 200
+        data = r.json()
+        assert isinstance(data, dict)
+        assert "chest" in data
+        assert "quads" in data
+        # Each value must be a list of dicts with correct keys
+        bench_list = data["chest"]
+        assert isinstance(bench_list, list)
+        assert bench_list[0]["display_name"] == "Bench Press"
+        # primary_muscles inside each item must be a list
+        assert isinstance(bench_list[0]["primary_muscles"], list)


### PR DESCRIPTION
## Summary

- `GET /api/plans/exercises/recent` and `GET /api/plans/exercises/grouped` both called `json.loads(ex.primary_muscles)` on a column that is now a SQLAlchemy `JSON` type
- SQLAlchemy automatically deserializes JSON columns to Python objects, so the value is already a `list`; calling `json.loads(list)` raises `TypeError` → HTTP 500 for any user hitting these endpoints
- Also removed stale `getattr(..., 'default')` defensive calls in `serialize_plan()` — all fields are guaranteed to exist on `WorkoutPlan`

## Test plan

- [ ] `pytest` green (66 tests)
- [ ] `ruff check` clean
- [ ] New tests verify both endpoints return `primary_muscles` as a Python list (the exact condition that was broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)