### PR TITLE
fix: progress insights 500 — date vs string comparison

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -398,7 +398,7 @@ async def get_insights(
         four_weeks_ago = today - timedelta(days=28)
         recent_exercise_ids = set()
         for sess in recent_sess_list:
-            if sess.date >= str(four_weeks_ago):
+            if sess.date >= four_weeks_ago:
                 for s in (sess.sets or []):
                     recent_exercise_ids.add(s.exercise_id)
 


### PR DESCRIPTION
Closes #365

One-line fix: `sess.date >= str(four_weeks_ago)` → `sess.date >= four_weeks_ago`

`sess.date` is `datetime.date`; wrapping the other side in `str()` caused a `TypeError` on every request to `GET /api/progress/insights`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)