### PR TITLE
fix: abandon-and-retry clears all in-progress sessions, not just one

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -152,7 +152,11 @@ async def start_session(
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Session '{existing.name}' is already in progress (id={existing.id}). Complete or delete it first.",
+            detail={
+                "message": f"Session '{existing.name}' is already in progress. Complete or delete it first.",
+                "session_id": existing.id,
+                "session_name": existing.name or "",
+            },
         )
 
     workout_session.status = WorkoutStatus.IN_PROGRESS
@@ -351,7 +355,11 @@ async def create_session_from_plan(
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Session '{existing.name}' is already in progress (id={existing.id}). Complete or delete it first.",
+            detail={
+                "message": f"Session '{existing.name}' is already in progress. Complete or delete it first.",
+                "session_id": existing.id,
+                "session_name": existing.name or "",
+            },
         )
 
     # ── Look up most recent prior session for the same plan + same day ────────

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -195,7 +195,7 @@
         raw = await createSessionFromPlan(planId, dayNumber, $settings.progressionStyle, bodyWtKg);
       } catch (e: any) {
         if (e?.response?.status === 409) {
-          await handleConflict(() => startFromPlan(planId, dayNumber));
+          await handleConflict(e, () => startFromPlan(planId, dayNumber));
           return;
         }
         throw e;
@@ -280,7 +280,7 @@
         });
       } catch (e: any) {
         if (e?.response?.status === 409) {
-          await handleConflict(startFreeSession);
+          await handleConflict(e, startFreeSession);
           return;
         }
         throw e;
@@ -831,11 +831,20 @@
   let conflictSession = $state<WorkoutSession | null>(null);
   let conflictRetry = $state<(() => Promise<void>) | null>(null); // re-run after abandoning
 
-  async function handleConflict(retry: () => Promise<void>) {
-    // Find the existing in-progress session to show its name in the UI
+  async function handleConflict(err: any, retry: () => Promise<void>) {
+    // Prefer the structured session_id from the 409 response body; fall back
+    // to scanning the sessions list if the backend returns a plain-text detail.
+    const detail = err?.response?.data?.detail;
+    const sessionId409: number | null =
+      detail && typeof detail === 'object' ? detail.session_id ?? null : null;
+
     try {
-      const sessions = await getSessions({ limit: 20 });
-      conflictSession = sessions.find(s => s.status === 'in_progress') ?? null;
+      if (sessionId409 != null) {
+        conflictSession = await getSession(sessionId409);
+      } else {
+        const sessions = await getSessions({ limit: 20 });
+        conflictSession = sessions.find(s => s.status === 'in_progress') ?? null;
+      }
     } catch { conflictSession = null; }
     conflictRetry = retry;
     loading = false;
@@ -853,9 +862,14 @@
   async function abandonAndRetry() {
     if (!conflictSession) return;
     loading = true;
+    // Delete ALL in-progress sessions so one orphaned session can't keep
+    // blocking new starts. (Previously only the displayed session was deleted,
+    // leaving any other orphans intact and causing repeated 409 loops.)
     try {
-      await deleteSession(conflictSession.id);
-    } catch { /* ignore if delete fails */ }
+      const all = await getSessions({ limit: 500 });
+      const inProgress = all.filter(s => s.status === 'in_progress');
+      await Promise.allSettled(inProgress.map(s => deleteSession(s.id)));
+    } catch { /* ignore individual delete failures */ }
     conflictSession = null;
     const retry = conflictRetry;
     conflictRetry = null;

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -60,8 +60,13 @@ class TestSessionLifecycle:
             f"/api/sessions/from-plan/{plan['id']}",
             params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
         )
-        # from-plan also checks for in-progress; expect 409
+        # from-plan also checks for in-progress; expect 409 with structured body
         assert r2.status_code == 409
+        body = r2.json()
+        # detail must be a dict with session_id so the frontend can target the right session
+        assert isinstance(body["detail"], dict)
+        assert "session_id" in body["detail"]
+        assert isinstance(body["detail"]["session_id"], int)
 
     async def test_complete_session(self, client: AsyncClient):
         """POST /sessions/{id}/complete transitions to completed."""


### PR DESCRIPTION
## Summary

- Users could accumulate multiple orphaned in-progress sessions (by navigating away before completing a workout)
- The 409 conflict UI only knew about **one** conflicting session; clicking "Abandon & Start New" deleted it, then the retry hit a 409 for a **different** orphan, making the button appear broken in an infinite loop

**Backend:**
- Both 409 paths (`start_session` and `create_session_from_plan`) now return a structured `detail` dict with `session_id` and `session_name`, letting the frontend identify the conflicting session directly

**Frontend (`abandonAndRetry` + `handleConflict`):**
- `handleConflict` reads `session_id` from the 409 response body to fetch the right conflicting session; falls back to scanning the sessions list
- `abandonAndRetry` now fetches **all** sessions and deletes every `in_progress` one via `Promise.allSettled` — a single click clears the entire orphan queue

## Test plan

- [ ] 66 tests pass
- [ ] `ruff check` clean
- [ ] Assert 409 body is now a structured dict containing `session_id`
- [ ] "Abandon & Start New" resolves all orphaned sessions in one click
- [ ] "Continue Existing Workout" resumes the correct conflicting session

🤖 Generated with [Claude Code](https://claude.com/claude-code)