### PR TITLE
feat: progressive overload calculator service + API

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -561,3 +561,98 @@ async def get_volume_landmarks(
         "muscles": muscle_data,
         "total_sets": sum(muscle_sets.values()),
     }
+
+
+# ── Progressive Overload ───────────────────────────────────────────────────
+
+from pydantic import BaseModel as _PydanticBase
+from app.services.overload import calculate_overload, OverloadInput, epley_1rm
+
+
+class OverloadRequest(_PydanticBase):
+    exercise_id: int
+    current_weight: float
+    current_reps: int
+    target_reps: int | None = None
+    weight_unit: str = "lbs"  # "lbs" or "kg"
+
+
+@router.post("/overload")
+async def get_overload_suggestion(
+    body: OverloadRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Calculate progressive overload suggestion for an exercise."""
+
+    # Get exercise info
+    ex_result = await db.execute(
+        select(Exercise).where(Exercise.id == body.exercise_id)
+    )
+    exercise = ex_result.scalar_one_or_none()
+    exercise_type = exercise.category if exercise else "compound"
+
+    # Get recent completed sets for this exercise (last 5 sessions)
+    recent_sets_q = await db.execute(
+        select(ExerciseSet)
+        .join(WorkoutSession, ExerciseSet.workout_session_id == WorkoutSession.id)
+        .where(
+            WorkoutSession.user_id == user.id,
+            WorkoutSession.status == "completed",
+            ExerciseSet.exercise_id == body.exercise_id,
+            ExerciseSet.completed_at.isnot(None),
+        )
+        .order_by(desc(ExerciseSet.completed_at))
+        .limit(20)
+    )
+    recent_sets = recent_sets_q.scalars().all()
+
+    # Conversion
+    kg_to_unit = 2.20462 if body.weight_unit == "lbs" else 1.0
+    unit_to_kg = 1 / kg_to_unit
+    weight_increment = 5.0 if body.weight_unit == "lbs" else 2.5
+
+    # Determine baseline (oldest of recent sets)
+    if recent_sets:
+        oldest = recent_sets[-1]
+        baseline_weight = (oldest.actual_weight_kg or 0) * kg_to_unit
+        baseline_reps = oldest.actual_reps or 0
+    else:
+        baseline_weight = body.current_weight
+        baseline_reps = body.current_reps
+
+    # Calculate rolling e1RM trend
+    e1rms = []
+    for s in recent_sets:
+        w = (s.actual_weight_kg or 0) * kg_to_unit
+        r = s.actual_reps or 0
+        if w > 0 and r > 0:
+            e1rms.append(epley_1rm(w, r))
+
+    rolling_trend = 0.0
+    if len(e1rms) >= 3:
+        # Average change between consecutive sessions
+        changes = [e1rms[i] - e1rms[i + 1] for i in range(min(len(e1rms) - 1, 4))]
+        rolling_trend = sum(changes) / len(changes) if changes else 0
+
+    result = calculate_overload(OverloadInput(
+        current_weight=body.current_weight,
+        current_reps=body.current_reps,
+        baseline_weight=baseline_weight,
+        baseline_reps=baseline_reps,
+        target_reps=body.target_reps,
+        exercise_type=exercise_type,
+        training_level="intermediate",  # TODO: get from user settings
+        rolling_e1rm_trend=rolling_trend,
+        weight_increment=weight_increment,
+    ))
+
+    return {
+        "next_weight": result.next_weight,
+        "next_reps": result.next_reps,
+        "strategy": result.strategy,
+        "confidence": result.confidence,
+        "explanation": result.explanation,
+        "estimated_1rm": round(result.estimated_1rm, 1),
+        "projected_1rm": round(result.projected_1rm, 1),
+    }

--- a/app/services/overload.py
+++ b/app/services/overload.py
@@ -1,0 +1,212 @@
+"""
+Progressive Overload Calculator
+
+Determines next weight and reps for any exercise based on:
+- Current performance (weight × reps)
+- Historical baseline
+- Rolling e1RM trend across recent sessions
+- Exercise type (compound vs isolation)
+- User training level
+
+Uses Epley formula: e1RM = weight × (1 + reps / 30)
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class OverloadInput:
+    """Input for the overload calculator."""
+    current_weight: float       # Current working weight (in user's unit)
+    current_reps: int           # Current reps achieved
+    baseline_weight: float      # Starting weight for this progression cycle
+    baseline_reps: int          # Starting reps for this progression cycle
+    target_reps: Optional[int]  # Preferred rep target (None = auto)
+    exercise_type: str          # "compound" or "isolation"
+    training_level: str         # "beginner", "intermediate", "advanced"
+    rolling_e1rm_trend: float   # Average e1RM change over last 3-5 sessions (positive = gaining)
+    weight_increment: float     # Minimum weight increment (5 lbs or 2.5 kg)
+
+
+@dataclass
+class OverloadResult:
+    """Output from the overload calculator."""
+    next_weight: float
+    next_reps: int
+    strategy: str              # "weight_up", "reps_up", "hold", "deload"
+    confidence: str            # "high", "medium", "low"
+    explanation: str           # Human-readable explanation
+    estimated_1rm: float       # Current estimated 1RM
+    projected_1rm: float       # Projected 1RM with new weight/reps
+
+
+def calculate_overload(inp: OverloadInput) -> OverloadResult:
+    """
+    Calculate the next weight and reps for progressive overload.
+
+    The algorithm:
+    1. Estimate current capacity via Epley 1RM
+    2. Determine if strength gain exceeds noise threshold
+    3. Project weight for target reps (or choose strategy)
+    4. Apply increment caps by exercise type and training level
+    5. Use systemic trend to modulate aggression
+    """
+
+    # 1. Estimate current and baseline 1RM
+    current_e1rm = epley_1rm(inp.current_weight, inp.current_reps)
+    baseline_e1rm = epley_1rm(inp.baseline_weight, inp.baseline_reps)
+    strength_gain = current_e1rm - baseline_e1rm
+
+    # Noise threshold — don't progress on tiny fluctuations
+    noise_threshold = current_e1rm * 0.02  # 2% of current 1RM
+
+    # 2. Determine base increment caps by type and level
+    max_weight_increment = _max_increment(inp.exercise_type, inp.training_level, inp.weight_increment)
+    max_reps_increment = _max_reps_increment(inp.exercise_type)
+
+    # 3. Determine target reps
+    target_reps = inp.target_reps or inp.current_reps
+
+    # 4. Calculate progression
+    if strength_gain < -noise_threshold:
+        # Performance declining — suggest hold or deload
+        if strength_gain < -noise_threshold * 3:
+            return OverloadResult(
+                next_weight=round_to_increment(inp.current_weight * 0.9, inp.weight_increment),
+                next_reps=inp.current_reps,
+                strategy="deload",
+                confidence="high",
+                explanation=f"Performance declining ({strength_gain:.1f} lbs e1RM). Reduce weight 10% and rebuild.",
+                estimated_1rm=current_e1rm,
+                projected_1rm=current_e1rm * 0.9,
+            )
+        return OverloadResult(
+            next_weight=inp.current_weight,
+            next_reps=inp.current_reps,
+            strategy="hold",
+            confidence="medium",
+            explanation="Performance dipped slightly. Repeat this weight/rep combo.",
+            estimated_1rm=current_e1rm,
+            projected_1rm=current_e1rm,
+        )
+
+    if strength_gain < noise_threshold:
+        # Within noise — try adding reps first (rep-first progression)
+        if inp.current_reps < target_reps + max_reps_increment:
+            new_reps = min(inp.current_reps + 1, target_reps + max_reps_increment)
+            new_e1rm = epley_1rm(inp.current_weight, new_reps)
+            return OverloadResult(
+                next_weight=inp.current_weight,
+                next_reps=new_reps,
+                strategy="reps_up",
+                confidence="medium",
+                explanation=f"Add 1 rep ({inp.current_reps} → {new_reps}). Same weight.",
+                estimated_1rm=current_e1rm,
+                projected_1rm=new_e1rm,
+            )
+        # At rep ceiling — hold
+        return OverloadResult(
+            next_weight=inp.current_weight,
+            next_reps=inp.current_reps,
+            strategy="hold",
+            confidence="low",
+            explanation="At rep ceiling. Hold until next session confirms progress.",
+            estimated_1rm=current_e1rm,
+            projected_1rm=current_e1rm,
+        )
+
+    # 5. Meaningful strength gain — progress!
+    # Calculate trend bonus (systemic adaptation signal)
+    trend_bonus = 0.0
+    if inp.rolling_e1rm_trend > 0:
+        trend_bonus = min(inp.rolling_e1rm_trend * 0.1, max_weight_increment * 0.5)
+
+    # Project weight for target reps at new 1RM
+    projected_weight = epley_weight(current_e1rm, target_reps)
+    raw_increment = projected_weight - inp.current_weight
+
+    # Clamp increment
+    weight_increment = min(raw_increment, max_weight_increment + trend_bonus)
+    weight_increment = max(weight_increment, 0)
+
+    if weight_increment >= inp.weight_increment:
+        # Weight increase
+        new_weight = round_to_increment(inp.current_weight + weight_increment, inp.weight_increment)
+        # Reset reps to base when weight goes up
+        new_reps = target_reps if target_reps else max(inp.current_reps - 2, 5)
+        new_e1rm = epley_1rm(new_weight, new_reps)
+
+        confidence = "high" if strength_gain > noise_threshold * 2 else "medium"
+        return OverloadResult(
+            next_weight=new_weight,
+            next_reps=new_reps,
+            strategy="weight_up",
+            confidence=confidence,
+            explanation=f"Increase weight {inp.current_weight:.0f} → {new_weight:.0f} ({weight_increment:.0f} lbs). Target {new_reps} reps.",
+            estimated_1rm=current_e1rm,
+            projected_1rm=new_e1rm,
+        )
+    else:
+        # Increment too small for weight — add reps
+        reps_increment = min(
+            int((projected_weight - inp.current_weight) / inp.current_weight * 30),
+            max_reps_increment
+        )
+        reps_increment = max(reps_increment, 1)
+        new_reps = inp.current_reps + reps_increment
+        new_e1rm = epley_1rm(inp.current_weight, new_reps)
+
+        return OverloadResult(
+            next_weight=inp.current_weight,
+            next_reps=new_reps,
+            strategy="reps_up",
+            confidence="medium",
+            explanation=f"Add {reps_increment} rep(s) ({inp.current_reps} → {new_reps}). Weight stays at {inp.current_weight:.0f}.",
+            estimated_1rm=current_e1rm,
+            projected_1rm=new_e1rm,
+        )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def epley_1rm(weight: float, reps: int) -> float:
+    """Estimate 1RM using Epley formula."""
+    if reps <= 0 or weight <= 0:
+        return 0
+    if reps == 1:
+        return weight
+    return weight * (1 + reps / 30)
+
+
+def epley_weight(one_rm: float, reps: int) -> float:
+    """Calculate weight for given reps at a 1RM."""
+    if reps <= 0 or one_rm <= 0:
+        return 0
+    if reps == 1:
+        return one_rm
+    return one_rm / (1 + reps / 30)
+
+
+def round_to_increment(weight: float, increment: float) -> float:
+    """Round weight to nearest increment (e.g., nearest 5 lbs)."""
+    return round(weight / increment) * increment
+
+
+def _max_increment(exercise_type: str, training_level: str, base_increment: float) -> float:
+    """Max weight increment per session by type and level."""
+    multipliers = {
+        ("compound", "beginner"): 4,      # 20 lbs
+        ("compound", "intermediate"): 2,   # 10 lbs
+        ("compound", "advanced"): 1,       # 5 lbs
+        ("isolation", "beginner"): 2,      # 10 lbs
+        ("isolation", "intermediate"): 1,  # 5 lbs
+        ("isolation", "advanced"): 1,      # 5 lbs
+    }
+    mult = multipliers.get((exercise_type, training_level), 1)
+    return base_increment * mult
+
+
+def _max_reps_increment(exercise_type: str) -> int:
+    """Max reps increment per session."""
+    return 3 if exercise_type == "compound" else 2


### PR DESCRIPTION
## Summary
- New `app/services/overload.py` — the core algorithm
- New `/progress/overload` POST endpoint
- Calculates next weight/reps using Epley e1RM, historical baseline, rolling trend
- Strategies: weight_up, reps_up, hold, deload
- Increment caps by exercise type + training level
- Noise threshold to avoid reacting to random fluctuations

Both web and native iOS apps will call this endpoint.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)