### PR TITLE
feat: service worker cache busting with update banner

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node -e \"const fs=require('fs');const f='build/client/sw.js';fs.writeFileSync(f,fs.readFileSync(f,'utf8').replace('__BUILD_TIMESTAMP__',Date.now()))\"",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "test:e2e": "playwright test",

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -19,6 +19,15 @@
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('/sw.js').catch(() => {});
+        // Show update banner when a new version is deployed
+        navigator.serviceWorker.addEventListener('message', (e) => {
+          if (e.data && e.data.type === 'SW_UPDATED') {
+            var banner = document.createElement('div');
+            banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:9999;padding:12px 16px;background:#1d4ed8;color:#fff;display:flex;align-items:center;justify-content:space-between;font-size:14px;font-family:system-ui';
+            banner.innerHTML = '<span>A new version is available</span><button onclick="window.location.reload()" style="background:#fff;color:#1d4ed8;border:none;padding:6px 16px;border-radius:8px;font-weight:600;cursor:pointer">Update</button>';
+            document.body.appendChild(banner);
+          }
+        });
       }
     </script>
   </body>

--- a/frontend/static/sw.js
+++ b/frontend/static/sw.js
@@ -1,5 +1,6 @@
 // GymTracker Service Worker — cache app shell for offline support
-const CACHE_NAME = 'gymtracker-v1';
+// VERSION is replaced at build time by vite.config.ts
+const CACHE_NAME = 'gymtracker-__BUILD_TIMESTAMP__';
 const SHELL_URLS = [
   '/',
   '/manifest.json',
@@ -8,7 +9,7 @@ const SHELL_URLS = [
   '/icons/icon-512.png',
 ];
 
-// Install: cache the app shell
+// Install: cache the app shell, immediately take over
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_URLS))
@@ -16,12 +17,17 @@ self.addEventListener('install', (event) => {
   self.skipWaiting();
 });
 
-// Activate: clean old caches
+// Activate: clean ALL old caches, notify clients to reload
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((keys) =>
       Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-    )
+    ).then(() => {
+      // Tell all open tabs to reload with the new version
+      self.clients.matchAll({ type: 'window' }).then((clients) => {
+        clients.forEach((client) => client.postMessage({ type: 'SW_UPDATED' }));
+      });
+    })
   );
   self.clients.claim();
 });


### PR DESCRIPTION
## Summary
- Each build stamps a unique timestamp into the service worker cache name
- When a new version deploys, the old cache is cleaned automatically
- A non-intrusive "Update" banner appears at the bottom — users tap to reload when ready
- No forced reload mid-workout

## Test plan
- [ ] Deploy, verify banner appears on existing clients
- [ ] Tapping "Update" reloads with fresh assets
- [ ] New visits get the latest version without banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)