### PR TITLE
feat: add belt squat equipment

### DIFF
--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -58,6 +58,7 @@ const defaultSettings: AppSettings = {
     ezBarRackable: 35,
     safetySquatBar: 65,
     trapBar: 45,
+    beltSquat: 0,
     smithMachine: 25,
     legPress: 75,
     hackSquat: 45,

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -446,6 +446,7 @@
           ['legPress', 'Leg Press'],
           ['hackSquat', 'Hack Squat'],
           ['tBarRow', 'T-Bar Row'],
+          ['beltSquat', 'Belt Squat'],
         ] as [key, label]}
           <div class="space-y-1">
             <div class="flex items-center justify-between gap-4">

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -151,6 +151,7 @@
       else if (n.includes('leg_press') || n.includes('leg press')) key = 'legPress';
       else if (n.includes('hack_squat') || n.includes('hack squat')) key = 'hackSquat';
       else if (n.includes('t_bar') || n.includes('t-bar')) key = 'tBarRow';
+      else if (n.includes('belt_squat') || n.includes('belt squat')) key = 'beltSquat';
       // Use display base for plate math if configured, otherwise actual weight
       return mw[`${key}_displayBase`] ?? mw[key] ?? defaultBar;
     }

--- a/scripts/seed_all_exercises.py
+++ b/scripts/seed_all_exercises.py
@@ -17,6 +17,7 @@ EQUIPMENT_MAP = {
     "machine": "machine",
     "band": "band",
     "tbar": "plate_loaded",
+    "belt": "plate_loaded",
     "weighted": "bodyweight",  # weighted pullups/dips are still bodyweight category
     "assist": "machine",       # assisted pullups/dips use a machine
     "press": "machine",        # calf press machines
@@ -104,6 +105,10 @@ def generate_all_exercises():
     for i in ci:
         for s in cs:
             ex.append({"name": f"{i}_{s}_calf", "display": f"{i.title()} {s.title()} Calf", "type": "isolation", "primary": ["gastrocnemius", "soleus"], "secondary": ["tibialis"]})
+
+    # BELT SQUAT
+    for s in ["standard", "wide", "narrow", "marching", "calf_raise"]:
+        ex.append({"name": f"belt_{s}_squat", "display": f"Belt {s.replace('_', ' ').title()} Squat", "type": "squat", "primary": ["quads", "glutes"], "secondary": ["hamstrings"]})
 
     return ex
 


### PR DESCRIPTION
## Summary
- Belt squat added to plate-loaded machines in Settings
- 5 belt squat exercise variants in seed data
- Plate math support for belt squat exercises

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)