### PR TITLE
feat: nutrition MFP parity v2 — crash-safe (#387)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
+++ b/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
@@ -195,6 +195,22 @@ struct NutritionEntry: Codable, Identifiable {
     let carbs: Double?
     let fat: Double?
     let quantity_g: Double?
+    let food_item_id: Int?
+    let meal: String?
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(Int.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        date = try c.decodeIfPresent(String.self, forKey: .date)
+        calories = try c.decodeIfPresent(Double.self, forKey: .calories)
+        protein = try c.decodeIfPresent(Double.self, forKey: .protein)
+        carbs = try c.decodeIfPresent(Double.self, forKey: .carbs)
+        fat = try c.decodeIfPresent(Double.self, forKey: .fat)
+        quantity_g = try c.decodeIfPresent(Double.self, forKey: .quantity_g)
+        food_item_id = try? c.decodeIfPresent(Int.self, forKey: .food_item_id)
+        meal = try? c.decodeIfPresent(String.self, forKey: .meal)
+    }
 }
 
 struct MacroTotals: Codable {
@@ -209,6 +225,7 @@ struct MacroGoals: Codable {
     let protein: Double?
     let carbs: Double?
     let fat: Double?
+    let water_goal_ml: Double?
     // API returns extra fields we can ignore
     let id: Int?
     let effective_from: String?
@@ -220,6 +237,7 @@ struct MacroGoals: Codable {
         self.protein = protein
         self.carbs = carbs
         self.fat = fat
+        self.water_goal_ml = nil
         self.id = nil
         self.effective_from = nil
         self.micronutrient_goals = nil
@@ -231,10 +249,24 @@ struct MacroGoals: Codable {
         protein = try c.decodeIfPresent(Double.self, forKey: .protein)
         carbs = try c.decodeIfPresent(Double.self, forKey: .carbs)
         fat = try c.decodeIfPresent(Double.self, forKey: .fat)
+        water_goal_ml = try c.decodeIfPresent(Double.self, forKey: .water_goal_ml)
         id = try c.decodeIfPresent(Int.self, forKey: .id)
         effective_from = try c.decodeIfPresent(String.self, forKey: .effective_from)
         micronutrient_goals = try c.decodeIfPresent([String: Double].self, forKey: .micronutrient_goals)
     }
+}
+
+struct WaterSummary: Codable {
+    let date: String
+    let total_ml: Double
+    let goal_ml: Double
+    let entries: [WaterEntryItem]
+}
+
+struct WaterEntryItem: Codable, Identifiable {
+    let id: Int
+    let amount_ml: Double
+    let logged_at: String
 }
 
 struct DailySummary: Codable {

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -16,6 +16,9 @@ struct NutritionView: View {
     @State private var showQuickAdd = false
     @State private var showRecipes = false
     @State private var showGoalsSheet = false
+    @State private var waterSummary: WaterSummary?
+    @State private var editingEntry: NutritionEntry? = nil
+    @State private var showCopyDayConfirm = false
 
     private let meals = ["breakfast", "lunch", "dinner", "snack"]
 
@@ -45,6 +48,12 @@ struct NutritionView: View {
 
                             // Macro rings
                             macroRings
+
+                            // Net calories banner
+                            netCaloriesBanner
+
+                            // Water tracker
+                            waterCard
 
                             // Micronutrients (when data available)
                             micronutrients
@@ -108,13 +117,13 @@ struct NutritionView: View {
             .navigationTitle("Nutrition")
             .navigationBarTitleDisplayMode(.inline)
             .keyboardDoneButton()
-            .task { await loadDay(); await loadPhase() }
-            .refreshable { await loadDay() }
+            .task { await loadAll(); await loadPhase() }
+            .refreshable { await loadAll() }
             .sheet(isPresented: $showAddFood) {
-                AddFoodView(date: dateString, onSave: { Task { await loadDay() } })
+                AddFoodView(date: dateString, onSave: { Task { await loadAll() } })
             }
             .sheet(isPresented: $showPhaseSheet) {
-                DietPhaseSheet(activePhase: activePhase, onUpdate: { Task { await loadPhase(); await loadDay() } })
+                DietPhaseSheet(activePhase: activePhase, onUpdate: { Task { await loadPhase(); await loadAll() } })
             }
             .sheet(isPresented: $showScanner) {
                 BarcodeScannerView { barcode in
@@ -129,16 +138,25 @@ struct NutritionView: View {
                 }
             }
             .sheet(isPresented: $showAlcoholCalc) {
-                AlcoholCalculatorView(date: dateString, onSave: { Task { await loadDay() } })
+                AlcoholCalculatorView(date: dateString, onSave: { Task { await loadAll() } })
             }
             .sheet(isPresented: $showQuickAdd) {
-                QuickAddView(date: dateString, onSave: { Task { await loadDay() } })
+                QuickAddView(date: dateString, onSave: { Task { await loadAll() } })
             }
             .sheet(isPresented: $showRecipes) {
-                RecipesView(date: dateString, onLog: { Task { await loadDay() } })
+                RecipesView(date: dateString, onLog: { Task { await loadAll() } })
             }
             .sheet(isPresented: $showGoalsSheet) {
-                MacroGoalsSheet(currentGoals: summary?.goals, onSave: { Task { await loadDay() } })
+                MacroGoalsSheet(currentGoals: summary?.goals, onSave: { Task { await loadAll() } })
+            }
+            .sheet(item: $editingEntry) { entry in
+                EditEntrySheet(entry: entry, onSave: { Task { await loadAll() } }, onDelete: {
+                    Task { await deleteEntry(entry.id); await loadAll() }
+                })
+            }
+            .confirmationDialog("Copy yesterday's food log?", isPresented: $showCopyDayConfirm, titleVisibility: .visible) {
+                Button("Copy") { Task { await copyPreviousDay() } }
+                Button("Cancel", role: .cancel) {}
             }
         }
     }
@@ -175,7 +193,7 @@ struct NutritionView: View {
         if let new = Calendar.current.date(byAdding: .day, value: days, to: selectedDate) {
             selectedDate = new
             loading = true
-            Task { await loadDay() }
+            Task { await loadAll() }
         }
     }
 
@@ -470,17 +488,24 @@ struct NutritionView: View {
                         .foregroundStyle(.tertiary)
                     Text("No food logged today")
                         .font(.subheadline.bold())
-                    Text("Tap the + button to log a meal.")
+                    Text("Tap + to log a meal or copy yesterday's log.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Button {
-                        showAddFood = true
-                    } label: {
-                        Label("Log Food", systemImage: "plus.circle.fill")
-                            .font(.subheadline.bold())
+                    HStack(spacing: 12) {
+                        Button { showAddFood = true } label: {
+                            Label("Add Food", systemImage: "plus.circle.fill")
+                                .font(.subheadline.bold())
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+
+                        Button { showCopyDayConfirm = true } label: {
+                            Label("Copy Yesterday", systemImage: "doc.on.doc")
+                                .font(.subheadline)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
                     .padding(.top, 4)
                 }
                 .padding(.vertical, 32)
@@ -549,43 +574,45 @@ struct NutritionView: View {
     }
 
     private func foodRow(_ entry: NutritionEntry) -> some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(entry.name)
-                    .font(.subheadline)
-                    .lineLimit(1)
-                HStack(spacing: 6) {
-                    if let cal = entry.calories {
-                        Text("\(Int(cal)) kcal")
-                            .font(.caption.bold())
-                            .foregroundStyle(.orange)
+        Button { editingEntry = entry } label: {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.name)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                        .foregroundStyle(.primary)
+                    HStack(spacing: 6) {
+                        if let cal = entry.calories {
+                            Text("\(Int(cal)) kcal")
+                                .font(.caption.bold())
+                                .foregroundStyle(.orange)
+                        }
+                        if let p = entry.protein, p > 0 {
+                            Text("·").font(.caption2).foregroundStyle(.tertiary)
+                            Text("P \(Int(p))g").foregroundStyle(.blue)
+                        }
+                        if let c = entry.carbs, c > 0 {
+                            Text("C \(Int(c))g").foregroundStyle(.green)
+                        }
+                        if let f = entry.fat, f > 0 {
+                            Text("F \(Int(f))g").foregroundStyle(.yellow)
+                        }
+                        if let q = entry.quantity_g, q > 0 {
+                            Text("·").font(.caption2).foregroundStyle(.tertiary)
+                            Text("\(Int(q))g").foregroundStyle(.secondary)
+                        }
                     }
-                    if let p = entry.protein, p > 0 {
-                        Text("·")
-                            .font(.caption2).foregroundStyle(.tertiary)
-                        Text("P \(Int(p))g").foregroundStyle(.blue)
-                    }
-                    if let c = entry.carbs, c > 0 {
-                        Text("C \(Int(c))g").foregroundStyle(.green)
-                    }
-                    if let f = entry.fat, f > 0 {
-                        Text("F \(Int(f))g").foregroundStyle(.yellow)
-                    }
+                    .font(.caption2)
                 }
-                .font(.caption2)
-            }
-            Spacer()
-            Button(role: .destructive) {
-                Task { await deleteEntry(entry.id) }
-            } label: {
-                Image(systemName: "minus.circle.fill")
+                Spacer()
+                Image(systemName: "pencil.circle")
                     .font(.body)
-                    .foregroundStyle(.red.opacity(0.4))
+                    .foregroundStyle(.secondary.opacity(0.5))
             }
-            .buttonStyle(.plain)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .buttonStyle(.plain)
     }
 
     // MARK: - Helpers
@@ -606,9 +633,54 @@ struct NutritionView: View {
         }
     }
 
+    // MARK: - Net Calories Banner
+
+    @ViewBuilder
+    private var netCaloriesBanner: some View {
+        if let remaining = summary?.remaining, let goalCal = summary?.goals?.calories, goalCal > 0 {
+            let rem = remaining.calories ?? 0
+            let isOver = rem < 0
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(isOver ? "Over budget" : "Remaining today")
+                        .font(.caption).foregroundStyle(.secondary)
+                    Text("\(abs(Int(rem))) kcal")
+                        .font(.title2.weight(.bold).monospacedDigit())
+                        .foregroundStyle(isOver ? .red : .green)
+                }
+                Spacer()
+                VStack(alignment: .trailing, spacing: 4) {
+                    HStack(spacing: 4) {
+                        Text("Goal").font(.caption2).foregroundStyle(.secondary)
+                        Text("\(Int(goalCal))").font(.caption2.weight(.semibold))
+                    }
+                    HStack(spacing: 4) {
+                        Text("Eaten").font(.caption2).foregroundStyle(.secondary)
+                        Text("\(Int(summary?.totals.calories ?? 0))").font(.caption2.weight(.semibold))
+                    }
+                }
+            }
+            .padding(.horizontal, 16).padding(.vertical, 12)
+            .background(isOver ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .padding(.horizontal)
+        }
+    }
+
+    // MARK: - Water Card
+
+    @ViewBuilder
+    private var waterCard: some View {
+        if let water = waterSummary {
+            WaterTrackerCard(summary: water, date: dateString, onLog: { Task { await loadWater() } })
+                .padding(.horizontal)
+        }
+    }
+
     // MARK: - Data Loading
 
-    private func loadDay() async {
+    private func loadAll() async {
+        // Sequential loading — safe for @State mutations
         do {
             summary = try await APIClient.shared.get("/nutrition/summary",
                 query: [.init(name: "date", value: dateString)])
@@ -618,7 +690,18 @@ struct NutritionView: View {
                 query: [.init(name: "date", value: dateString)])
             mealEntries = response.meals
         } catch { print("[Nutrition] Entries: \(error)") }
+        do {
+            waterSummary = try await APIClient.shared.get("/nutrition/water",
+                query: [.init(name: "date", value: dateString)])
+        } catch { print("[Nutrition] Water: \(error)") }
         loading = false
+    }
+
+    private func loadWater() async {
+        do {
+            waterSummary = try await APIClient.shared.get("/nutrition/water",
+                query: [.init(name: "date", value: dateString)])
+        } catch { print("[Nutrition] Water: \(error)") }
     }
 
     private func loadPhase() async {
@@ -627,7 +710,21 @@ struct NutritionView: View {
 
     private func deleteEntry(_ id: Int) async {
         try? await APIClient.shared.delete("/nutrition/entries/\(id)")
-        await loadDay()
+    }
+
+    private func copyPreviousDay() async {
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: selectedDate) ?? selectedDate
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        let fromDate = df.string(from: yesterday)
+        do {
+            struct CopyResult: Decodable { let copied: Int }
+            let _: CopyResult = try await APIClient.shared.post(
+                "/nutrition/entries/copy-day",
+                queryItems: [.init(name: "from_date", value: fromDate), .init(name: "to_date", value: dateString)]
+            )
+        } catch { print("[Nutrition] CopyDay: \(error)") }
+        await loadAll()
     }
 
     private func endPhase(_ id: Int) async {
@@ -641,7 +738,7 @@ struct NutritionView: View {
             print("[Phase] End status: \(code)")
             if code == 204 || (200...299).contains(code) {
                 activePhase = nil
-                await loadDay()
+                await loadAll()
             } else {
                 print("[Phase] End failed: \(code)")
             }
@@ -650,24 +747,19 @@ struct NutritionView: View {
 
     private func lookupBarcode(_ barcode: String) async {
         do {
-            let results: [FoodSearchResult] = try await APIClient.shared.get("/nutrition/barcode/\(barcode)")
-            if let food = results.first {
-                // Auto-log it
-                let body = NutritionEntryBody(
-                    name: food.name + (food.brand != nil ? " (\(food.brand!))" : ""),
-                    date: dateString,
-                    quantity_g: 100,
-                    calories: food.calories_per_100g ?? 0,
-                    protein: food.protein_per_100g ?? 0,
-                    carbs: food.carbs_per_100g ?? 0,
-                    fat: food.fat_per_100g ?? 0
-                )
-                let _: NutritionEntry = try await APIClient.shared.post("/nutrition/entries", body: body)
-                await loadDay()
-            } else {
-                pendingBarcode = barcode
-                showLabelScanner = true
-            }
+            let food: FoodSearchResult = try await APIClient.shared.get("/nutrition/barcode/\(barcode)")
+            // Auto-log it
+            let body = NutritionEntryBody(
+                name: food.name + (food.brand != nil ? " (\(food.brand!))" : ""),
+                date: dateString,
+                quantity_g: food.serving_size_g ?? 100,
+                calories: (food.calories_per_100g ?? 0) * (food.serving_size_g ?? 100) / 100,
+                protein: (food.protein_per_100g ?? 0) * (food.serving_size_g ?? 100) / 100,
+                carbs: (food.carbs_per_100g ?? 0) * (food.serving_size_g ?? 100) / 100,
+                fat: (food.fat_per_100g ?? 0) * (food.serving_size_g ?? 100) / 100
+            )
+            let _: NutritionEntry = try await APIClient.shared.post("/nutrition/entries", body: body)
+            await loadAll()
         } catch {
             pendingBarcode = barcode
             showLabelScanner = true
@@ -683,8 +775,10 @@ private struct EntriesResponse: Codable {
 }
 
 private struct NutritionEntryBody: Encodable {
+    var food_item_id: Int? = nil
     let name: String
     let date: String
+    var meal: String = "snack"
     let quantity_g: Double
     let calories: Double
     let protein: Double
@@ -701,6 +795,8 @@ struct FoodSearchResult: Codable {
     let protein_per_100g: Double?
     let carbs_per_100g: Double?
     let fat_per_100g: Double?
+    let serving_size_g: Double?
+    let serving_label: String?
 }
 
 // MARK: - Add Food View
@@ -1499,6 +1595,205 @@ struct MacroGoalsSheet: View {
         } catch {
             print("[MacroGoals] Save error: \(error)")
         }
+        saving = false
+    }
+}
+
+// MARK: - Water Tracker Card
+
+struct WaterTrackerCard: View {
+    let summary: WaterSummary
+    let date: String
+    let onLog: () -> Void
+
+    @State private var customAmountText = ""
+    @State private var showCustomInput = false
+
+    private var progress: Double {
+        summary.goal_ml > 0 ? min(summary.total_ml / summary.goal_ml, 1.0) : 0
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Water", systemImage: "drop.fill")
+                    .font(.caption.bold()).foregroundStyle(.blue)
+                Spacer()
+                Text("\(Int(summary.total_ml)) / \(Int(summary.goal_ml)) ml")
+                    .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.blue.opacity(0.1)).frame(height: 8)
+                    Capsule().fill(Color.blue)
+                        .frame(width: geo.size.width * progress, height: 8)
+                        .animation(.easeInOut(duration: 0.4), value: progress)
+                }
+            }
+            .frame(height: 8)
+
+            HStack(spacing: 8) {
+                ForEach([250, 500, 750], id: \.self) { amount in
+                    Button("+\(amount)ml") {
+                        Task { await logWater(Double(amount)) }
+                    }
+                    .font(.caption.weight(.medium))
+                    .padding(.horizontal, 10).padding(.vertical, 5)
+                    .background(Color.blue.opacity(0.12))
+                    .clipShape(Capsule()).foregroundStyle(.blue)
+                }
+                Spacer()
+                if showCustomInput {
+                    HStack(spacing: 4) {
+                        TextField("ml", text: $customAmountText)
+                            .keyboardType(.numberPad)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 60)
+                        Button("Add") {
+                            if let ml = Double(customAmountText), ml > 0 {
+                                Task { await logWater(ml) }
+                                customAmountText = ""
+                                showCustomInput = false
+                            }
+                        }
+                        .font(.caption.weight(.medium))
+                    }
+                } else {
+                    Button { showCustomInput = true } label: {
+                        Image(systemName: "plus.circle").font(.caption).foregroundStyle(.blue)
+                    }
+                }
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func logWater(_ amount: Double) async {
+        struct WaterBody: Encodable { let date: String; let amount_ml: Double }
+        struct WaterResponse: Decodable { let id: Int }
+        do {
+            let _: WaterResponse = try await APIClient.shared.post("/nutrition/water",
+                body: WaterBody(date: date, amount_ml: amount))
+            onLog()
+        } catch { print("[Water] Log error: \(error)") }
+    }
+}
+
+// MARK: - Edit Entry Sheet
+
+struct EditEntrySheet: View {
+    let entry: NutritionEntry
+    let onSave: () -> Void
+    let onDelete: () -> Void
+
+    @State private var quantityText: String
+    @State private var caloriesText: String
+    @State private var proteinText: String
+    @State private var carbsText: String
+    @State private var fatText: String
+    @State private var selectedMeal: String
+    @State private var saving = false
+    @State private var showDeleteConfirm = false
+    @Environment(\.dismiss) private var dismiss
+
+    private let mealOptions = ["breakfast", "lunch", "dinner", "snack"]
+
+    init(entry: NutritionEntry, onSave: @escaping () -> Void, onDelete: @escaping () -> Void) {
+        self.entry = entry
+        self.onSave = onSave
+        self.onDelete = onDelete
+        _quantityText = State(initialValue: entry.quantity_g.map { "\(Int($0))" } ?? "100")
+        _caloriesText = State(initialValue: entry.calories.map { "\(Int($0))" } ?? "0")
+        _proteinText = State(initialValue: entry.protein.map { "\(Int($0))" } ?? "0")
+        _carbsText = State(initialValue: entry.carbs.map { "\(Int($0))" } ?? "0")
+        _fatText = State(initialValue: entry.fat.map { "\(Int($0))" } ?? "0")
+        _selectedMeal = State(initialValue: entry.meal ?? "snack")
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        Text("Quantity (g)")
+                        Spacer()
+                        TextField("100", text: $quantityText)
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing).frame(width: 80)
+                    }
+                    Picker("Meal", selection: $selectedMeal) {
+                        ForEach(mealOptions, id: \.self) { Text($0.capitalized).tag($0) }
+                    }
+                } header: { Text(entry.name).textCase(nil) }
+
+                Section("Macros") {
+                    macroRow("Calories", text: $caloriesText, unit: "kcal")
+                    macroRow("Protein", text: $proteinText, unit: "g")
+                    macroRow("Carbs", text: $carbsText, unit: "g")
+                    macroRow("Fat", text: $fatText, unit: "g")
+                }
+
+                Section {
+                    Button(role: .destructive) { showDeleteConfirm = true } label: {
+                        HStack { Spacer(); Text("Delete Entry"); Spacer() }
+                    }
+                }
+            }
+            .navigationTitle("Edit Entry")
+            .navigationBarTitleDisplayMode(.inline)
+            .keyboardDoneButton()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { Task { await save() } }
+                        .disabled(saving).fontWeight(.semibold)
+                }
+            }
+            .confirmationDialog("Delete this entry?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+                Button("Delete", role: .destructive) { dismiss(); onDelete() }
+                Button("Cancel", role: .cancel) {}
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func macroRow(_ label: String, text: Binding<String>, unit: String) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            TextField("0", text: text)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing).frame(width: 70)
+            Text(unit).foregroundStyle(.secondary).font(.caption)
+        }
+    }
+
+    private func save() async {
+        saving = true
+        struct UpdateBody: Encodable {
+            let quantity_g: Double?
+            let calories: Double?
+            let protein: Double?
+            let carbs: Double?
+            let fat: Double?
+            let meal: String?
+        }
+        let body = UpdateBody(
+            quantity_g: Double(quantityText),
+            calories: Double(caloriesText),
+            protein: Double(proteinText),
+            carbs: Double(carbsText),
+            fat: Double(fatText),
+            meal: selectedMeal
+        )
+        do {
+            let _: NutritionEntry = try await APIClient.shared.patch("/nutrition/entries/\(entry.id)", body: body)
+            onSave()
+            dismiss()
+        } catch { print("[EditEntry] Save error: \(error)") }
         saving = false
     }
 }


### PR DESCRIPTION
## Summary
Re-implements MFP parity features from #391 using crash-safe patterns:
- **Sequential data loading only** — no `async let` or `withTaskGroup` for @State mutations
- **Edit entries**: tap any logged food to change quantity, macros, or meal
- **Net calories banner**: remaining kcal displayed (green/red)
- **Water tracker card**: quick-add buttons (+250/500/750ml), progress bar
- **Copy yesterday**: button on empty-day state
- **Serving size awareness**: barcode scan uses food's serving_size_g
- Model additions: `food_item_id`, `meal` on NutritionEntry; `water_goal_ml` on MacroGoals; WaterSummary types

## Test plan
- [ ] 99 backend tests pass
- [ ] Lint passes
- [ ] App launches without crash
- [ ] Nutrition tab loads, date navigation works
- [ ] Tap entry → edit sheet opens
- [ ] Water card quick-add buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)