### PR TITLE
fix: --watch mode force-recreates dev container after rebuild

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -186,7 +186,10 @@ docker_deploy() {
     git archive origin/dev | tar -x -C "$tmpdir"
     docker build -t fitness-app-dev "$tmpdir"
     rm -rf "$tmpdir"
-    docker compose up -d --no-build dev
+
+    # Stop old container, then recreate with the freshly built image
+    docker compose stop dev
+    docker compose up -d --no-build --force-recreate dev
     docker_health_check_async dev
     return
   elif [ "$target" = "main" ]; then
@@ -214,7 +217,7 @@ docker_deploy() {
     docker build -t fitness-app-dev "$tmpdir"
     rm -rf "$tmpdir"
 
-    docker compose up -d --no-build
+    docker compose up -d --no-build --force-recreate
   fi
 
   docker_health_check_async all


### PR DESCRIPTION
## Summary
The `--watch` mode was rebuilding the dev image but `docker compose up --no-build` wasn't picking up the new image. Added `--force-recreate` and explicit `docker compose stop dev` before recreate.

Fixes both the `dev`-only and `all` deploy paths.

Closes #383

## Test plan
- [ ] SCP updated deploy.sh to server
- [ ] Push a change to dev, verify watch mode detects and redeploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)