### PR TITLE
fix: layout 404 crash, quick chart links, page discoverability

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -39,13 +39,13 @@
       const [exercisesData, plansData, latestBW, phase] = await Promise.all([
         getExercises(),
         getPlans(),
-        getLatestBodyWeight(),
-        getActivePhase(),
+        getLatestBodyWeight().catch(() => null),
+        getActivePhase().catch(() => null),
       ]);
       exercises.set(exercisesData);
       workoutPlans.set(plansData);
-      latestBodyWeight.set(latestBW);
-      activeDietPhase.set(phase);
+      if (latestBW) latestBodyWeight.set(latestBW);
+      if (phase) activeDietPhase.set(phase);
     } catch (error) {
       console.error('Failed to load initial data:', error);
     }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -723,7 +723,7 @@
       </a>
     </div>
     <div class="grid grid-cols-2 gap-3">
-      <a href="/progress" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
+      <a href="/body" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
         <p class="text-xs text-zinc-500">Body Weight</p>
         <p class="text-sm font-semibold text-primary-400 mt-0.5">Trend →</p>
       </a>
@@ -731,13 +731,21 @@
         <p class="text-xs text-zinc-500">Est. 1RM</p>
         <p class="text-sm font-semibold text-green-400 mt-0.5">All Lifts →</p>
       </a>
-      <a href="/progress" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
+      <a href="/volume" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
         <p class="text-xs text-zinc-500">Volume</p>
         <p class="text-sm font-semibold text-amber-400 mt-0.5">Weekly →</p>
       </a>
-      <a href="/progress" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
+      <a href="/records" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
         <p class="text-xs text-zinc-500">Records</p>
         <p class="text-sm font-semibold text-purple-400 mt-0.5">PRs →</p>
+      </a>
+      <a href="/compare" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
+        <p class="text-xs text-zinc-500">Compare</p>
+        <p class="text-sm font-semibold text-cyan-400 mt-0.5">Side by Side →</p>
+      </a>
+      <a href="/calculator" class="bg-zinc-800/60 rounded-xl px-3 py-3 hover:bg-zinc-800 transition-colors">
+        <p class="text-xs text-zinc-500">Calculator</p>
+        <p class="text-sm font-semibold text-rose-400 mt-0.5">1RM →</p>
       </a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **#273**: Layout's `Promise.all` no longer crashes when body weight/diet phase returns 404 (new users)
- Quick Charts widget now links to correct pages (body→/body, volume→/volume, records→/records)
- Added Compare and Calculator links to Quick Charts grid (#275)

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)