### PR TITLE
feat: warn when logging more than 30 reps per set

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -1343,6 +1343,14 @@
                       >✓</button>
                     {/if}
                   </div>
+                  <!-- High-rep advisory (unilateral) -->
+                  {#if !set.done && ((set.repsLeft ?? 0) > 30 || (set.repsRight ?? 0) > 30)}
+                    <div class="px-1 mt-0.5">
+                      <p class="text-xs text-amber-400 leading-snug">
+                        ⚠ Sets above 30 reps are outside the reliable range for weight progression. Consider increasing the load instead.
+                      </p>
+                    </div>
+                  {/if}
                   <!-- Deviation warning (unilateral) -->
                   {#if deviationWarning(set, set.weightLbs, set.repsLeft ?? set.repsRight)}
                     <div class="px-1 mt-0.5">
@@ -1439,6 +1447,14 @@
                       >✓</button>
                     {/if}
                   </div>
+                  <!-- High-rep advisory (> 30 reps moves outside the Epley range) -->
+                  {#if !set.done && (set.reps ?? 0) > 30}
+                    <div class="col-span-full px-1 mt-0.5">
+                      <p class="text-xs text-amber-400 leading-snug">
+                        ⚠ Sets above 30 reps are outside the reliable range for weight progression. Consider increasing the load instead.
+                      </p>
+                    </div>
+                  {/if}
                   <!-- Deviation warning -->
                   {#if deviationWarning(set, set.weightLbs, set.reps)}
                     <div class="col-span-full px-1 mt-0.5">


### PR DESCRIPTION
## Summary

The Epley 1RM formula becomes unreliable above ~30 reps (the 1RM estimate inflates and weight progression suggestions stop being useful). Added a non-blocking advisory that appears when the user enters > 30 reps for any set.

- Appears inline below the set row while editing (both bilateral and unilateral)
- Auto-dismisses once the set is marked done
- Covers both bilateral (`set.reps > 30`) and unilateral (`repsLeft > 30 || repsRight > 30`)
- No blocking — user can still log the set if they want

## Test plan

- [ ] 68 tests pass
- [ ] Enter 31+ reps → amber warning appears below that set row
- [ ] Warning dismisses when ✓ is clicked
- [ ] No warning at 30 reps (boundary is exclusive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)