### PR TITLE
feat: Apple Watch companion — rest timer + set logging

### DIFF
--- a/frontend/ios/App/App/WatchBridgePlugin.swift
+++ b/frontend/ios/App/App/WatchBridgePlugin.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Capacitor
+
+/// Capacitor plugin that bridges the WebView ↔ WatchConnectivity
+@objc(WatchBridgePlugin)
+public class WatchBridgePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "WatchBridgePlugin"
+    public let jsName = "WatchBridge"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "sendWorkoutState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "sendWorkoutEnded", returnType: CAPPluginReturnPromise),
+    ]
+
+    override public func load() {
+        // Give WatchSessionManager access to the webView
+        WatchSessionManager.shared.setWebView(bridge?.webView)
+    }
+
+    /// Called from JS when workout state changes
+    @objc func sendWorkoutState(_ call: CAPPluginCall) {
+        guard let stateJSON = call.getString("state") else {
+            call.reject("Missing state parameter")
+            return
+        }
+        WatchSessionManager.shared.sendWorkoutState(stateJSON)
+        call.resolve()
+    }
+
+    /// Called from JS when workout ends
+    @objc func sendWorkoutEnded(_ call: CAPPluginCall) {
+        WatchSessionManager.shared.sendWorkoutEnded()
+        call.resolve()
+    }
+}

--- a/frontend/ios/App/App/WatchSessionManager.swift
+++ b/frontend/ios/App/App/WatchSessionManager.swift
@@ -1,0 +1,93 @@
+import Foundation
+import WatchConnectivity
+import Capacitor
+
+/// Manages WatchConnectivity on the iPhone side.
+/// Receives messages from the Watch (set complete, skip rest)
+/// and forwards workout state updates to the Watch.
+class WatchSessionManager: NSObject, WCSessionDelegate {
+    static let shared = WatchSessionManager()
+
+    private var webView: WKWebView?
+
+    private override init() {
+        super.init()
+        if WCSession.isSupported() {
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+        }
+    }
+
+    /// Set the webView reference so we can inject JS callbacks
+    func setWebView(_ webView: WKWebView?) {
+        self.webView = webView
+    }
+
+    /// Send workout state to the Watch
+    func sendWorkoutState(_ stateJSON: String) {
+        guard WCSession.default.isReachable else {
+            // Use application context for background delivery
+            if let data = stateJSON.data(using: .utf8) {
+                try? WCSession.default.updateApplicationContext(["workoutState": data])
+            }
+            return
+        }
+
+        if let data = stateJSON.data(using: .utf8) {
+            WCSession.default.sendMessage(
+                ["type": "workoutState", "data": data],
+                replyHandler: nil
+            ) { error in
+                print("[Phone] Send to watch failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Notify Watch that workout ended
+    func sendWorkoutEnded() {
+        let message: [String: Any] = ["type": "workoutEnded"]
+        if WCSession.default.isReachable {
+            WCSession.default.sendMessage(message, replyHandler: nil, errorHandler: nil)
+        }
+        try? WCSession.default.updateApplicationContext([:])
+    }
+
+    // MARK: - WCSessionDelegate
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        if let error = error {
+            print("[Phone] WC activation error: \(error.localizedDescription)")
+        }
+    }
+
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidDeactivate(_ session: WCSession) {
+        // Re-activate for switching watches
+        WCSession.default.activate()
+    }
+
+    /// Receive messages from Watch (set complete, skip rest)
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        guard let type = message["type"] as? String else { return }
+
+        DispatchQueue.main.async {
+            switch type {
+            case "setComplete":
+                let exerciseId = message["exerciseId"] as? Int ?? 0
+                let setLocalId = message["setLocalId"] as? String ?? ""
+                let action = message["action"] as? String ?? "complete"
+                // Forward to WebView
+                let js = "window.dispatchEvent(new CustomEvent('watchSetAction', { detail: { exerciseId: \(exerciseId), setLocalId: '\(setLocalId)', action: '\(action)' } }))"
+                self.webView?.evaluateJavaScript(js, completionHandler: nil)
+
+            case "skipRest":
+                let js = "window.dispatchEvent(new CustomEvent('watchSkipRest'))"
+                self.webView?.evaluateJavaScript(js, completionHandler: nil)
+
+            default:
+                break
+            }
+        }
+    }
+}

--- a/frontend/ios/GymTrackerWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/frontend/ios/GymTrackerWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/ios/GymTrackerWatch/Assets.xcassets/Contents.json
+++ b/frontend/ios/GymTrackerWatch/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/frontend/ios/GymTrackerWatch/GymTrackerWatchApp.swift
+++ b/frontend/ios/GymTrackerWatch/GymTrackerWatchApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct GymTrackerWatchApp: App {
+    @StateObject private var connectivityManager = WatchConnectivityManager.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(connectivityManager)
+        }
+    }
+}

--- a/frontend/ios/GymTrackerWatch/Models/WatchConnectivityManager.swift
+++ b/frontend/ios/GymTrackerWatch/Models/WatchConnectivityManager.swift
@@ -1,0 +1,119 @@
+import Foundation
+import WatchConnectivity
+import Combine
+
+/// Manages communication between Watch and iPhone via WatchConnectivity
+class WatchConnectivityManager: NSObject, ObservableObject {
+    static let shared = WatchConnectivityManager()
+
+    @Published var workoutState: WorkoutState?
+    @Published var isReachable = false
+    @Published var isWorkoutActive = false
+
+    private override init() {
+        super.init()
+        if WCSession.isSupported() {
+            let session = WCSession.default
+            session.delegate = self
+            session.activate()
+        }
+    }
+
+    /// Send a set completion to the phone
+    func completeSet(exerciseId: Int, setLocalId: String) {
+        let message: [String: Any] = [
+            "type": "setComplete",
+            "exerciseId": exerciseId,
+            "setLocalId": setLocalId,
+            "action": "complete"
+        ]
+        sendMessage(message)
+    }
+
+    /// Send a skip set to the phone
+    func skipSet(exerciseId: Int, setLocalId: String) {
+        let message: [String: Any] = [
+            "type": "setComplete",
+            "exerciseId": exerciseId,
+            "setLocalId": setLocalId,
+            "action": "skip"
+        ]
+        sendMessage(message)
+    }
+
+    /// Skip the rest timer
+    func skipRest() {
+        let message: [String: Any] = [
+            "type": "skipRest"
+        ]
+        sendMessage(message)
+    }
+
+    private func sendMessage(_ message: [String: Any]) {
+        guard WCSession.default.isReachable else {
+            print("[Watch] Phone not reachable")
+            return
+        }
+        WCSession.default.sendMessage(message, replyHandler: nil) { error in
+            print("[Watch] Send error: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - WCSessionDelegate
+extension WatchConnectivityManager: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async {
+            self.isReachable = session.isReachable
+        }
+        if let error = error {
+            print("[Watch] Activation error: \(error.localizedDescription)")
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async {
+            self.isReachable = session.isReachable
+        }
+    }
+
+    /// Receive workout state updates from the phone
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        guard let type = message["type"] as? String else { return }
+
+        DispatchQueue.main.async {
+            switch type {
+            case "workoutState":
+                if let data = message["data"] as? Data {
+                    if let state = try? JSONDecoder().decode(WorkoutState.self, from: data) {
+                        self.workoutState = state
+                        self.isWorkoutActive = true
+                    }
+                }
+            case "workoutEnded":
+                self.workoutState = nil
+                self.isWorkoutActive = false
+            default:
+                break
+            }
+        }
+    }
+
+    /// Receive application context (latest state when Watch wakes up)
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        guard let data = applicationContext["workoutState"] as? Data else {
+            DispatchQueue.main.async {
+                self.workoutState = nil
+                self.isWorkoutActive = false
+            }
+            return
+        }
+
+        if let state = try? JSONDecoder().decode(WorkoutState.self, from: data) {
+            DispatchQueue.main.async {
+                self.workoutState = state
+                self.isWorkoutActive = true
+            }
+        }
+    }
+}

--- a/frontend/ios/GymTrackerWatch/Models/WorkoutState.swift
+++ b/frontend/ios/GymTrackerWatch/Models/WorkoutState.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Represents the current workout state sent from the phone app
+struct WorkoutState: Codable {
+    let sessionId: Int
+    let workoutName: String
+    let exercises: [WatchExercise]
+    let currentExerciseIndex: Int
+    let currentSetIndex: Int
+    let elapsed: Int // seconds since workout started
+    let restActive: Bool
+    let restSecs: Int
+}
+
+struct WatchExercise: Codable, Identifiable {
+    let id: Int // exercise_id
+    let name: String
+    let sets: [WatchSet]
+}
+
+struct WatchSet: Codable, Identifiable {
+    let id: String // localId
+    let setNumber: Int
+    let weight: Double? // in user's unit (lbs or kg)
+    let reps: Int?
+    let done: Bool
+    let skipped: Bool
+    let unit: String // "lbs" or "kg"
+}
+
+/// Message sent from Watch to Phone when completing a set
+struct SetCompleteMessage: Codable {
+    let exerciseId: Int
+    let setLocalId: String
+    let action: String // "complete" or "skip"
+}
+
+/// Message sent from Watch to Phone to skip rest
+struct RestSkipMessage: Codable {
+    let action: String // "skipRest"
+}

--- a/frontend/ios/GymTrackerWatch/Views/ContentView.swift
+++ b/frontend/ios/GymTrackerWatch/Views/ContentView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var connectivity: WatchConnectivityManager
+
+    var body: some View {
+        if connectivity.isWorkoutActive, let state = connectivity.workoutState {
+            WorkoutView(state: state)
+                .environmentObject(connectivity)
+        } else {
+            IdleView(isReachable: connectivity.isReachable)
+        }
+    }
+}
+
+// MARK: - Idle View (no active workout)
+struct IdleView: View {
+    let isReachable: Bool
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "dumbbell.fill")
+                .font(.system(size: 40))
+                .foregroundColor(.blue)
+
+            Text("GymTracker")
+                .font(.headline)
+
+            if isReachable {
+                Text("Start a workout\non your phone")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+            } else {
+                HStack(spacing: 4) {
+                    Image(systemName: "iphone.slash")
+                        .font(.caption2)
+                    Text("Phone not connected")
+                        .font(.caption2)
+                }
+                .foregroundColor(.orange)
+            }
+        }
+    }
+}

--- a/frontend/ios/GymTrackerWatch/Views/WorkoutView.swift
+++ b/frontend/ios/GymTrackerWatch/Views/WorkoutView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+struct WorkoutView: View {
+    let state: WorkoutState
+    @EnvironmentObject var connectivity: WatchConnectivityManager
+
+    var currentExercise: WatchExercise? {
+        guard state.currentExerciseIndex < state.exercises.count else { return nil }
+        return state.exercises[state.currentExerciseIndex]
+    }
+
+    var currentSet: WatchSet? {
+        guard let ex = currentExercise,
+              state.currentSetIndex < ex.sets.count else { return nil }
+        return ex.sets[state.currentSetIndex]
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 8) {
+                // Workout name + elapsed time
+                HStack {
+                    Text(state.workoutName)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                    Spacer()
+                    Text(formatTime(state.elapsed))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .monospacedDigit()
+                }
+                .padding(.horizontal, 4)
+
+                // Rest timer
+                if state.restActive {
+                    RestTimerView(seconds: state.restSecs) {
+                        connectivity.skipRest()
+                    }
+                } else if let exercise = currentExercise, let set = currentSet {
+                    // Current exercise + set
+                    SetView(
+                        exercise: exercise,
+                        set: set,
+                        onComplete: {
+                            connectivity.completeSet(
+                                exerciseId: exercise.id,
+                                setLocalId: set.id
+                            )
+                        },
+                        onSkip: {
+                            connectivity.skipSet(
+                                exerciseId: exercise.id,
+                                setLocalId: set.id
+                            )
+                        }
+                    )
+                } else {
+                    // All exercises done
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 36))
+                            .foregroundColor(.green)
+                        Text("All sets done!")
+                            .font(.headline)
+                        Text("Finish on phone")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.top, 20)
+                }
+
+                // Exercise list (compact)
+                Divider()
+                    .padding(.vertical, 4)
+
+                ForEach(state.exercises) { exercise in
+                    ExerciseRow(
+                        exercise: exercise,
+                        isCurrent: exercise.id == currentExercise?.id
+                    )
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+
+    func formatTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
+// MARK: - Set View
+struct SetView: View {
+    let exercise: WatchExercise
+    let set: WatchSet
+    let onComplete: () -> Void
+    let onSkip: () -> Void
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Text(exercise.name)
+                .font(.system(.body, weight: .semibold))
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+
+            Text("Set \(set.setNumber) of \(exercise.sets.count)")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+
+            // Weight + Reps
+            HStack(spacing: 16) {
+                VStack {
+                    Text("\(Int(set.weight ?? 0))")
+                        .font(.system(.title2, weight: .bold))
+                    Text(set.unit)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+
+                VStack {
+                    Text("\(set.reps ?? 0)")
+                        .font(.system(.title2, weight: .bold))
+                    Text("reps")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+
+            // Action buttons
+            HStack(spacing: 12) {
+                Button(action: onSkip) {
+                    Image(systemName: "forward.fill")
+                        .font(.title3)
+                }
+                .buttonStyle(.bordered)
+                .tint(.gray)
+
+                Button(action: onComplete) {
+                    Image(systemName: "checkmark")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.green)
+            }
+        }
+    }
+}
+
+// MARK: - Rest Timer View
+struct RestTimerView: View {
+    let seconds: Int
+    let onSkip: () -> Void
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text("REST")
+                .font(.caption)
+                .foregroundColor(.blue)
+                .fontWeight(.semibold)
+
+            Text(formatTime(seconds))
+                .font(.system(size: 44, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundColor(seconds <= 10 ? .orange : .white)
+
+            Button("Skip", action: onSkip)
+                .buttonStyle(.bordered)
+                .tint(.blue)
+                .font(.caption)
+        }
+        .padding(.vertical, 12)
+    }
+
+    func formatTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%d:%02d", m, s)
+    }
+}
+
+// MARK: - Exercise Row (compact list)
+struct ExerciseRow: View {
+    let exercise: WatchExercise
+    let isCurrent: Bool
+
+    var completedSets: Int {
+        exercise.sets.filter { $0.done || $0.skipped }.count
+    }
+
+    var body: some View {
+        HStack {
+            if isCurrent {
+                Circle()
+                    .fill(.blue)
+                    .frame(width: 6, height: 6)
+            }
+
+            Text(exercise.name)
+                .font(.caption2)
+                .foregroundColor(isCurrent ? .white : .secondary)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text("\(completedSets)/\(exercise.sets.count)")
+                .font(.caption2)
+                .foregroundColor(completedSets == exercise.sets.count ? .green : .secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/frontend/src/lib/watchbridge.ts
+++ b/frontend/src/lib/watchbridge.ts
@@ -1,0 +1,91 @@
+/**
+ * Watch Bridge — sends workout state to Apple Watch via Capacitor native plugin.
+ * No-op on web/PWA. Only active when running inside the iOS Capacitor shell.
+ */
+
+import { Capacitor, registerPlugin } from '@capacitor/core';
+
+interface WatchBridgePlugin {
+  sendWorkoutState(options: { state: string }): Promise<void>;
+  sendWorkoutEnded(): Promise<void>;
+}
+
+const WatchBridge = registerPlugin<WatchBridgePlugin>('WatchBridge');
+
+/** Check if we're running in native iOS */
+function isNative(): boolean {
+  return Capacitor.isNativePlatform();
+}
+
+/**
+ * Send current workout state to the Watch.
+ * Call this whenever the workout UI state changes (set completed, rest timer tick, etc.)
+ */
+export async function sendWorkoutStateToWatch(state: {
+  sessionId: number;
+  workoutName: string;
+  exercises: Array<{
+    id: number;
+    name: string;
+    sets: Array<{
+      id: string;
+      setNumber: number;
+      weight: number | null;
+      reps: number | null;
+      done: boolean;
+      skipped: boolean;
+      unit: string;
+    }>;
+  }>;
+  currentExerciseIndex: number;
+  currentSetIndex: number;
+  elapsed: number;
+  restActive: boolean;
+  restSecs: number;
+}): Promise<void> {
+  if (!isNative()) return;
+  try {
+    await WatchBridge.sendWorkoutState({ state: JSON.stringify(state) });
+  } catch (e) {
+    // Silently fail — Watch may not be connected
+  }
+}
+
+/** Notify Watch that workout has ended */
+export async function sendWorkoutEndedToWatch(): Promise<void> {
+  if (!isNative()) return;
+  try {
+    await WatchBridge.sendWorkoutEnded();
+  } catch {
+    // Silently fail
+  }
+}
+
+/**
+ * Listen for Watch actions (set complete, skip rest).
+ * The native plugin dispatches CustomEvents on window.
+ * Returns a cleanup function to remove listeners.
+ */
+export function listenForWatchActions(handlers: {
+  onSetAction?: (exerciseId: number, setLocalId: string, action: 'complete' | 'skip') => void;
+  onSkipRest?: () => void;
+}): () => void {
+  if (!isNative()) return () => {};
+
+  const handleSetAction = (e: Event) => {
+    const detail = (e as CustomEvent).detail;
+    handlers.onSetAction?.(detail.exerciseId, detail.setLocalId, detail.action);
+  };
+
+  const handleSkipRest = () => {
+    handlers.onSkipRest?.();
+  };
+
+  window.addEventListener('watchSetAction', handleSetAction);
+  window.addEventListener('watchSkipRest', handleSkipRest);
+
+  return () => {
+    window.removeEventListener('watchSetAction', handleSetAction);
+    window.removeEventListener('watchSkipRest', handleSkipRest);
+  };
+}


### PR DESCRIPTION
## Summary
- watchOS app with workout tracking UI (exercise name, weight, reps, ✓/skip buttons)
- Rest timer countdown with skip
- WatchConnectivity bridge between phone ↔ Watch
- Capacitor plugin (WatchBridgePlugin) bridges WebView ↔ native
- TypeScript API in watchbridge.ts (no-op on web)

## Setup
After merging, you need to manually add the Watch App target in Xcode:
1. File → New → Target → watchOS → App
2. Name it "GymTrackerWatch"
3. Replace the generated files with the ones in `frontend/ios/GymTrackerWatch/`
4. Add WatchConnectivity framework to both targets

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)