### PR TITLE
feat: visual plate breakdown with colored plates

### DIFF
--- a/frontend/src/lib/components/PlateVisual.svelte
+++ b/frontend/src/lib/components/PlateVisual.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  /**
+   * Visual plate breakdown — shows colored plates on a bar, per side.
+   * Props: totalWeight, barWeight, isLbs
+   */
+  interface Props {
+    totalWeight: number;
+    barWeight: number;
+    isLbs: boolean;
+  }
+
+  let { totalWeight, barWeight, isLbs }: Props = $props();
+
+  const PLATES_LBS: [number, string, string][] = [
+    [45, '#3b82f6', '2rem'],    // blue, tallest
+    [35, '#eab308', '1.75rem'], // yellow
+    [25, '#22c55e', '1.5rem'],  // green
+    [10, '#a1a1aa', '1.15rem'], // zinc/gray
+    [5,  '#ef4444', '0.9rem'],  // red, small
+    [2.5,'#71717a', '0.7rem'],  // dark gray, smallest
+  ];
+
+  const PLATES_KG: [number, string, string][] = [
+    [20,   '#3b82f6', '2rem'],
+    [15,   '#eab308', '1.75rem'],
+    [10,   '#22c55e', '1.5rem'],
+    [5,    '#a1a1aa', '1.15rem'],
+    [2.5,  '#ef4444', '0.9rem'],
+    [1.25, '#71717a', '0.7rem'],
+  ];
+
+  interface PlateSlice {
+    weight: number;
+    color: string;
+    height: string;
+    count: number;
+  }
+
+  let plates = $derived.by(() => {
+    const perSide = (totalWeight - barWeight) / 2;
+    if (perSide <= 0) return [];
+
+    const available = isLbs ? PLATES_LBS : PLATES_KG;
+    let remaining = perSide;
+    const result: PlateSlice[] = [];
+
+    for (const [weight, color, height] of available) {
+      const count = Math.floor(remaining / weight);
+      if (count > 0) {
+        result.push({ weight, color, height, count });
+        remaining -= count * weight;
+      }
+    }
+    if (remaining > 0.1) return []; // can't make exact weight
+    return result;
+  });
+</script>
+
+{#if plates.length > 0}
+  <div class="flex items-center gap-0.5 justify-center mt-0.5">
+    <!-- Plates (per side) -->
+    {#each plates as plate}
+      {#each Array(plate.count) as _}
+        <div
+          style="width: 6px; height: {plate.height}; background: {plate.color}; border-radius: 1px;"
+          title="{plate.weight} {isLbs ? 'lbs' : 'kg'}"
+        ></div>
+      {/each}
+    {/each}
+    <!-- Bar -->
+    <div style="width: 18px; height: 5px; background: #52525b; border-radius: 1px;"></div>
+    <!-- Plates (mirrored) -->
+    {#each [...plates].reverse() as plate}
+      {#each Array(plate.count) as _}
+        <div
+          style="width: 6px; height: {plate.height}; background: {plate.color}; border-radius: 1px;"
+          title="{plate.weight} {isLbs ? 'lbs' : 'kg'}"
+        ></div>
+      {/each}
+    {/each}
+  </div>
+  <p class="text-[9px] text-zinc-500 text-center">
+    {plates.map(p => `${p.count}×${p.weight}`).join(' + ')} /side
+  </p>
+{/if}

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -11,6 +11,7 @@
   } from '$lib/api';
   import type { Exercise, WorkoutPlan, ExerciseHistorySession, WorkoutSession } from '$lib/api';
   import { swipeable } from '$lib/actions/swipeable';
+  import PlateVisual from '$lib/components/PlateVisual.svelte';
 
   // ─── Constants ────────────────────────────────────────────────────────────
   const LBS_TO_KG = 0.453592;
@@ -1625,9 +1626,8 @@
                         <span class="text-xs text-amber-400 text-center">{netDisplay(set.weightLbs)}</span>
                       {:else if shouldShowPlates(exercise) && set.weightLbs != null}
                         {@const bw = getBarWeight(exercise)}
-                        {@const plates = set.weightLbs > bw ? calcPlates(set.weightLbs, unit === 'lbs', bw) : ''}
-                        {#if plates}
-                          <span class="text-[9px] text-zinc-500 text-center leading-tight">{plates}</span>
+                        {#if set.weightLbs > bw}
+                          <PlateVisual totalWeight={set.weightLbs} barWeight={bw} isLbs={unit === 'lbs'} />
                         {/if}
                       {/if}
                     </div>
@@ -1842,9 +1842,8 @@
                         <span class="text-xs text-amber-400 text-center">{netDisplay(set.weightLbs)}</span>
                       {:else if shouldShowPlates(exercise) && set.weightLbs != null}
                         {@const bw = getBarWeight(exercise)}
-                        {@const plates = set.weightLbs > bw ? calcPlates(set.weightLbs, unit === 'lbs', bw) : ''}
-                        {#if plates}
-                          <span class="text-[9px] text-zinc-500 text-center leading-tight">{plates}</span>
+                        {#if set.weightLbs > bw}
+                          <PlateVisual totalWeight={set.weightLbs} barWeight={bw} isLbs={unit === 'lbs'} />
                         {/if}
                       {/if}
                     </div>


### PR DESCRIPTION
## Summary
- New `PlateVisual` component showing a bar diagram with color-coded plates
- Plates sized by weight: 45 lbs (blue, tallest) down to 2.5 lbs (gray, smallest)
- Mirrored on both sides of a bar center
- Text breakdown still shown below: "2×45 + 1×25 /side"
- Hover any plate to see its weight

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)