### PR TITLE
fix: add back loadDay/loadWater missing from loadAll refactor

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -726,6 +726,15 @@ struct NutritionView: View {
         loading = false
     }
 
+    private func loadDay() async {
+        await loadAll()
+    }
+
+    private func loadWater() async {
+        waterSummary = try? await APIClient.shared.get("/nutrition/water",
+            query: [.init(name: "date", value: dateString)])
+    }
+
     private func loadPhase() async {
         activePhase = try? await APIClient.shared.get("/nutrition/phases/active")
     }
@@ -746,7 +755,7 @@ struct NutritionView: View {
                 queryItems: [.init(name: "from_date", value: fromDate), .init(name: "to_date", value: dateString)]
             )
         } catch { print("[Nutrition] CopyDay: \(error)") }
-        await loadDay()
+        await loadAll()
     }
 
     private func endPhase(_ id: Int) async {


### PR DESCRIPTION
## Summary
- `loadDay()` and `loadWater()` were removed in PR #392's `loadAll()` refactor but are still called from `copyPreviousDay()`, `endPhase()`, and the water card
- Adds them back: `loadDay()` delegates to `loadAll()`, `loadWater()` fetches water independently

## Test plan
- [ ] App compiles without errors
- [ ] Nutrition tab loads, date navigation works, copy-day works

🤖 Generated with [Claude Code](https://claude.com/claude-code)