### PR TITLE
fix: HealthKitManager compile error, silent try?, add Logger (#424 #427 #429)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Models/UIModels.swift
+++ b/ios/GymTracker/Gym Tracker/Models/UIModels.swift
@@ -1,6 +1,11 @@
 import Foundation
 import SwiftUI
 import UIKit
+import os
+
+// MARK: - App Logger
+
+let appLog = Logger(subsystem: "dev.lethal.gymtracker", category: "app")
 
 // MARK: - UI State Models for Workout
 

--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -3,13 +3,14 @@ import HealthKit
 
 /// Centralized HealthKit manager for reading/writing health data.
 /// Handles body weight sync, workout logging, and authorization.
-@MainActor
-final class HealthKitManager {
+final class HealthKitManager: @unchecked Sendable {
     static let shared = HealthKitManager()
 
     private let store = HKHealthStore()
 
-    var isAuthorized = false
+    // Protected by MainActor access pattern — only mutated from async functions
+    // called from .task modifiers which run on MainActor
+    private(set) var isAuthorized = false
 
     // MARK: - Types we read/write
 

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -659,7 +659,9 @@ struct NutritionView: View {
     }
 
     private func deleteEntry(_ id: Int) async {
-        try? await APIClient.shared.delete("/nutrition/entries/\(id)")
+        do {
+            try await APIClient.shared.delete("/nutrition/entries/\(id)")
+        } catch { print("[Nutrition] Delete error: \(error)") }
     }
 
     private func duplicateEntry(_ entry: NutritionEntry) async {
@@ -821,7 +823,9 @@ struct WaterTrackerCard: View {
     private func log(_ ml: Double) async {
         struct B: Encodable { let date: String; let amount_ml: Double }
         struct R: Decodable { let id: Int }
-        let _: R? = try? await APIClient.shared.post("/nutrition/water", body: B(date: date, amount_ml: ml))
+        do {
+            let _: R = try await APIClient.shared.post("/nutrition/water", body: B(date: date, amount_ml: ml))
+        } catch { print("[Water] Log error: \(error)") }
         onLog()
     }
 }


### PR DESCRIPTION
## Summary
- **#424**: Revert HealthKitManager from `@MainActor` to `@unchecked Sendable` — `@MainActor` broke SettingsView calls. Added `private(set)` on `isAuthorized` for safety.
- **#427**: Replace silent `try?` with `do/catch` in `deleteEntry()` and water logging
- **#429**: Add shared `os.Logger` (`appLog`) for structured production logging

## Test plan
- [ ] App builds without errors
- [ ] HealthKit import works from Settings
- [ ] Delete food entry logs errors if they fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)