### PR TITLE
fix: settings page scroll cutoff on mobile

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -116,7 +116,7 @@
   }
 </script>
 
-<div class="space-y-6 max-w-2xl mx-auto p-6">
+<div class="space-y-6 max-w-2xl mx-auto p-6 pb-24">
   <h2 class="text-2xl font-bold">Settings</h2>
 
   <!-- ── Profile ─────────────────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
- Added bottom padding (pb-24) so logout button isn't hidden behind mobile nav bar

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)