### PR TITLE
fix: double update banner and auth loss during SW update

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -18,13 +18,21 @@
     <div style="display: contents">%sveltekit.body%</div>
     <script>
       if ('serviceWorker' in navigator) {
+        // Suppress banner after force update — set by the Update button
+        var justForceUpdated = sessionStorage.getItem('gymtracker_force_updated');
+        if (justForceUpdated) sessionStorage.removeItem('gymtracker_force_updated');
+
         function showUpdateBanner() {
-          if (document.getElementById('sw-update-banner')) return; // already showing
+          // Don't show if we just did a force update (avoids double-banner #263)
+          if (justForceUpdated) return;
+          if (document.getElementById('sw-update-banner')) return;
           var banner = document.createElement('div');
           banner.id = 'sw-update-banner';
           banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:9999;padding:12px 16px;background:#1d4ed8;color:#fff;display:flex;align-items:center;justify-content:space-between;font-size:14px;font-family:system-ui';
           banner.innerHTML = '<span>A new version is available</span><button style="background:#fff;color:#1d4ed8;border:none;padding:6px 16px;border-radius:8px;font-weight:600;cursor:pointer">Update</button>';
           banner.querySelector('button').onclick = async function() {
+            // Set flag BEFORE reload so the next page load suppresses the banner
+            sessionStorage.setItem('gymtracker_force_updated', '1');
             if ('caches' in window) { var keys = await caches.keys(); await Promise.all(keys.map(function(k) { return caches.delete(k); })); }
             window.location.reload();
           };
@@ -39,21 +47,19 @@
             var newWorker = reg.installing;
             if (newWorker) {
               newWorker.addEventListener('statechange', function() {
-                if (newWorker.state === 'activated') showUpdateBanner();
+                if (newWorker.state === 'activated' && navigator.serviceWorker.controller) showUpdateBanner();
               });
             }
           });
         }).catch(function() {});
 
-        // Also listen for SW messages (backup)
+        // Listen for SW messages
         navigator.serviceWorker.addEventListener('message', function(e) {
           if (e.data && e.data.type === 'SW_UPDATED') showUpdateBanner();
         });
 
-        // Detect controller change (new SW took over)
-        navigator.serviceWorker.addEventListener('controllerchange', function() {
-          showUpdateBanner();
-        });
+        // Note: removed controllerchange listener — it fires on first install
+        // and after force update, causing false-positive banners
       }
     </script>
     <script>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -759,13 +759,17 @@
         </div>
         <button
           onclick={async () => {
+            // Set flag to suppress the "new version" banner after reload
+            sessionStorage.setItem('gymtracker_force_updated', '1');
+            // Clear caches but DON'T unregister SW — that causes a re-registration
+            // cycle that triggers the update banner again (#263) and can lose auth (#269)
             if ('caches' in window) {
               const keys = await caches.keys();
               await Promise.all(keys.map(k => caches.delete(k)));
             }
-            if ('serviceWorker' in navigator) {
-              const regs = await navigator.serviceWorker.getRegistrations();
-              await Promise.all(regs.map(r => r.unregister()));
+            // Tell the SW to skip waiting if there's a new version queued
+            if (navigator.serviceWorker?.controller) {
+              navigator.serviceWorker.controller.postMessage({ type: 'SKIP_WAITING' });
             }
             window.location.reload();
           }}

--- a/frontend/static/sw.js
+++ b/frontend/static/sw.js
@@ -32,6 +32,13 @@ self.addEventListener('activate', (event) => {
   self.clients.claim();
 });
 
+// Listen for skip-waiting message from the page
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 // Fetch: network-first for API, cache-first for static assets
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);


### PR DESCRIPTION
## Summary
- **#263**: sessionStorage flag suppresses banner after force update reload
- **#269**: Don't unregister SW — just clear caches + send SKIP_WAITING message
- Remove `controllerchange` listener (false-positive trigger on first install)
- Only show banner when `navigator.serviceWorker.controller` exists (not on first visit)

Closes #263
Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)