### PR TITLE
fix: return 422 instead of 500 when plan references missing exercises

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -587,6 +587,12 @@ async def create_session_from_plan(
         exercise_model_map: dict[int, Exercise] = {
             ex.id: ex for ex in ex_rows.scalars().all()
         }
+        missing = [eid for eid in day_exercise_ids if eid not in exercise_model_map]
+        if missing:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Plan references exercises that no longer exist: {missing}. Edit the plan to replace them.",
+            )
     else:
         exercise_model_map = {}
 


### PR DESCRIPTION
Closes #367

Validates all exercise IDs from the plan exist in the `exercises` table before attempting to insert any sets. Returns 422 with the specific missing IDs so the user knows exactly which exercises to replace in their plan.

Previously this fell through to a Postgres FK violation → unhandled 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)