### PR TITLE
fix: crash safety — force unwraps, force casts, raw URLSession, data races (#423-426)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/APIClient.swift
+++ b/ios/GymTracker/Gym Tracker/Services/APIClient.swift
@@ -36,10 +36,15 @@ final class APIClient: Sendable {
         body: (any Encodable)? = nil,
         queryItems: [URLQueryItem]? = nil
     ) async throws -> T {
-        var components = URLComponents(string: "\(baseURL)\(path)")!
+        guard var components = URLComponents(string: "\(baseURL)\(path)") else {
+            throw APIError.httpError(0, "Invalid URL: \(path)")
+        }
         if let queryItems { components.queryItems = queryItems }
+        guard let url = components.url else {
+            throw APIError.httpError(0, "Invalid URL components")
+        }
 
-        var request = URLRequest(url: components.url!)
+        var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -54,7 +59,9 @@ final class APIClient: Sendable {
         }
 
         let (data, response) = try await session.data(for: request)
-        let httpResponse = response as! HTTPURLResponse
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.httpError(0, "Invalid response")
+        }
 
         // Handle 401 — try refresh
         if httpResponse.statusCode == 401 {
@@ -65,7 +72,9 @@ final class APIClient: Sendable {
                     request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
                 }
                 let (retryData, retryResponse) = try await session.data(for: request)
-                let retryHTTP = retryResponse as! HTTPURLResponse
+                guard let retryHTTP = retryResponse as? HTTPURLResponse else {
+                    throw APIError.httpError(0, "Invalid response")
+                }
                 guard (200...299).contains(retryHTTP.statusCode) else {
                     throw APIError.httpError(retryHTTP.statusCode, String(data: retryData, encoding: .utf8))
                 }
@@ -89,10 +98,15 @@ final class APIClient: Sendable {
         body: (any Encodable)? = nil,
         queryItems: [URLQueryItem]? = nil
     ) async throws {
-        var components = URLComponents(string: "\(baseURL)\(path)")!
+        guard var components = URLComponents(string: "\(baseURL)\(path)") else {
+            throw APIError.httpError(0, "Invalid URL: \(path)")
+        }
         if let queryItems { components.queryItems = queryItems }
+        guard let url = components.url else {
+            throw APIError.httpError(0, "Invalid URL components")
+        }
 
-        var request = URLRequest(url: components.url!)
+        var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -106,7 +120,9 @@ final class APIClient: Sendable {
         }
 
         let (data, response) = try await session.data(for: request)
-        let httpResponse = response as! HTTPURLResponse
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.httpError(0, "Invalid response")
+        }
 
         // Handle 401 — try refresh
         if httpResponse.statusCode == 401 {
@@ -115,7 +131,9 @@ final class APIClient: Sendable {
                     request.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
                 }
                 let (_, retryResponse) = try await session.data(for: request)
-                let retryHttp = retryResponse as! HTTPURLResponse
+                guard let retryHttp = retryResponse as? HTTPURLResponse else {
+                    throw APIError.httpError(0, "Invalid response")
+                }
                 guard (200...299).contains(retryHttp.statusCode) else {
                     throw APIError.httpError(retryHttp.statusCode, nil)
                 }

--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -3,7 +3,8 @@ import HealthKit
 
 /// Centralized HealthKit manager for reading/writing health data.
 /// Handles body weight sync, workout logging, and authorization.
-final class HealthKitManager: @unchecked Sendable {
+@MainActor
+final class HealthKitManager {
     static let shared = HealthKitManager()
 
     private let store = HKHealthStore()

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -695,16 +695,9 @@ struct NutritionView: View {
 
     private func endPhase(_ id: Int) async {
         do {
-            guard let token = await AuthService.shared.accessToken else { return }
-            var req = URLRequest(url: URL(string: "https://lethal.dev/api/nutrition/phases/active")!)
-            req.httpMethod = "DELETE"
-            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            let (_, resp) = try await URLSession.shared.data(for: req)
-            let code = (resp as! HTTPURLResponse).statusCode
-            if code == 204 || (200...299).contains(code) {
-                activePhase = nil
-                await loadAll()
-            }
+            try await APIClient.shared.delete("/nutrition/phases/active")
+            activePhase = nil
+            await loadAll()
         } catch { print("[Phase] End error: \(error)") }
     }
 
@@ -714,7 +707,7 @@ struct NutritionView: View {
             let qty = food.serving_size_g ?? 100
             let scale = qty / 100
             let body = NutritionEntryBody(
-                name: food.name + (food.brand != nil ? " (\(food.brand!))" : ""),
+                name: food.name + (food.brand.map { " (\($0))" } ?? ""),
                 date: dateString,
                 quantity_g: qty,
                 calories: (food.calories_per_100g ?? 0) * scale,
@@ -1093,7 +1086,7 @@ struct ServingSizeSheet: View {
         saving = true
         let body = NutritionEntryBody(
             food_item_id: food.id,
-            name: food.name + (food.brand != nil ? " (\(food.brand!))" : ""),
+            name: food.name + (food.brand.map { " (\($0))" } ?? ""),
             date: date,
             quantity_g: quantity,
             calories: cal,
@@ -1500,7 +1493,7 @@ struct AddFoodView: View {
         let qty = Double(manualQty) ?? 100
         let scale = qty / 100
         let body = NutritionEntryBody(
-            name: food.name + (food.brand != nil ? " (\(food.brand!))" : ""),
+            name: food.name + (food.brand.map { " (\($0))" } ?? ""),
             date: date,
             quantity_g: qty,
             calories: (food.calories_per_100g ?? 0) * scale,

--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -87,6 +87,7 @@ struct SettingsJSON: Codable {
     }
 }
 
+@MainActor
 enum SettingsSync {
     private static var saveTask: Task<Void, Never>?
 


### PR DESCRIPTION
## Summary
Fixes 4 crash-risk issues found in audit:

- **#423**: Replace all force unwraps (`!`) with `guard let` in APIClient and NutritionView
- **#424**: HealthKitManager `@unchecked Sendable` → `@MainActor` (fixes data race on `isAuthorized`)
- **#425**: `endPhase()` raw URLSession call → `APIClient.shared.delete()` (was bypassing auth, error handling, dev cookie)
- **#426**: Force casts `as! HTTPURLResponse` → `guard let as?` in APIClient
- Also fixes SettingsSync `saveTask` concurrency warning with `@MainActor`

## Test plan
- [ ] App builds without warnings
- [ ] Settings sync still works
- [ ] End diet phase works
- [ ] API errors show friendly messages (not crashes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)