### PR TITLE
feat: community food verification — pending visibility + submission count

### DIFF
--- a/app/api/nutrition.py
+++ b/app/api/nutrition.py
@@ -20,8 +20,8 @@ router = APIRouter()
 
 # ── Serializers ───────────────────────────────────────────────────────────────
 
-def serialize_food_item(item: FoodItem) -> dict:
-    return {
+def serialize_food_item(item: FoodItem, submission_count: int | None = None) -> dict:
+    d = {
         "id": item.id,
         "name": item.name,
         "brand": item.brand,
@@ -37,6 +37,9 @@ def serialize_food_item(item: FoodItem) -> dict:
         "is_custom": item.is_custom,
         "micronutrients": json.loads(item.micronutrients) if item.micronutrients else None,
     }
+    if submission_count is not None:
+        d["submission_count"] = submission_count
+    return d
 
 
 def serialize_entry(entry: NutritionEntry) -> dict:
@@ -101,7 +104,13 @@ async def barcode_lookup(
     )
     local_food = local_result.scalar_one_or_none()
     if local_food:
-        return serialize_food_item(local_food)
+        sc = None
+        if local_food.source == "pending":
+            cr = await db.execute(
+                select(func.count()).select_from(FoodSubmission).where(FoodSubmission.food_item_id == local_food.id)
+            )
+            sc = cr.scalar_one()
+        return serialize_food_item(local_food, submission_count=sc)
 
     # Fall back to external APIs
     result = await lookup_barcode(code)
@@ -119,12 +128,32 @@ async def list_foods(
     q: str = "",
     limit: int = 50,
 ) -> list[dict]:
-    """List saved foods, optionally filtered by name substring."""
-    stmt = select(FoodItem).where(FoodItem.user_id == user.id).order_by(desc(FoodItem.created_at)).limit(limit)
+    """List saved foods — includes custom foods and pending community submissions by this user."""
+    own_ids = select(FoodItem.id).where(FoodItem.user_id == user.id)
+    submitted_ids = select(FoodSubmission.food_item_id).where(FoodSubmission.user_id == user.id)
+    stmt = (
+        select(FoodItem)
+        .where(FoodItem.id.in_(own_ids.union(submitted_ids)))
+        .order_by(desc(FoodItem.created_at))
+        .limit(limit)
+    )
     if q.strip():
         stmt = stmt.where(FoodItem.name.ilike(f"%{q.strip()}%"))
     result = await db.execute(stmt)
-    return [serialize_food_item(f) for f in result.scalars().all()]
+    foods = result.scalars().all()
+
+    # Enrich pending foods with submission counts
+    pending_ids = [f.id for f in foods if f.source == "pending"]
+    counts: dict[int, int] = {}
+    if pending_ids:
+        count_result = await db.execute(
+            select(FoodSubmission.food_item_id, func.count())
+            .where(FoodSubmission.food_item_id.in_(pending_ids))
+            .group_by(FoodSubmission.food_item_id)
+        )
+        counts = dict(count_result.all())
+
+    return [serialize_food_item(f, submission_count=counts.get(f.id)) for f in foods]
 
 
 @router.post("/foods", status_code=status.HTTP_201_CREATED)
@@ -259,7 +288,7 @@ async def create_community_food(
 
     await db.flush()
     await db.refresh(pending)
-    return serialize_food_item(pending)
+    return serialize_food_item(pending, submission_count=submission_count)
 
 
 @router.delete("/foods/{food_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -578,7 +578,7 @@ export const MICRO_META: Record<string, { label: string; unit: string; rda: numb
 export interface FoodSearchResult {
   name: string;
   brand: string | null;
-  source: 'openfoodfacts' | 'usda' | 'custom';
+  source: 'openfoodfacts' | 'usda' | 'custom' | 'pending' | 'community' | 'calorieninjas';
   source_id: string | null;
   barcode: string | null;
   calories_per_100g: number | null;
@@ -593,6 +593,7 @@ export interface FoodSearchResult {
 export interface FoodItem extends FoodSearchResult {
   id: number;
   is_custom: boolean;
+  submission_count?: number;
 }
 
 export interface NutritionEntry {

--- a/frontend/src/routes/nutrition/+page.svelte
+++ b/frontend/src/routes/nutrition/+page.svelte
@@ -576,6 +576,11 @@
       // Select it for logging
       selectedFood = food;
       selectedQty = srv;
+      if (food.source === 'pending') {
+        ocrError = `Saved! ${food.submission_count ?? 1} verification(s) so far.`;
+      } else if (food.source === 'community') {
+        ocrError = 'Added to community library!';
+      }
       ocrResult = null;
     } catch (e) {
       ocrError = 'Failed to save food. Please try again.';
@@ -1371,7 +1376,14 @@
                 <div class="flex items-center gap-1 rounded-lg hover:bg-zinc-800 transition-colors group">
                   <button onclick={() => { selectedFood = food; selectedQty = food.serving_size_g || 100; }}
                           class="flex-1 text-left px-3 py-2.5">
-                    <p class="text-sm text-white truncate">{food.name}</p>
+                    <p class="text-sm text-white truncate">
+                      {food.name}
+                      {#if food.source === 'pending'}
+                        <span class="text-[10px] ml-1 px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400">Pending{#if food.submission_count} ({food.submission_count}){/if}</span>
+                      {:else if food.source === 'community'}
+                        <span class="text-[10px] ml-1 px-1.5 py-0.5 rounded-full bg-green-500/15 text-green-400">Community</span>
+                      {/if}
+                    </p>
                     <p class="text-xs text-zinc-500">
                       {food.brand ?? 'Custom'}
                       {#if food.calories_per_100g != null}

--- a/tests/test_community_food.py
+++ b/tests/test_community_food.py
@@ -1,0 +1,105 @@
+"""Tests for community food verification flow."""
+import contextlib
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+
+
+FOOD_DATA = {
+    "name": "Test Protein Bar",
+    "brand": "TestBrand",
+    "barcode": "1234567890123",
+    "calories_per_100g": 400,
+    "protein_per_100g": 30,
+    "carbs_per_100g": 40,
+    "fat_per_100g": 15,
+    "serving_size_g": 60,
+}
+
+
+@contextlib.contextmanager
+def override_threshold(n: int):
+    import app.api.nutrition as api_mod
+    old = api_mod.COMMUNITY_THRESHOLD
+    api_mod.COMMUNITY_THRESHOLD = n
+    try:
+        yield
+    finally:
+        api_mod.COMMUNITY_THRESHOLD = old
+
+
+async def make_authed_client(username: str) -> AsyncClient:
+    c = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    r = await c.post("/api/auth/register", json={
+        "username": username,
+        "email": f"{username}@test.com",
+        "password": "testpass123",
+    })
+    assert r.status_code == 201
+    c.headers["Authorization"] = f"Bearer {r.json()['access_token']}"
+    return c
+
+
+@pytest.mark.asyncio
+async def test_community_submission_returns_pending(client: AsyncClient):
+    with override_threshold(3):
+        r = await client.post("/api/nutrition/foods/community", json=FOOD_DATA)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["source"] == "pending"
+        assert data["submission_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_pending_food_visible_in_user_library(client: AsyncClient):
+    with override_threshold(3):
+        await client.post("/api/nutrition/foods/community", json=FOOD_DATA)
+        r = await client.get("/api/nutrition/foods")
+        assert r.status_code == 200
+        foods = r.json()
+        names = [f["name"] for f in foods]
+        assert "Test Protein Bar" in names
+        pending = [f for f in foods if f["name"] == "Test Protein Bar"][0]
+        assert pending["source"] == "pending"
+        assert pending["submission_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_multi_user_promotion(client: AsyncClient):
+    with override_threshold(2):
+        r1 = await client.post("/api/nutrition/foods/community", json=FOOD_DATA)
+        assert r1.json()["source"] == "pending"
+
+        client2 = await make_authed_client("user2")
+        try:
+            food2 = {**FOOD_DATA, "calories_per_100g": 420, "protein_per_100g": 32}
+            r2 = await client2.post("/api/nutrition/foods/community", json=food2)
+            assert r2.status_code == 201
+            data = r2.json()
+            assert data["source"] == "community"
+            assert data["calories_per_100g"] == 410.0
+            assert data["protein_per_100g"] == 31.0
+        finally:
+            await client2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_barcode_returns_pending_for_submitter(client: AsyncClient):
+    with override_threshold(3):
+        await client.post("/api/nutrition/foods/community", json=FOOD_DATA)
+        r = await client.get(f"/api/nutrition/barcode/{FOOD_DATA['barcode']}")
+        assert r.status_code == 200
+        assert r.json()["source"] == "pending"
+        assert r.json()["submission_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_promoted_food_still_in_submitter_library(client: AsyncClient):
+    with override_threshold(1):
+        r = await client.post("/api/nutrition/foods/community", json=FOOD_DATA)
+        assert r.json()["source"] == "community"
+
+        r2 = await client.get("/api/nutrition/foods")
+        names = [f["name"] for f in r2.json()]
+        assert "Test Protein Bar" in names


### PR DESCRIPTION
## Summary
- Pending community food submissions now appear in the user's Saved foods tab (via `FoodSubmission` join)
- `submission_count` included in API responses for pending foods
- Frontend shows Pending/Community badges on saved food items
- Toast feedback after community food submission

Closes #351

## Test plan
- [x] 5 new tests pass (`test_community_food.py`)
- [x] Full backend suite passes (93 tests)
- [x] Frontend builds cleanly
- [ ] Backend CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)