### PR TITLE
feat: serving size picker + friendly error messages (#409, #410)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/APIClient.swift
+++ b/ios/GymTracker/Gym Tracker/Services/APIClient.swift
@@ -171,9 +171,60 @@ enum APIError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .unauthorized: return "Session expired. Please log in again."
-        case .httpError(let code, let body): return "Server error (\(code)): \(body ?? "Unknown")"
-        case .decodingError(let error): return "Data error: \(error.localizedDescription)"
+        case .unauthorized:
+            return "Session expired. Please log in again."
+        case .httpError(let code, let body):
+            return Self.friendlyMessage(code: code, body: body)
+        case .decodingError:
+            return "Something went wrong loading data. Please try again."
+        }
+    }
+
+    /// Parse FastAPI/Pydantic validation errors into human-readable messages
+    private static func friendlyMessage(code: Int, body: String?) -> String {
+        guard let body, let data = body.data(using: .utf8) else {
+            return friendlyStatus(code)
+        }
+
+        // Try parsing Pydantic validation error: {"detail": [{"msg": "...", "loc": [...]}]}
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            // Array of validation errors
+            if let details = json["detail"] as? [[String: Any]] {
+                let messages = details.compactMap { detail -> String? in
+                    guard let msg = detail["msg"] as? String else { return nil }
+                    // Clean up Pydantic messages
+                    let clean = msg
+                        .replacingOccurrences(of: "Input should be ", with: "Must be ")
+                        .replacingOccurrences(of: "Value error, ", with: "")
+                    // Get field name from loc array
+                    if let loc = detail["loc"] as? [Any], let field = loc.last as? String {
+                        let label = field.replacingOccurrences(of: "_", with: " ").capitalized
+                        return "\(label): \(clean)"
+                    }
+                    return clean
+                }
+                if !messages.isEmpty { return messages.joined(separator: "\n") }
+            }
+            // Simple detail string: {"detail": "Not found"}
+            if let detail = json["detail"] as? String {
+                return detail
+            }
+        }
+
+        return friendlyStatus(code)
+    }
+
+    private static func friendlyStatus(_ code: Int) -> String {
+        switch code {
+        case 400: return "Invalid request. Please check your input."
+        case 401: return "Session expired. Please log in again."
+        case 403: return "You don't have permission for this action."
+        case 404: return "Not found."
+        case 409: return "This item already exists."
+        case 422: return "Please check your input and try again."
+        case 429: return "Too many requests. Please wait a moment."
+        case 500...599: return "Server error. Please try again later."
+        default: return "Something went wrong. Please try again."
         }
     }
 }

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/DietPhaseSheet.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/DietPhaseSheet.swift
@@ -254,9 +254,6 @@ struct DietPhaseSheet: View {
             )
             onUpdate()
             dismiss()
-        } catch let APIError.httpError(code, body) {
-            errorMessage = body ?? "Server error (\(code))"
-            print("[Phase] Create error: \(code) \(body ?? "")")
         } catch {
             errorMessage = error.localizedDescription
             print("[Phase] Create error: \(error)")

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -728,6 +728,11 @@ struct FoodSearchResult: Codable {
     let serving_label: String?
 }
 
+struct IdentifiedFood: Identifiable {
+    let id = UUID()
+    let food: FoodSearchResult
+}
+
 // MARK: - Water Tracker Card
 
 struct WaterTrackerCard: View {
@@ -855,6 +860,149 @@ struct EditEntrySheet: View {
     }
 }
 
+// MARK: - Serving Size Sheet
+
+struct ServingSizeSheet: View {
+    let food: FoodSearchResult
+    let date: String
+    let onSave: () -> Void
+
+    @State private var servings: Double = 1.0
+    @State private var customGrams: String = ""
+    @State private var useServings = true
+    @State private var saving = false
+    @Environment(\.dismiss) private var dismiss
+
+    private var servingG: Double { food.serving_size_g ?? 100 }
+    private var quantity: Double { useServings ? servings * servingG : (Double(customGrams) ?? servingG) }
+    private var scale: Double { quantity / 100 }
+    private var cal: Double { (food.calories_per_100g ?? 0) * scale }
+    private var pro: Double { (food.protein_per_100g ?? 0) * scale }
+    private var carb: Double { (food.carbs_per_100g ?? 0) * scale }
+    private var fat: Double { (food.fat_per_100g ?? 0) * scale }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                // Food info
+                VStack(spacing: 4) {
+                    Text(food.name).font(.headline)
+                    if let brand = food.brand, !brand.isEmpty {
+                        Text(brand).font(.subheadline).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.top, 8)
+
+                // Serving toggle
+                Picker("Mode", selection: $useServings) {
+                    Text("Servings").tag(true)
+                    Text("Grams").tag(false)
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+
+                if useServings {
+                    VStack(spacing: 8) {
+                        Text(food.serving_label ?? "\(Int(servingG))g serving")
+                            .font(.caption).foregroundStyle(.secondary)
+                        HStack(spacing: 20) {
+                            Button { if servings > 0.25 { servings -= 0.25 } } label: {
+                                Image(systemName: "minus.circle.fill").font(.title2).foregroundStyle(.secondary)
+                            }
+                            Text(String(format: servings == floor(servings) ? "%.0f" : "%.2g", servings))
+                                .font(.system(size: 40, weight: .bold, design: .rounded))
+                                .monospacedDigit()
+                                .frame(minWidth: 60)
+                            Button { servings += 0.25 } label: {
+                                Image(systemName: "plus.circle.fill").font(.title2).foregroundStyle(.blue)
+                            }
+                        }
+                        Text(String(format: "%.0fg total", quantity))
+                            .font(.caption).foregroundStyle(.tertiary)
+                    }
+                } else {
+                    HStack {
+                        TextField("\(Int(servingG))", text: $customGrams)
+                            .font(.system(size: 36, weight: .bold, design: .rounded))
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.center)
+                            .frame(width: 120)
+                        Text("g").font(.title3).foregroundStyle(.secondary)
+                    }
+                }
+
+                // Macro preview
+                HStack(spacing: 0) {
+                    macroPreview("Cal", cal, .orange)
+                    macroPreview("P", pro, .blue)
+                    macroPreview("C", carb, .green)
+                    macroPreview("F", fat, .yellow)
+                }
+                .padding(.horizontal)
+
+                Spacer()
+
+                // Log button
+                Button {
+                    Task { await logFood() }
+                } label: {
+                    if saving {
+                        ProgressView().frame(maxWidth: .infinity)
+                    } else {
+                        Text("Add \(Int(cal)) kcal")
+                            .font(.headline)
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .disabled(saving || quantity <= 0)
+                .padding(.horizontal)
+                .padding(.bottom)
+            }
+            .navigationTitle("Log Food")
+            .navigationBarTitleDisplayMode(.inline)
+            .keyboardDoneButton()
+            .dismissKeyboardOnTap()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+            }
+        }
+        .presentationDetents([.medium])
+        .onAppear {
+            customGrams = "\(Int(servingG))"
+        }
+    }
+
+    private func macroPreview(_ label: String, _ value: Double, _ color: Color) -> some View {
+        VStack(spacing: 2) {
+            Text("\(Int(value))").font(.title3.weight(.bold).monospacedDigit()).foregroundStyle(color)
+            Text(label).font(.caption2).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func logFood() async {
+        saving = true
+        let body = NutritionEntryBody(
+            food_item_id: food.id,
+            name: food.name + (food.brand != nil ? " (\(food.brand!))" : ""),
+            date: date,
+            quantity_g: quantity,
+            calories: cal,
+            protein: pro,
+            carbs: carb,
+            fat: fat
+        )
+        do {
+            let _: NutritionEntry = try await APIClient.shared.post("/nutrition/entries", body: body)
+            onSave()
+            dismiss()
+        } catch { print("[ServingSize] Log error: \(error)") }
+        saving = false
+    }
+}
+
 // MARK: - Add Food View
 
 struct AddFoodView: View {
@@ -874,6 +1022,7 @@ struct AddFoodView: View {
     @State private var searchTask: Task<Void, Never>? = nil
     @State private var recentEntries: [NutritionEntry] = []
     @State private var loadingRecent = false
+    @State private var selectedFoodWrapper: IdentifiedFood? = nil
 
     // Saved/custom foods
     @State private var savedFoods: [FoodSearchResult] = []
@@ -957,6 +1106,12 @@ struct AddFoodView: View {
                     manualCarbs = scanned.carbs > 0 ? "\(Int(scanned.carbs))" : ""
                     manualFat = scanned.fat > 0 ? "\(Int(scanned.fat))" : ""
                     activeTab = .manual
+                }
+            }
+            .sheet(item: $selectedFoodWrapper) { wrapper in
+                ServingSizeSheet(food: wrapper.food, date: date) {
+                    onSave()
+                    dismiss()
                 }
             }
         }
@@ -1099,7 +1254,7 @@ struct AddFoodView: View {
             } else {
                 List {
                     ForEach(savedFoods, id: \.name) { food in
-                        Button { Task { await logFood(food) } } label: {
+                        Button { selectedFoodWrapper = IdentifiedFood(food: food) } label: {
                             foodRow(food)
                         }
                         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
@@ -1120,7 +1275,7 @@ struct AddFoodView: View {
 
     private func foodList(_ foods: [FoodSearchResult]) -> some View {
         List(foods, id: \.name) { food in
-            Button { Task { await logFood(food) } } label: {
+            Button { selectedFoodWrapper = IdentifiedFood(food: food) } label: {
                 foodRow(food)
             }
         }
@@ -1138,9 +1293,15 @@ struct AddFoodView: View {
                 }
             }
             Spacer()
-            Text("\(Int(food.calories_per_100g ?? 0)) cal/100g")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(Int(food.calories_per_100g ?? 0)) kcal")
+                    .font(.caption.weight(.semibold)).foregroundStyle(.orange)
+                if let label = food.serving_label {
+                    Text(label).font(.caption2).foregroundStyle(.tertiary)
+                } else {
+                    Text("per 100g").font(.caption2).foregroundStyle(.tertiary)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

**#409 — Serving Size Picker:**
- Tapping a search/saved food opens a serving size sheet instead of auto-logging at 100g
- Shows the food's natural serving (e.g., "1 can 250ml") as default quantity
- Toggle between Servings mode (stepper, 0.25 increments) and Grams mode
- Live macro preview updates as you adjust quantity
- "Add X kcal" button shows calculated calories

**#410 — Friendly Error Messages:**
- Parses Pydantic 422 validation errors → "Body Fat Pct: Must be less than or equal to 60"
- No more raw JSON shown to users
- HTTP status codes mapped to friendly messages
- Applied globally via APIClient — all views benefit automatically

## Test plan
- [ ] Search → tap food → serving picker opens with correct serving size
- [ ] Adjust servings → macros update live
- [ ] Switch to grams mode → enter custom amount
- [ ] Enter body fat 356% in diet phase → shows clean error message
- [ ] All other API errors show human-readable text

🤖 Generated with [Claude Code](https://claude.com/claude-code)