### PR TITLE
feat: per-equipment plate math base weight override

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -402,32 +402,53 @@
   <div class="card space-y-4">
     <div>
       <h3 class="text-lg font-semibold">Machine & Bar Weights</h3>
-      <p class="text-sm text-zinc-400 mt-1">Set the unloaded weight of your equipment for accurate plate calculations.</p>
+      <p class="text-sm text-zinc-400 mt-1">Set the unloaded weight of your equipment. For plate-loaded machines, set a "plate math base" to count plates from (e.g. 45 lbs regardless of actual sled weight).</p>
     </div>
 
     {#each [
-      ['barbell', 'Standard Barbell'],
-      ['smithMachine', 'Smith Machine'],
-      ['legPress', 'Leg Press Sled'],
-      ['hackSquat', 'Hack Squat Sled'],
-      ['tBarRow', 'T-Bar Row'],
-    ] as [key, label]}
-      <div class="flex items-center justify-between gap-4">
-        <label for="mw-{key}" class="text-sm text-zinc-300 flex-1">{label}</label>
-        <div class="flex items-center gap-2">
-          <input id="mw-{key}" type="number" inputmode="decimal"
-                 value={$settings.machineWeights?.[key] ?? 0}
-                 onchange={(e) => {
-                   const val = parseFloat((e.target as HTMLInputElement).value) || 0;
-                   settings.update(s => ({
-                     ...s,
-                     machineWeights: { ...s.machineWeights, [key]: val }
-                   }));
-                 }}
-                 class="w-20 text-center bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-2 text-white"
-                 style="font-size: 16px;" />
-          <span class="text-xs text-zinc-500 w-6">{$settings.weightUnit}</span>
+      ['barbell', 'Standard Barbell', false],
+      ['smithMachine', 'Smith Machine', true],
+      ['legPress', 'Leg Press Sled', true],
+      ['hackSquat', 'Hack Squat Sled', true],
+      ['tBarRow', 'T-Bar Row', true],
+    ] as [key, label, hasDisplayBase]}
+      <div class="space-y-1">
+        <div class="flex items-center justify-between gap-4">
+          <label for="mw-{key}" class="text-sm text-zinc-300 flex-1">{label}</label>
+          <div class="flex items-center gap-2">
+            <input id="mw-{key}" type="number" inputmode="decimal"
+                   value={$settings.machineWeights?.[key] ?? 0}
+                   onchange={(e) => {
+                     const val = parseFloat((e.target as HTMLInputElement).value) || 0;
+                     settings.update(s => ({
+                       ...s,
+                       machineWeights: { ...s.machineWeights, [key]: val }
+                     }));
+                   }}
+                   class="w-20 text-center bg-zinc-800 border border-zinc-700 rounded-lg px-2 py-2 text-white"
+                   style="font-size: 16px;" />
+            <span class="text-xs text-zinc-500 w-6">{$settings.weightUnit}</span>
+          </div>
         </div>
+        {#if hasDisplayBase}
+          <div class="flex items-center justify-between gap-4 pl-4">
+            <span class="text-xs text-zinc-500 flex-1">Plate math base</span>
+            <div class="flex items-center gap-2">
+              <input type="number" inputmode="decimal"
+                     value={$settings.machineWeights?.[`${key}_displayBase`] ?? $settings.machineWeights?.[key] ?? 0}
+                     onchange={(e) => {
+                       const val = parseFloat((e.target as HTMLInputElement).value) || 0;
+                       settings.update(s => ({
+                         ...s,
+                         machineWeights: { ...s.machineWeights, [`${key}_displayBase`]: val }
+                       }));
+                     }}
+                     class="w-20 text-center bg-zinc-800 border border-zinc-600 rounded-lg px-2 py-1.5 text-white text-sm"
+                     style="font-size: 16px;" />
+              <span class="text-xs text-zinc-500 w-6">{$settings.weightUnit}</span>
+            </div>
+          </div>
+        {/if}
       </div>
     {/each}
   </div>

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -137,6 +137,7 @@
     return exercise.equipment_type === 'barbell' || exercise.equipment_type === 'plate_loaded';
   }
 
+  /** Get bar/sled weight for plate math. Uses display base if set, else actual weight. */
   function getBarWeight(exercise: Exercise | undefined): number {
     const mw = $settings.machineWeights;
     const defaultBar = $settings.weightUnit === 'lbs' ? 45 : 20;
@@ -144,11 +145,13 @@
 
     if (exercise.equipment_type === 'plate_loaded') {
       const n = exercise.name.toLowerCase();
-      if (n.includes('smith')) return mw.smithMachine ?? 25;
-      if (n.includes('leg_press') || n.includes('leg press')) return mw.legPress ?? 75;
-      if (n.includes('hack_squat') || n.includes('hack squat')) return mw.hackSquat ?? 45;
-      if (n.includes('t_bar') || n.includes('t-bar')) return mw.tBarRow ?? 20;
-      return mw.barbell ?? defaultBar;
+      let key = 'barbell';
+      if (n.includes('smith')) key = 'smithMachine';
+      else if (n.includes('leg_press') || n.includes('leg press')) key = 'legPress';
+      else if (n.includes('hack_squat') || n.includes('hack squat')) key = 'hackSquat';
+      else if (n.includes('t_bar') || n.includes('t-bar')) key = 'tBarRow';
+      // Use display base for plate math if configured, otherwise actual weight
+      return mw[`${key}_displayBase`] ?? mw[key] ?? defaultBar;
     }
     return mw.barbell ?? defaultBar;
   }


### PR DESCRIPTION
## Summary
- Plate-loaded machines (Smith, Leg Press, Hack Squat, T-Bar) now have a configurable "plate math base" in settings
- Users can set this to 45 lbs so plate calculations count from their preferred base regardless of actual sled weight
- Backend stores true weight; plate display uses the override

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)