### PR TITLE
fix: prevent iOS link preview on dashboard long-press

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -882,4 +882,29 @@
   :global(.edit-mode .widget-wrapper:active) {
     cursor: grabbing;
   }
+  /* Prevent iOS link preview on long-press (#282) */
+  :global(.page-content) {
+    -webkit-touch-callout: none;
+  }
+  :global(.edit-mode) {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  :global(.edit-mode a) {
+    -webkit-touch-callout: none;
+    pointer-events: none;
+  }
+  :global(.edit-mode button:not([class*="rounded-full"])) {
+    pointer-events: none;
+  }
+  /* Re-enable the edit controls */
+  :global(.edit-mode .widget-wrapper > button) {
+    pointer-events: auto !important;
+  }
+  :global(.edit-mode [class*="sticky"] button) {
+    pointer-events: auto !important;
+  }
+  :global(.edit-mode [class*="sticky"] a) {
+    pointer-events: auto !important;
+  }
 </style>


### PR DESCRIPTION
## Summary
- Add `-webkit-touch-callout: none` to prevent iOS system link preview on long-press
- In edit mode, disable pointer-events on links/buttons (except edit controls)
- Re-enable pointer events for the − remove buttons, + add button, and Done button

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)