### PR TITLE
feat: enforce 4-rep minimum floor in progressive overload

### DIFF
--- a/app/services/progression.py
+++ b/app/services/progression.py
@@ -90,7 +90,16 @@ def compute_overload(
 
     # ── Weighted exercises ─────────────────────────────────────────────────
 
-    # Didn't hit planned reps → retry same weight / same reps
+    # Minimum rep floor: never plan fewer than 4 reps.
+    # If the user got fewer than 4 reps, reduce weight (via Epley) to a load
+    # where they should be able to get 4 reps rather than planning an
+    # unproductive sub-4-rep set at the same load.
+    MIN_REPS = 4
+    if prior_reps < MIN_REPS and prior_weight > 0:
+        weight_for_min = epley_weight_for_reps(prior_weight, prior_reps, MIN_REPS)
+        return weight_for_min, MIN_REPS
+
+    # Didn't hit planned reps (but ≥ floor) → retry same weight / same reps
     if prior_reps < planned_reps:
         return prior_weight, prior_reps
 

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -160,13 +160,13 @@ class TestWeek2Prefill:
                 f"set {s['set_number']}: expected 9 reps (8+1), got {s['planned_reps']}"
 
     async def test_no_progression_if_reps_below_target(self, client: AsyncClient):
-        """If prior reps < planned reps, retry same weight and same reps."""
+        """If prior reps < planned reps (but >= 4 floor), retry same weight and same reps."""
         ex = await create_exercise(client)
         plan = await create_plan(client, ex["id"], sets=3, reps=8)
 
         sess1 = await start_session_from_plan(client, plan["id"])
         for s in sess1["sets"]:
-            await log_set(client, sess1["id"], s["id"], 100.0, 6)  # missed target
+            await log_set(client, sess1["id"], s["id"], 100.0, 6)  # missed target, but ≥ 4
 
         sess2 = await start_session_from_plan(client, plan["id"])
         for s in sess2["sets"]:
@@ -174,6 +174,43 @@ class TestWeek2Prefill:
                 f"set {s['set_number']}: expected 6 reps (retry), got {s['planned_reps']}"
             assert abs(s["planned_weight_kg"] - 100.0) < 0.01, \
                 f"set {s['set_number']}: expected same weight 100, got {s['planned_weight_kg']}"
+
+    async def test_reps_floor_deloads_weight_below_four_reps(self, client: AsyncClient):
+        """If prior reps < 4, weight drops (via Epley) to target 4 reps — never plan sub-4."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        sess1 = await start_session_from_plan(client, plan["id"])
+        # Log 3 reps — below the floor
+        await log_set(client, sess1["id"], sess1["sets"][0]["id"], 100.0, 3)
+
+        sess2 = await start_session_from_plan(client, plan["id"])
+        s = sess2["sets"][0]
+        # Reps must be exactly 4 (the floor)
+        assert s["planned_reps"] == 4, \
+            f"Expected planned_reps=4 (floor), got {s['planned_reps']}"
+        # Weight must be LESS than 100 (Epley deload to make 4 reps achievable)
+        assert s["planned_weight_kg"] is not None
+        assert s["planned_weight_kg"] < 100.0, \
+            f"Expected deloaded weight < 100, got {s['planned_weight_kg']}"
+        # Weight must still be a valid 2.5 kg increment
+        assert s["planned_weight_kg"] % 2.5 == 0, \
+            f"Weight {s['planned_weight_kg']} is not a multiple of 2.5"
+
+    async def test_reps_floor_at_exactly_four_is_unchanged(self, client: AsyncClient):
+        """Prior reps = 4 is at the floor — retry same weight, same reps (no deload)."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        sess1 = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess1["id"], sess1["sets"][0]["id"], 100.0, 4)
+
+        sess2 = await start_session_from_plan(client, plan["id"])
+        s = sess2["sets"][0]
+        # 4 is at the floor, not below it — retry, don't deload
+        assert s["planned_reps"] == 4, f"Expected 4 (retry at floor), got {s['planned_reps']}"
+        assert abs(s["planned_weight_kg"] - 100.0) < 0.01, \
+            f"Expected same weight 100 at floor, got {s['planned_weight_kg']}"
 
 
 # ── Per-set independence ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When `prior_reps < 4`, `compute_overload()` previously returned the same weight and the actual (sub-4) rep count. This planned unproductive near-failure sets.

New behavior: if prior reps drop below 4, weight is reduced via the Epley formula to a load where 4 reps should be achievable. Reps stay at 4 — never planned below that.

- `prior_reps < 4` and `prior_weight > 0` → `epley_weight_for_reps(prior_weight, prior_reps, 4)` rounded to 2.5 kg
- `prior_reps == 4` → normal retry (no deload); `prior_reps >= 4` → existing progression logic
- Bodyweight (`weight=0`) and assisted exercises unaffected (handled by earlier guards)

## Test plan

- [ ] 68 tests pass
- [ ] `ruff check` clean
- [ ] New test: 3 reps at 100 kg plans 4 reps at Epley-deloaded weight < 100 kg
- [ ] New test: 4 reps at 100 kg stays at 4 reps / 100 kg (at-floor retry, no deload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)