### PR TITLE
feat: Apple-style widget editing with drag-and-drop

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -803,16 +803,17 @@
 </div>
 
 <style>
-  /* Apple-style jiggle animation for edit mode */
+  /* Apple-style jiggle animation — very subtle */
   @keyframes jiggle {
-    0%, 100% { transform: rotate(-0.5deg); }
-    50% { transform: rotate(0.5deg); }
+    0%, 100% { transform: rotate(-0.15deg); }
+    50% { transform: rotate(0.15deg); }
   }
   :global(.jiggle) {
-    animation: jiggle 0.15s ease-in-out infinite alternate;
+    animation: jiggle 0.3s ease-in-out infinite alternate;
   }
   :global(.jiggle:nth-child(even)) {
-    animation-delay: 0.075s;
+    animation-delay: 0.15s;
+    animation-direction: alternate-reverse;
   }
   :global(.drag-over) {
     outline: 2px dashed rgba(59, 130, 246, 0.5);


### PR DESCRIPTION
## Summary
- Long-press (600ms) on dashboard enters edit mode with jiggle animation
- Red − buttons on each widget to remove it
- Blue + button in header to add hidden widgets back
- Drag-and-drop reorder (desktop HTML5 drag + mobile touch drag)
- Required widgets (Next Workout, Manage Plans) can't be removed
- Replaces the old checkbox-based customize panel

## Test plan
- [ ] Long-press on dashboard → widgets jiggle, edit UI appears
- [ ] Red − buttons on removable widgets, none on required ones
- [ ] Tap − → widget disappears
- [ ] Tap + → list of hidden widgets, tap one to add
- [ ] Drag widget to new position → reorders
- [ ] Tap Done → edit mode exits, layout saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)