### PR TITLE
fix: missing db.flush() in delete_plan and enum safety in progress queries

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -257,6 +257,7 @@ async def delete_plan(
             detail=f"Workout plan {plan_id} not found",
         )
     await db.delete(plan)
+    await db.flush()
 
 
 class PlanUpdate(BaseModel):

--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.models.exercise import Exercise
-from app.models.workout import ExerciseSet, WorkoutSession
+from app.models.workout import ExerciseSet, WorkoutSession, WorkoutStatus
 
 router = APIRouter()
 
@@ -38,7 +38,7 @@ async def get_progress(
     session_result = await db.execute(
         select(WorkoutSession)
         .where(
-            WorkoutSession.status == "completed",
+            WorkoutSession.status == WorkoutStatus.COMPLETED,
             WorkoutSession.date >= start_date,
             WorkoutSession.date <= end_date,
         )
@@ -131,7 +131,7 @@ async def get_recommendations(
     # ── Batch fetch sessions ──────────────────────────────────────────────────
     sessions_result = await db.execute(
         select(WorkoutSession).where(
-            WorkoutSession.status == "completed",
+            WorkoutSession.status == WorkoutStatus.COMPLETED,
             WorkoutSession.date >= start_date,
         )
     )


### PR DESCRIPTION
## Summary
- **`delete_plan`**: `await db.delete(plan)` was never followed by `await db.flush()` — the deletion wasn't visible within the transaction, so the plan would reappear if anything forced a rollback before commit. Added `await db.flush()` to match every other mutation endpoint.
- **`progress.py`**: Two `WorkoutSession.status == "completed"` string comparisons replaced with `WorkoutSession.status == WorkoutStatus.COMPLETED` — type-safe, consistent with the rest of the codebase, and future-proof if the enum value changes.

## Test plan
- [ ] All 76 tests pass
- [ ] Delete a plan → it's gone on next page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)