### PR TITLE
fix: dev/main cookie needs Secure flag for .dev domains

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -740,9 +740,9 @@
         <button
           onclick={() => {
             if (document.cookie.includes('gymtracker_branch=dev')) {
-              document.cookie = 'gymtracker_branch=; path=/; max-age=0';
+              document.cookie = 'gymtracker_branch=; path=/; max-age=0; Secure; SameSite=Lax';
             } else {
-              document.cookie = 'gymtracker_branch=dev; path=/; max-age=31536000';
+              document.cookie = 'gymtracker_branch=dev; path=/; max-age=31536000; Secure; SameSite=Lax';
             }
             window.location.reload();
           }}


### PR DESCRIPTION
## Summary
.dev domains are HSTS-preloaded — browsers silently reject cookies without the `Secure` flag. The `gymtracker_branch` cookie was never being set, making the dev/main toggle completely non-functional.

Added `Secure; SameSite=Lax` to all cookie operations.

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)