### PR TITLE
feat: accessibility — skip link, ARIA labels, larger touch targets

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -183,3 +183,41 @@ html, body {
 }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb { @apply bg-zinc-700 rounded-full; }
+
+/* ── Accessibility: larger touch targets ──────────────────────────────── */
+body.large-targets button,
+body.large-targets a,
+body.large-targets select,
+body.large-targets input,
+body.large-targets [role="button"] {
+  min-height: 48px;
+  min-width: 48px;
+}
+
+body.large-targets .bottom-nav-item {
+  min-height: 56px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+body.large-targets .set-input {
+  min-height: 48px;
+  font-size: 16px;
+}
+
+body.large-targets .card {
+  padding: 1.25rem;
+}
+
+/* ── Screen reader only (visible on focus for skip links) ─────────── */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -55,6 +55,7 @@ export interface AppSettings {
   machineWeights: MachineWeights;
   maxWarmupSets: number;
   showPlateMath: boolean;
+  largerTouchTargets: boolean;
   deload: DeloadSettings;
   progression: ProgressionSettings;
   dashboardWidgets: DashboardWidget[];
@@ -103,6 +104,7 @@ const defaultSettings: AppSettings = {
   },
   maxWarmupSets: 4,
   showPlateMath: true,
+  largerTouchTargets: false,
   deload: {
     sessions: 0,        // 0 = match plan days
     weightPercent: 70,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -63,6 +63,13 @@
     }
   });
 
+  // ── Accessibility: larger touch targets ──────────────────────────────
+  $effect(() => {
+    if (typeof document !== 'undefined') {
+      document.body.classList.toggle('large-targets', $settings.largerTouchTargets);
+    }
+  });
+
   // ── Offline detection + sync ──────────────────────────────────────────
   $effect(() => {
     if (typeof window === 'undefined') return;
@@ -165,6 +172,12 @@
 <!-- ── Full-height shell ──────────────────────────────────────────────── -->
 <div class="min-h-screen flex flex-col bg-zinc-950">
 
+  <!-- Skip to main content (screen reader / keyboard nav) -->
+  <a href="#main-content"
+     class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-primary-600 focus:text-white focus:px-4 focus:py-2 focus:rounded-lg focus:text-sm">
+    Skip to main content
+  </a>
+
   <!-- ── Top header bar ────────────────────────────────────────────────── -->
   <header class="shrink-0 sticky top-0 z-30 bg-zinc-950/90 border-b border-white/5"
           style="padding-top: env(safe-area-inset-top);"
@@ -174,7 +187,7 @@
 
       <div class="flex items-center gap-3">
         <!-- Desktop nav links (hidden on mobile) -->
-        <nav class="hidden md:flex items-center gap-1">
+        <nav aria-label="Main navigation" class="hidden md:flex items-center gap-1">
           {#each staticNavItems as item}
             <a href={item.path}
                class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm transition-colors
@@ -191,13 +204,13 @@
   </header>
 
   <!-- ── Main content ────────────────────────────────────────────────────── -->
-  <main class="flex-1 w-full max-w-2xl mx-auto md:max-w-4xl">
+  <main id="main-content" class="flex-1 w-full max-w-2xl mx-auto md:max-w-4xl">
     {@render children()}
   </main>
 
   <!-- ── Offline banner ──────────────────────────────────────────────── -->
   {#if !$isOnline}
-    <div class="fixed top-0 left-0 right-0 z-50 bg-amber-600 text-white text-center text-xs py-1.5 font-medium">
+    <div role="alert" class="fixed top-0 left-0 right-0 z-50 bg-amber-600 text-white text-center text-xs py-1.5 font-medium">
       📡 Offline — changes will sync when reconnected
       {#if $pendingSyncCount > 0}
         <span class="ml-1 opacity-80">({$pendingSyncCount} pending)</span>
@@ -210,7 +223,7 @@
   {/if}
 
   <!-- ── Bottom nav (mobile only) ──────────────────────────────────────── -->
-  <nav class="bottom-nav md:hidden" class:hidden={keyboardOpen}>
+  <nav aria-label="Mobile navigation" class="bottom-nav md:hidden" class:hidden={keyboardOpen}>
     {#each staticNavItems as item}
       <a href={item.path} class="bottom-nav-item {isActive(item.path) ? 'active' : ''}">
         <span class="text-xl leading-none">{item.icon}</span>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -805,6 +805,20 @@
     {/each}
   </div>
 
+  <!-- ── Accessibility ───────────────────────────────────────────── -->
+  <div class="card space-y-3">
+    <h3 class="text-lg font-semibold">Accessibility</h3>
+    <label class="flex items-center justify-between cursor-pointer">
+      <div>
+        <span class="text-sm font-medium">Larger Touch Targets</span>
+        <p class="text-xs text-zinc-500">Increase button and input sizes for easier tapping</p>
+      </div>
+      <input type="checkbox" class="toggle"
+             checked={$settings.largerTouchTargets}
+             onchange={(e) => $settings = { ...$settings, largerTouchTargets: (e.target as HTMLInputElement).checked }} />
+    </label>
+  </div>
+
   <!-- ── Apple Health ──────────────────────────────────────────────── -->
   {#if healthKitAvailable}
     <div class="card space-y-3">


### PR DESCRIPTION
## Summary
- Skip-to-content link (visible on Tab focus)
- ARIA labels on navigation landmarks
- `role="alert"` on offline status banner
- "Larger Touch Targets" setting: min 48px buttons/inputs (WCAG 2.5.8)
- `.sr-only` CSS utility class

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)