### PR TITLE
fix: diet phase and nutrition timezone bug

### DIFF
--- a/app/api/diet_phase.py
+++ b/app/api/diet_phase.py
@@ -1,6 +1,6 @@
 """Diet phase API — create/manage cut/bulk/maintenance phases with auto-calculated macros."""
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -48,7 +48,7 @@ def serialize_phase(phase: DietPhase, extra: dict | None = None) -> dict:
 
 async def _get_weight_entries(db: AsyncSession, user_id: int, days: int = 14) -> list[BodyWeightEntry]:
     """Fetch recent body weight entries."""
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    cutoff = datetime.utcnow() - timedelta(days=days)
     result = await db.execute(
         select(BodyWeightEntry)
         .where(BodyWeightEntry.recorded_at >= cutoff, BodyWeightEntry.user_id == user_id)
@@ -59,7 +59,7 @@ async def _get_weight_entries(db: AsyncSession, user_id: int, days: int = 14) ->
 
 async def _build_phase_status(phase: DietPhase, db: AsyncSession, user_id: int) -> dict:
     """Build the full status response for a phase."""
-    today = datetime.now(timezone.utc).date()
+    today = datetime.utcnow().date()
     days_in = (today - phase.started_on).days
     current_week = min(max(1, days_in // 7 + 1), phase.duration_weeks)
     weeks_remaining = max(0, phase.duration_weeks - current_week)
@@ -142,7 +142,7 @@ async def create_phase(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     """Start a new diet phase. Deactivates any existing active phase."""
-    today = datetime.now(timezone.utc).date()
+    today = datetime.utcnow().date()
 
     # Get starting weight
     bw_result = await db.execute(
@@ -257,7 +257,7 @@ async def recalculate_phase(
         if cal_adj:
             macros["calories"] = max(1200, macros["calories"] + cal_adj)
 
-        today = datetime.now(timezone.utc).date()
+        today = datetime.utcnow().date()
         await _upsert_goal(db, macros, today, user_id=user.id)
         status_data["current_goals"] = {k: macros[k] for k in ("calories", "protein", "carbs", "fat")}
 
@@ -277,5 +277,5 @@ async def end_phase(
     if not phase:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active phase")
     phase.is_active = False
-    phase.ended_on = datetime.now(timezone.utc).date()
+    phase.ended_on = datetime.utcnow().date()
     await db.flush()

--- a/app/api/nutrition.py
+++ b/app/api/nutrition.py
@@ -1,7 +1,7 @@
 """Nutrition tracking API endpoints — food log, custom foods, goals, and search."""
 
 import json
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -211,7 +211,7 @@ async def list_entries(
     date: date = Query(default=None),
 ) -> dict:
     """Get nutrition entries for a date, grouped by meal with totals."""
-    target_date = date or datetime.now(timezone.utc).date()
+    target_date = date or datetime.utcnow().date()
     result = await db.execute(
         select(NutritionEntry)
         .where(NutritionEntry.date == target_date, NutritionEntry.user_id == user.id)
@@ -287,7 +287,7 @@ async def daily_summary(
     date: date = Query(default=None),
 ) -> dict:
     """Get daily macro totals vs goals."""
-    target_date = date or datetime.now(timezone.utc).date()
+    target_date = date or datetime.utcnow().date()
 
     # Totals
     result = await db.execute(
@@ -344,7 +344,7 @@ async def weekly_report(
     from app.models.body_weight import BodyWeightEntry
     from app.models.workout import WorkoutSession
 
-    today = datetime.now(timezone.utc).date()
+    today = datetime.utcnow().date()
     week_ago = today - timedelta(days=7)
 
     # Daily nutrition totals for each of the last 7 days
@@ -437,7 +437,7 @@ async def get_goals(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict | None:
     """Get current active macro goals."""
-    today = datetime.now(timezone.utc).date()
+    today = datetime.utcnow().date()
     result = await db.execute(
         select(MacroGoal)
         .where(MacroGoal.effective_from <= today, MacroGoal.user_id == user.id)
@@ -455,7 +455,7 @@ async def set_goals(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
     """Set or update daily macro goals (upserts on effective_from)."""
-    effective = data.effective_from or datetime.now(timezone.utc).date()
+    effective = data.effective_from or datetime.utcnow().date()
 
     # Upsert: check if a goal already exists for this date
     result = await db.execute(


### PR DESCRIPTION
## Summary
- Replace `datetime.now(timezone.utc)` with `datetime.utcnow()` in diet_phase.py and nutrition.py
- PostgreSQL rejects mixing tz-aware and naive datetimes, causing diet phase creation to fail
- Same fix pattern as the session timezone fix from earlier

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)