### PR TITLE
fix: route iOS app to dev container via gymtracker_branch cookie

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/APIClient.swift
+++ b/ios/GymTracker/Gym Tracker/Services/APIClient.swift
@@ -13,6 +13,14 @@ final class APIClient: Sendable {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 30
+        // Route to the dev container via nginx cookie
+        let cookie = HTTPCookie(properties: [
+            .domain: "lethal.dev",
+            .path: "/",
+            .name: "gymtracker_branch",
+            .value: "dev",
+        ])!
+        config.httpCookieStorage?.setCookie(cookie)
         session = URLSession(configuration: config)
 
         decoder = JSONDecoder()


### PR DESCRIPTION
Closes #369

Adds `gymtracker_branch=dev` cookie to `URLSessionConfiguration` so nginx routes all iOS API requests to the dev container during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)