### PR TITLE
fix: safe NutritionEntry decoder to prevent launch crash

### DIFF
--- a/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
+++ b/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
@@ -188,16 +188,30 @@ struct BodyWeightEntry: Codable, Identifiable {
 
 struct NutritionEntry: Codable, Identifiable {
     let id: Int
-    let food_item_id: Int?
     let name: String
     let date: String?
-    let meal: String?
     let calories: Double?
     let protein: Double?
     let carbs: Double?
     let fat: Double?
     let quantity_g: Double?
-    let micronutrients: [String: Double]?
+    // Decoded separately to avoid crash from unexpected JSON shapes
+    let food_item_id: Int?
+    let meal: String?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(Int.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        date = try c.decodeIfPresent(String.self, forKey: .date)
+        calories = try c.decodeIfPresent(Double.self, forKey: .calories)
+        protein = try c.decodeIfPresent(Double.self, forKey: .protein)
+        carbs = try c.decodeIfPresent(Double.self, forKey: .carbs)
+        fat = try c.decodeIfPresent(Double.self, forKey: .fat)
+        quantity_g = try c.decodeIfPresent(Double.self, forKey: .quantity_g)
+        food_item_id = try? c.decodeIfPresent(Int.self, forKey: .food_item_id)
+        meal = try? c.decodeIfPresent(String.self, forKey: .meal)
+    }
 }
 
 struct MacroTotals: Codable {


### PR DESCRIPTION
## Summary
- Removed `micronutrients: [String: Double]?` from `NutritionEntry` — could crash decoder if server returns non-numeric values
- Added custom `init(from:)` with `try?` for `food_item_id` and `meal` fields so unexpected JSON shapes don't crash the app
- Also please try **Product > Clean Build Folder** (Cmd+Shift+K) before building

## Test plan
- [ ] App launches without crashing
- [ ] Nutrition tab loads entries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)