### PR TITLE
fix: weight input auto-inserts decimal point (#421)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Workout/ActiveWorkoutView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Workout/ActiveWorkoutView.swift
@@ -596,7 +596,7 @@ struct ActiveWorkoutView: View {
                     focusedExercise = exercise
                     focusedWeight = newVal
                 }
-            ), format: .number.precision(.fractionLength(1)))
+            ), format: .number)
             .keyboardType(.decimalPad)
             .textFieldStyle(.roundedBorder)
             .frame(maxWidth: .infinity)
@@ -701,7 +701,7 @@ struct ActiveWorkoutView: View {
                             focusedExercise = exercise
                             focusedWeight = newVal
                         }
-                    ), format: .number.precision(.fractionLength(1)))
+                    ), format: .number)
                     .keyboardType(.decimalPad)
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
Weight TextField used `format: .number.precision(.fractionLength(1))` which forced 1 decimal place — typing "135" displayed as "1.35". Removed `.precision(.fractionLength(1))`, now uses plain `.number`.

Fixed in both standard and unilateral weight fields.

## Test plan
- [ ] Enter 135 in weight field → displays "135" not "1.35"
- [ ] Decimal input still works (2.5 for small plates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)