### PR TITLE
fix: pre-fill all sets with uniform weight/reps based on set-1 baseline

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -402,18 +402,27 @@ async def create_session_from_plan(
                 "planned_reps": s.planned_reps,
             }
 
-    def _overload_for_set(
-        exercise_id: int, set_number: int, target_reps: int, ex_model
+    def _overload_for_exercise(
+        exercise_id: int, target_reps: int, ex_model
     ) -> tuple[float | None, int | None]:
-        """Resolve prior-session data for this set and delegate to compute_overload()."""
+        """Compute the progressive overload suggestion for an exercise.
+
+        Uses set 1 from the prior session as the baseline (the heaviest set
+        the user actually performed).  All sets in the new session are pre-filled
+        with the same suggested weight so the display doesn't show a stepped-down
+        weight before the user has even started.  The frontend's inter-set
+        Epley drop-off will reduce subsequent sets' weight as each set is
+        completed during the workout.
+        """
         ex_sets = prior_set_data.get(exercise_id)
         if not ex_sets:
             return None, None
 
-        prior_set = ex_sets.get(set_number) or ex_sets[max(ex_sets.keys())]
-        prior_weight = prior_set["weight"]
-        prior_reps = prior_set["reps"]
-        planned_reps = prior_set.get("planned_reps") or target_reps
+        # Prefer set 1 as the baseline; fall back to the lowest-numbered set present.
+        baseline_set = ex_sets.get(1) or ex_sets[min(ex_sets.keys())]
+        prior_weight = baseline_set["weight"]
+        prior_reps = baseline_set["reps"]
+        planned_reps = baseline_set.get("planned_reps") or target_reps
 
         return compute_overload(
             prior_weight=prior_weight,
@@ -460,10 +469,13 @@ async def create_session_from_plan(
 
         ex_model = exercise_model_map.get(exercise_id) if exercise_id else None
 
+        # Compute progression once per exercise (from set 1 baseline) so that
+        # all sets in the new session share the same suggested weight.  The
+        # frontend's Epley drop-off will step the weight down as sets are
+        # completed during the workout.
+        weight_kg, suggested_reps = _overload_for_exercise(exercise_id, reps, ex_model)
+
         for set_num in range(1, sets + 1):
-            # Compute progression individually per set so each set uses
-            # its own history from the prior session.
-            weight_kg, suggested_reps = _overload_for_set(exercise_id, set_num, reps, ex_model)
             planned_reps_val = suggested_reps if suggested_reps is not None else None
 
             exercise_set = ExerciseSet(

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -235,9 +235,10 @@
               backendId: bset?.id ?? null,
               setNumber: i,
               weightLbs: suggestedWeight,
-              // Reps always start blank — drop-off fills them after set 1 is logged.
-              // initReps is kept for the Epley anchor, deviation warning, and PR detection.
-              reps: null,
+              // Pre-fill reps with the suggested target so the user can see what
+              // they're aiming for.  The Epley drop-off adjusts weight (not reps)
+              // as each set is completed.
+              reps: suggestedReps,
               repsLeft: null,
               repsRight: null,
               done: false,

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -216,49 +216,34 @@ class TestWeek2Prefill:
 # ── Per-set independence ──────────────────────────────────────────────────────
 
 class TestPerSetIndependence:
-    async def test_each_set_uses_its_own_prior_data(self, client: AsyncClient):
-        """Set 1 progresses from prior set 1, set 2 from prior set 2, etc."""
+    async def test_all_sets_use_set1_baseline(self, client: AsyncClient):
+        """All sets in the new session use set 1 as the progression baseline.
+
+        Even if previous sets had different reps (due to intra-session fatigue),
+        the new session's planned weight/reps should be uniform across sets so
+        the user sees a clean starting point.  The frontend Epley drop-off handles
+        intra-session variation as sets are completed.
+        """
         ex = await create_exercise(client)
         plan = await create_plan(client, ex["id"], sets=3, reps=8)
 
-        # Week 1: different reps per set (fatigue drop-off)
+        # Week 1: different reps per set (simulating intra-session fatigue)
         sess1 = await start_session_from_plan(client, plan["id"])
         sets_by_num = {s["set_number"]: s for s in sess1["sets"]}
         await log_set(client, sess1["id"], sets_by_num[1]["id"], 100.0, 8)
         await log_set(client, sess1["id"], sets_by_num[2]["id"], 100.0, 7)
         await log_set(client, sess1["id"], sets_by_num[3]["id"], 100.0, 6)
 
-        # Week 2: each set should progress from ITS OWN prior result
+        # Week 2: all sets should progress from set 1's result (8 reps → 9 reps)
         sess2 = await start_session_from_plan(client, plan["id"])
         s2_by_num = {s["set_number"]: s for s in sess2["sets"]}
 
-        # Set 1 had 8 reps → should progress to 9
-        assert s2_by_num[1]["planned_reps"] == 9, \
-            f"Set 1: expected 9, got {s2_by_num[1]['planned_reps']}"
-        # Set 2 had 7 reps → retry (7 < 8 target)
-        assert s2_by_num[2]["planned_reps"] == 7, \
-            f"Set 2: expected 7 (retry), got {s2_by_num[2]['planned_reps']}"
-        # Set 3 had 6 reps → retry (6 < 8 target)
-        assert s2_by_num[3]["planned_reps"] == 6, \
-            f"Set 3: expected 6 (retry), got {s2_by_num[3]['planned_reps']}"
-
-    async def test_sets_not_all_same_when_different_history(self, client: AsyncClient):
-        """Verify different sets get different pre-fills (not all identical)."""
-        ex = await create_exercise(client)
-        plan = await create_plan(client, ex["id"], sets=3, reps=8)
-
-        sess1 = await start_session_from_plan(client, plan["id"])
-        sets_by_num = {s["set_number"]: s for s in sess1["sets"]}
-        # Log different reps for each set
-        await log_set(client, sess1["id"], sets_by_num[1]["id"], 100.0, 8)
-        await log_set(client, sess1["id"], sets_by_num[2]["id"], 100.0, 7)
-        await log_set(client, sess1["id"], sets_by_num[3]["id"], 100.0, 6)
-
-        sess2 = await start_session_from_plan(client, plan["id"])
-        all_reps = [s["planned_reps"] for s in sess2["sets"]]
-        # They should NOT all be the same
-        assert len(set(all_reps)) > 1, \
-            f"Sets should have different reps when prior reps differed, got: {all_reps}"
+        # All sets use set 1 baseline (8 reps hit target → progress to 9)
+        for set_num in (1, 2, 3):
+            assert s2_by_num[set_num]["planned_reps"] == 9, \
+                f"Set {set_num}: expected 9 (set-1 baseline), got {s2_by_num[set_num]['planned_reps']}"
+            assert s2_by_num[set_num]["planned_weight_kg"] == 100.0, \
+                f"Set {set_num}: expected 100.0 kg, got {s2_by_num[set_num]['planned_weight_kg']}"
 
     async def test_extra_set_falls_back_gracefully(self, client: AsyncClient):
         """If week 2 has more sets than week 1, extra sets fall back to the last available."""


### PR DESCRIPTION
## Summary
- All sets in a new session now get the same suggested weight/reps — computed from set 1 of the prior session. This prevents the confusing \"already stepped down\" weight display where sets 2 and 3 started lower than set 1 before the user had lifted anything.
- Reps input is now pre-filled with the suggested target (was always blank before) so users immediately see what they're aiming for.
- The frontend Epley inter-set drop-off continues to adjust subsequent set weights as each set is completed during the workout.

## Test plan
- [x] All 75 tests pass
- [x] Day 1 session shows 195/195/195 lbs (uniform) with reps pre-filled
- [x] All 8 exercises in Day 1 verified uniform via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)