### PR TITLE
fix: batch-fetch exercises in session creation and normalize db.flush() usage

### DIFF
--- a/app/api/exercises.py
+++ b/app/api/exercises.py
@@ -222,4 +222,4 @@ async def delete_exercise(
 
     # Delete the exercise
     await db.execute(delete(Exercise).where(Exercise.id == exercise_id))
-    await db.commit()
+    await db.flush()

--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -210,7 +210,7 @@ async def archive_plan(
     if not plan:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Plan {plan_id} not found")
     plan.is_archived = True
-    await db.commit()
+    await db.flush()
     await db.refresh(plan)
     return serialize_plan(plan)
 
@@ -317,6 +317,6 @@ async def update_plan(
 
         plan.planned_exercises = json.dumps(planned_data)
 
-    await db.commit()
+    await db.flush()
     await db.refresh(plan)
     return serialize_plan(plan)

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -437,13 +437,28 @@ async def create_session_from_plan(
 
     # Create sets for each exercise
     day_exercises = day.get("exercises", [])
+
+    # Batch-fetch all exercise models needed by this day in one query so we
+    # don't hit the DB once per exercise inside the loop below (N+1).
+    day_exercise_ids = [
+        ex_d.get("exercise_id") for ex_d in day_exercises if ex_d.get("exercise_id")
+    ]
+    if day_exercise_ids:
+        ex_rows = await db.execute(
+            select(Exercise).where(Exercise.id.in_(day_exercise_ids))
+        )
+        exercise_model_map: dict[int, Exercise] = {
+            ex.id: ex for ex in ex_rows.scalars().all()
+        }
+    else:
+        exercise_model_map = {}
+
     for exercise_data in day_exercises:
         exercise_id = exercise_data.get("exercise_id")
         sets = exercise_data.get("sets", 3)
         reps = exercise_data.get("reps", 8)
 
-        # Look up exercise metadata for overload logic
-        ex_model = await db.get(Exercise, exercise_id)
+        ex_model = exercise_model_map.get(exercise_id) if exercise_id else None
 
         for set_num in range(1, sets + 1):
             # Compute progression individually per set so each set uses


### PR DESCRIPTION
## Summary
- Replace per-exercise `db.get()` N+1 loop in `create_session_from_plan` with a single batch query via `.in_()` — reduces DB round-trips from O(exercises) to O(1)
- Normalize `delete_exercise`, `archive_plan`, and `update_plan` to use `db.flush()` instead of `db.commit()` so the request-scoped session manager in `database.py` owns the commit boundary consistently

## Test plan
- [ ] All 68 existing tests pass
- [ ] Start a workout from a plan with multiple exercises — session creates without errors
- [ ] Archive a plan — still shows as archived after reload
- [ ] Update a plan — changes persist after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)