### PR TITLE
feat: volume landmarks — weekly sets vs MEV/MAV/MRV

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -474,3 +474,90 @@ async def get_personal_records(
 
     records = sorted(exercise_data.values(), key=lambda x: x["best_1rm_kg"], reverse=True)
     return records
+
+
+# ── Volume landmarks (MEV/MRV) ────────────────────────────────────────────
+
+# Evidence-based volume landmarks per muscle group (sets per week)
+# Based on RP/Israetel recommendations
+VOLUME_LANDMARKS = {
+    "chest":       {"mev": 8,  "mav": 14, "mrv": 20},
+    "back":        {"mev": 8,  "mav": 14, "mrv": 22},
+    "quads":       {"mev": 6,  "mav": 12, "mrv": 18},
+    "hamstrings":  {"mev": 4,  "mav": 10, "mrv": 16},
+    "glutes":      {"mev": 4,  "mav": 10, "mrv": 16},
+    "shoulders":   {"mev": 6,  "mav": 14, "mrv": 20},
+    "biceps":      {"mev": 4,  "mav": 10, "mrv": 18},
+    "triceps":     {"mev": 4,  "mav": 10, "mrv": 16},
+    "calves":      {"mev": 6,  "mav": 10, "mrv": 16},
+    "abs":         {"mev": 0,  "mav": 8,  "mrv": 16},
+    "traps":       {"mev": 0,  "mav": 8,  "mrv": 16},
+    "forearms":    {"mev": 0,  "mav": 6,  "mrv": 12},
+}
+
+
+@router.get("/volume-landmarks")
+async def get_volume_landmarks(
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    days: int = Query(default=7, description="Look-back window in days"),
+) -> dict:
+    """Weekly sets per muscle group vs MEV/MAV/MRV landmarks."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+
+    # Get completed sets with exercise data
+    result = await db.execute(
+        select(ExerciseSet, Exercise)
+        .join(Exercise, ExerciseSet.exercise_id == Exercise.id)
+        .join(WorkoutSession, ExerciseSet.workout_session_id == WorkoutSession.id)
+        .where(
+            WorkoutSession.user_id == user.id,
+            WorkoutSession.started_at >= cutoff,
+            ExerciseSet.completed_at.isnot(None),
+            ExerciseSet.skipped_at.is_(None),
+        )
+    )
+    rows = result.all()
+
+    # Count sets per muscle group
+    muscle_sets: dict[str, int] = {}
+    for exercise_set, exercise in rows:
+        muscles = exercise.primary_muscles or []
+        for muscle in muscles:
+            m = muscle.lower().strip()
+            muscle_sets[m] = muscle_sets.get(m, 0) + 1
+
+    # Build response with landmarks
+    muscle_data = []
+    # Include all muscles that have landmarks OR have sets logged
+    all_muscles = set(VOLUME_LANDMARKS.keys()) | set(muscle_sets.keys())
+    for muscle in sorted(all_muscles):
+        landmarks = VOLUME_LANDMARKS.get(muscle, {"mev": 4, "mav": 10, "mrv": 16})
+        sets = muscle_sets.get(muscle, 0)
+        status = "below_mev"
+        if sets == 0:
+            status = "none"
+        elif sets >= landmarks["mrv"]:
+            status = "above_mrv"
+        elif sets >= landmarks["mav"]:
+            status = "above_mav"
+        elif sets >= landmarks["mev"]:
+            status = "in_range"
+
+        muscle_data.append({
+            "muscle": muscle,
+            "sets": sets,
+            "mev": landmarks["mev"],
+            "mav": landmarks["mav"],
+            "mrv": landmarks["mrv"],
+            "status": status,
+        })
+
+    # Sort: muscles with sets first, then alphabetical
+    muscle_data.sort(key=lambda x: (-x["sets"], x["muscle"]))
+
+    return {
+        "days": days,
+        "muscles": muscle_data,
+        "total_sets": sum(muscle_sets.values()),
+    }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -833,4 +833,20 @@ export async function getExerciseFeedback(sessionId: number): Promise<any[]> {
   return response.data;
 }
 
+// ── Volume landmarks ────────────────────────────────────────────────────────
+
+export interface VolumeLandmark {
+  muscle: string;
+  sets: number;
+  mev: number;
+  mav: number;
+  mrv: number;
+  status: 'below_mev' | 'in_range' | 'above_mav' | 'above_mrv';
+}
+
+export async function getVolumeLandmarks(days: number = 7): Promise<{ days: number; muscles: VolumeLandmark[]; total_sets: number }> {
+  const response = await api.get(`/progress/volume-landmarks?days=${days}`);
+  return response.data;
+}
+
 export default api;

--- a/frontend/src/routes/volume/+page.svelte
+++ b/frontend/src/routes/volume/+page.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getVolumeLandmarks } from '$lib/api';
+  import type { VolumeLandmark } from '$lib/api';
+
+  let muscles = $state<VolumeLandmark[]>([]);
+  let totalSets = $state(0);
+  let loading = $state(true);
+  let days = $state(7);
+
+  onMount(() => loadData());
+
+  async function loadData() {
+    loading = true;
+    try {
+      const data = await getVolumeLandmarks(days);
+      muscles = data.muscles;
+      totalSets = data.total_sets;
+    } catch (e) {
+      console.error('Failed to load volume data:', e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function statusColor(status: string): string {
+    switch (status) {
+      case 'none': return 'text-zinc-600';
+      case 'below_mev': return 'text-red-400';
+      case 'in_range': return 'text-green-400';
+      case 'above_mav': return 'text-amber-400';
+      case 'above_mrv': return 'text-red-400';
+      default: return 'text-zinc-400';
+    }
+  }
+
+  function statusLabel(status: string): string {
+    switch (status) {
+      case 'none': return 'No sets';
+      case 'below_mev': return 'Below MEV';
+      case 'in_range': return 'Optimal';
+      case 'above_mav': return 'High volume';
+      case 'above_mrv': return 'Over MRV';
+      default: return '';
+    }
+  }
+
+  function barWidth(sets: number, mrv: number): number {
+    return Math.min(100, (sets / Math.max(mrv, 1)) * 100);
+  }
+
+  function barColor(status: string): string {
+    switch (status) {
+      case 'none': return 'bg-zinc-700';
+      case 'below_mev': return 'bg-red-500/60';
+      case 'in_range': return 'bg-green-500/60';
+      case 'above_mav': return 'bg-amber-500/60';
+      case 'above_mrv': return 'bg-red-500/80';
+      default: return 'bg-zinc-600';
+    }
+  }
+</script>
+
+<div class="space-y-5 max-w-lg mx-auto">
+  <div class="flex items-center justify-between">
+    <h2 class="text-2xl font-bold">Volume Landmarks</h2>
+    <span class="text-sm text-zinc-500">{totalSets} total sets</span>
+  </div>
+
+  <p class="text-xs text-zinc-500">
+    Weekly sets per muscle group vs evidence-based volume targets.
+    MEV = minimum effective volume. MRV = maximum recoverable volume.
+  </p>
+
+  <!-- Time range -->
+  <div class="flex gap-2">
+    {#each [[7, '7d'], [14, '14d'], [21, '3wk']] as [val, label]}
+      <button onclick={() => { days = val; loadData(); }}
+              class="px-3 py-1 text-sm rounded-lg {days === val ? 'bg-primary-600 text-white' : 'bg-zinc-800 text-zinc-400'}">
+        {label}
+      </button>
+    {/each}
+  </div>
+
+  {#if loading}
+    <div class="space-y-3">
+      {#each { length: 6 } as _}
+        <div class="animate-pulse bg-zinc-800 rounded-xl h-16"></div>
+      {/each}
+    </div>
+  {:else}
+    <!-- Legend -->
+    <div class="flex flex-wrap gap-3 text-[10px] text-zinc-500">
+      <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-red-500/60"></span> Below MEV</span>
+      <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-green-500/60"></span> MEV–MAV (Optimal)</span>
+      <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-amber-500/60"></span> MAV–MRV (High)</span>
+      <span class="flex items-center gap-1"><span class="w-2 h-2 rounded-full bg-red-500/80"></span> Over MRV</span>
+    </div>
+
+    <div class="space-y-2">
+      {#each muscles as m}
+        <div class="card !py-3 !px-4">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-sm font-medium capitalize">{m.muscle}</span>
+            <div class="flex items-center gap-2">
+              <span class="text-sm font-mono font-bold {statusColor(m.status)}">{m.sets}</span>
+              <span class="text-[10px] {statusColor(m.status)}">{statusLabel(m.status)}</span>
+            </div>
+          </div>
+
+          <!-- Volume bar -->
+          <div class="relative h-3 bg-zinc-800 rounded-full overflow-hidden">
+            <!-- MEV marker -->
+            <div class="absolute top-0 bottom-0 w-px bg-zinc-600" style="left: {(m.mev / m.mrv) * 100}%"></div>
+            <!-- MAV marker -->
+            <div class="absolute top-0 bottom-0 w-px bg-zinc-500" style="left: {(m.mav / m.mrv) * 100}%"></div>
+            <!-- MRV marker (end) -->
+            <div class="absolute top-0 bottom-0 w-px bg-red-500/40 right-0"></div>
+            <!-- Actual bar -->
+            <div class="h-full rounded-full transition-all duration-300 {barColor(m.status)}"
+                 style="width: {barWidth(m.sets, m.mrv)}%"></div>
+          </div>
+
+          <!-- Labels -->
+          <div class="flex justify-between text-[9px] text-zinc-600 mt-0.5">
+            <span>0</span>
+            <span style="position:relative; left: {(m.mev / m.mrv) * 50 - 5}%">MEV {m.mev}</span>
+            <span>MAV {m.mav}</span>
+            <span>MRV {m.mrv}</span>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    {#if muscles.every(m => m.sets === 0)}
+      <div class="card text-center py-8">
+        <p class="text-zinc-500">No completed sets in the last {days} days.</p>
+        <p class="text-zinc-600 text-sm mt-1">Complete a workout to see your volume breakdown.</p>
+      </div>
+    {/if}
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- New `/volume` page showing weekly sets per muscle group
- Bar chart with MEV/MAV/MRV markers per muscle
- Color coded status: Below MEV (red), Optimal (green), High (amber), Over MRV (red)
- Time range selector (7d / 14d / 3wk)
- Evidence-based targets from RP/Israetel research
- Backend endpoint: GET /progress/volume-landmarks?days=7

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)