### PR TITLE
test: add coverage for PUT /plans/{id} and set CRUD endpoints

### DIFF
--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -197,3 +197,47 @@ class TestPlansCRUD:
         assert bench_list[0]["display_name"] == "Bench Press"
         # primary_muscles inside each item must be a list
         assert isinstance(bench_list[0]["primary_muscles"], list)
+
+    async def test_update_plan_rename(self, client: AsyncClient):
+        """PUT /plans/{id} can rename the plan."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], name="Old Name")
+
+        r = await client.put(f"/api/plans/{plan['id']}", json={"name": "New Name"})
+        assert r.status_code == 200
+        assert r.json()["name"] == "New Name"
+
+    async def test_update_plan_days(self, client: AsyncClient):
+        """PUT /plans/{id} can replace the days structure."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=3, reps=8)
+
+        new_days = [
+            {
+                "day_number": 1,
+                "day_name": "Push",
+                "exercises": [
+                    {
+                        "exercise_id": ex["id"],
+                        "sets": 4,
+                        "reps": 6,
+                        "starting_weight_kg": 0,
+                        "progression_type": "linear",
+                    }
+                ],
+            }
+        ]
+        r = await client.put(
+            f"/api/plans/{plan['id']}",
+            json={"number_of_days": 1, "days": new_days},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["number_of_days"] == 1
+        assert data["days"][0]["day_name"] == "Push"
+        assert data["days"][0]["exercises"][0]["sets"] == 4
+
+    async def test_update_plan_not_found(self, client: AsyncClient):
+        """PUT /plans/99999 returns 404."""
+        r = await client.put("/api/plans/99999", json={"name": "Ghost"})
+        assert r.status_code == 404

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -145,3 +145,76 @@ class TestSessionLifecycle:
         data = r.json()
         assert isinstance(data, list)
         assert len(data) <= 500
+
+    async def test_add_set_to_session(self, client: AsyncClient):
+        """POST /sessions/{id}/sets creates a new set and returns 201."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        r = await client.post(
+            f"/api/sessions/{sess['id']}/sets",
+            json={
+                "exercise_id": ex["id"],
+                "set_number": 99,
+                "planned_reps": 10,
+                "planned_weight_kg": 60.0,
+            },
+        )
+        assert r.status_code == 201
+        data = r.json()
+        assert data["exercise_id"] == ex["id"]
+        assert data["set_number"] == 99
+        assert data["planned_reps"] == 10
+        assert data["planned_weight_kg"] == 60.0
+        assert "id" in data
+
+    async def test_add_set_session_not_found(self, client: AsyncClient):
+        """POST /sessions/99999/sets returns 404 when session doesn't exist."""
+        ex = await create_exercise(client)
+        r = await client.post(
+            "/api/sessions/99999/sets",
+            json={
+                "exercise_id": ex["id"],
+                "set_number": 1,
+                "planned_reps": 8,
+            },
+        )
+        assert r.status_code == 404
+
+    async def test_delete_set(self, client: AsyncClient):
+        """DELETE /sessions/{id}/sets/{set_id} removes the set and returns 204."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=2, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        set_id = sess["sets"][0]["id"]
+        r = await client.delete(f"/api/sessions/{sess['id']}/sets/{set_id}")
+        assert r.status_code == 204
+
+        # Verify the set is gone
+        r2 = await client.get(f"/api/sessions/{sess['id']}")
+        assert r2.status_code == 200
+        remaining_ids = [s["id"] for s in r2.json()["sets"]]
+        assert set_id not in remaining_ids
+
+    async def test_delete_set_not_found(self, client: AsyncClient):
+        """DELETE /sessions/{id}/sets/99999 returns 404."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        r = await client.delete(f"/api/sessions/{sess['id']}/sets/99999")
+        assert r.status_code == 404
+
+    async def test_delete_set_wrong_session(self, client: AsyncClient):
+        """DELETE with set_id belonging to a different session returns 404."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess1 = await start_session_from_plan(client, plan["id"])
+        sess2 = await start_session_from_plan(client, plan["id"])
+
+        # Try to delete sess1's set via sess2's endpoint
+        set_id = sess1["sets"][0]["id"]
+        r = await client.delete(f"/api/sessions/{sess2['id']}/sets/{set_id}")
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary
- **PUT /plans/{id}**: rename, replace days structure, 404 on missing plan
- **POST /sessions/{id}/sets**: create set returns 201 with correct fields; 404 on missing session
- **DELETE /sessions/{id}/sets/{set_id}**: removes set + 204; 404 on missing set; 404 when set_id belongs to a different session (verifies the session-scoping WHERE clause is enforced)

Total test count: 68 → 76

## Test plan
- [ ] `venv/bin/pytest tests/ -q` → 76 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)