### PR TITLE
feat: estimated reps and weight range feedback

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -1750,6 +1750,19 @@
                           <PlateVisual totalWeight={set.weightLbs} barWeight={bw} isLbs={unit === 'lbs'} />
                         {/if}
                       {/if}
+                      {#if !isAssistedEx && set.oneRM && set.weightLbs != null && set.weightLbs > 0 && !set.done}
+                        {@const estReps = epleyReps(set.oneRM, set.weightLbs)}
+                        {#if estReps < 5}
+                          <span class="text-[10px] text-red-400 text-center leading-tight">~{estReps} reps (heavy)</span>
+                        {:else if estReps > 30}
+                          <span class="text-[10px] text-red-400 text-center leading-tight">~{estReps} reps (light)</span>
+                        {:else}
+                          <span class="text-[10px] text-zinc-500 text-center leading-tight">~{estReps} reps</span>
+                        {/if}
+                        {@const w5 = roundWeight(epleyWeight(set.oneRM, 5))}
+                        {@const w30 = roundWeight(epleyWeight(set.oneRM, 30))}
+                        <span class="text-[9px] text-zinc-600 text-center leading-tight">{w30}–{w5} {unit}</span>
+                      {/if}
                     </div>
 
                     <!-- Left reps -->
@@ -1965,6 +1978,19 @@
                         {#if set.weightLbs > bw}
                           <PlateVisual totalWeight={set.weightLbs} barWeight={bw} isLbs={unit === 'lbs'} />
                         {/if}
+                      {/if}
+                      {#if !isAssistedEx && set.oneRM && set.weightLbs != null && set.weightLbs > 0 && !set.done}
+                        {@const estReps = epleyReps(set.oneRM, set.weightLbs)}
+                        {#if estReps < 5}
+                          <span class="text-[10px] text-red-400 text-center leading-tight">~{estReps} reps (heavy)</span>
+                        {:else if estReps > 30}
+                          <span class="text-[10px] text-red-400 text-center leading-tight">~{estReps} reps (light)</span>
+                        {:else}
+                          <span class="text-[10px] text-zinc-500 text-center leading-tight">~{estReps} reps</span>
+                        {/if}
+                        {@const w5 = roundWeight(epleyWeight(set.oneRM, 5))}
+                        {@const w30 = roundWeight(epleyWeight(set.oneRM, 30))}
+                        <span class="text-[9px] text-zinc-600 text-center leading-tight">{w30}–{w5} {unit}</span>
                       {/if}
                     </div>
 


### PR DESCRIPTION
## Summary
- Shows estimated reps (from Epley formula) below weight input when you change weight
- Red warning for <5 reps (too heavy) or >30 reps (too light)
- Shows valid weight range (5-30 reps) as subtle hint below
- Works for both unilateral and standard set rows

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)