### PR TITLE
fix: MainActor.run for DashboardView @State mutations

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -712,17 +712,19 @@ struct DashboardView: View {
             let streakResult = calculateStreak(allSessions)
             let weekCountResult = countThisWeek(allSessions)
 
-            // Assign all @State at once on MainActor
-            plans = plansResult
-            recentSessions = completedSessions
-            activeSession = activeSessionResult
-            insights = insResult
-            nextDay = nextDayResult
-            streak = streakResult
-            weekCount = weekCountResult
-            latestBodyWeight = bwResult
-            nutritionSummary = nsResult
-            loading = false
+            // Marshal all @State mutations on MainActor atomically
+            await MainActor.run {
+                plans = plansResult
+                recentSessions = completedSessions
+                activeSession = activeSessionResult
+                insights = insResult
+                nextDay = nextDayResult
+                streak = streakResult
+                weekCount = weekCountResult
+                latestBodyWeight = bwResult
+                nutritionSummary = nsResult
+                loading = false
+            }
         } catch is CancellationError {
             // Task was cancelled (view disappeared or pull-to-refresh restarted) — ignore
             return
@@ -730,9 +732,11 @@ struct DashboardView: View {
             // URLSession cancelled — ignore
             return
         } catch {
-            self.error = error.localizedDescription
+            await MainActor.run {
+                self.error = error.localizedDescription
+                loading = false
+            }
             print("[Dashboard] Load error: \(error)")
-            loading = false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Previous fix (#397) collected results before assigning but didn't ensure MainActor
- After `await`, Swift can resume on ANY thread — @State writes on a background thread cause heap corruption
- Wraps all @State assignments in `await MainActor.run { }` — same pattern ProgressView_ uses successfully

## Test plan
- [ ] App launches without SIGABRT crash
- [ ] Dashboard loads data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)