### PR TITLE
fix: plans 500 + sessions 500 (stale container notes field)

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -37,7 +37,7 @@ def serialize_plan(plan: WorkoutPlan) -> dict:
     else:
         # New format
         days = planned_data.get("days", [])
-        number_of_days = planned_data.get("number_of_days", len(days))
+        number_of_days = planned_data.get("number_of_days") or len(days)
 
     return {
         "id": plan.id,


### PR DESCRIPTION
## Summary

### 1. Plans `GET /api/plans/` → 500 (code fix)
Plans stored with `"number_of_days": null` in JSON failed response validation since `WorkoutPlanResponse` requires `int`. Changed `planned_data.get("number_of_days", len(days))` to `planned_data.get("number_of_days") or len(days)` so explicit `null` values fall back to `len(days)`.

### 2. Sessions `GET /api/sessions/` → 500 (deployment fix)
`WorkoutSession` model is missing `notes` attribute in the production container. This is because the `feat: persist session notes` commit (`bc2e2b4`) is on `dev` but not `main`. **Redeploying the main container after this PR merges to dev → main will fix it.**

### Impact on exercise_sets being empty
Both 500s were preventing the workout flow from working correctly. Fixing these should allow sets to be saved again.

Closes #374

## Test plan
- [x] 16 plan tests pass locally
- [ ] Backend tests pass in CI
- [ ] Redeploy server after merge to main — verify sessions and plans endpoints return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)