### PR TITLE
feat: local build + deploy script for faster deploys

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -77,9 +77,16 @@ transfer_image() {
 
   log "Saving and transferring $tag to server..."
 
-  # Save image, compress, pipe over SSH, load on server
-  docker save "$tag:latest" | gzip | \
-    ssh "$SERVER" "docker load"
+  # Save to temp file, scp, then load on server (avoids pipe hang)
+  local tmpfile="/tmp/${tag}.tar.gz"
+  docker save "$tag:latest" | gzip > "$tmpfile"
+  local size
+  size=$(du -h "$tmpfile" | cut -f1)
+  log "Image saved ($size), transferring..."
+
+  scp -C "$tmpfile" "$SERVER:/tmp/${tag}.tar.gz"
+  ssh "$SERVER" "docker load < /tmp/${tag}.tar.gz && rm -f /tmp/${tag}.tar.gz"
+  rm -f "$tmpfile"
 
   local duration=$((SECONDS - start_time))
   log "Transferred $tag in $(elapsed $duration)"


### PR DESCRIPTION
## Summary
- New `deploy-local.sh` script that builds Docker images on your Mac and transfers them to the VPS
- Cross-compiles for linux/amd64 using Docker buildx
- Much faster than building on the 1-CPU VPS since the Mac Studio has way more horsepower
- Supports `./deploy-local.sh [all|main|dev]` for selective deploys

Closes #161

## Test plan
- [ ] Run `./deploy-local.sh dev` and verify dev container updates on server
- [ ] Run `./deploy-local.sh main` and verify main container updates
- [ ] Verify health check passes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)