### PR TITLE
fix: duplicate arrows removed, chart legend overflow fixed

### DIFF
--- a/frontend/src/routes/progress/+page.svelte
+++ b/frontend/src/routes/progress/+page.svelte
@@ -184,7 +184,11 @@
   let chartOptions = $derived({
     responsive: true,
     plugins: {
-      legend: { position: 'top' as const },
+      legend: {
+        position: 'top' as const,
+        display: selectedExercise !== 'all' || exercises.length <= 6,
+        labels: { color: '#d1d5db', boxWidth: 12, padding: 8, font: { size: 11 } },
+      },
       title: {
         display: true,
         text: chartTitle,

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -2048,23 +2048,12 @@
             <!-- Exercise header -->
             <div class="flex items-start justify-between mb-3">
               <div>
-                <div class="flex items-center gap-1">
-                  <h3 class="font-semibold">
-                    {exercise?.display_name ?? `Exercise ${ex.exerciseId}`}
-                    {#if allDone}
-                      <span class="ml-2 text-green-400 text-sm">✓</span>
-                    {/if}
-                  </h3>
-                  <!-- Reorder buttons -->
-                  <div class="flex items-center gap-0.5 ml-1">
-                    <button onclick={() => moveExercise(exIdx, -1)} disabled={exIdx === 0}
-                            class="w-5 h-5 rounded text-[10px] text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 disabled:opacity-20 transition-colors"
-                            title="Move up">▲</button>
-                    <button onclick={() => moveExercise(exIdx, 1)} disabled={exIdx === uiExercises.length - 1}
-                            class="w-5 h-5 rounded text-[10px] text-zinc-500 hover:text-zinc-300 hover:bg-zinc-700 disabled:opacity-20 transition-colors"
-                            title="Move down">▼</button>
-                  </div>
-                </div>
+                <h3 class="font-semibold">
+                  {exercise?.display_name ?? `Exercise ${ex.exerciseId}`}
+                  {#if allDone}
+                    <span class="ml-2 text-green-400 text-sm">✓</span>
+                  {/if}
+                </h3>
                 <div class="flex items-center gap-2 mt-0.5">
                   {#if exercise?.primary_muscles?.length}
                     <p class="text-xs text-zinc-500 capitalize">{muscleLabel(ex.exerciseId)}</p>


### PR DESCRIPTION
## Summary
- Remove duplicate ▲▼ reorder buttons on exercise cards (keep original set)
- Chart legend auto-hides when viewing >6 exercises to prevent overwhelming the graph

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)