### PR TITLE
fix: SettingsView type-check compiler error

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -305,17 +305,21 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             List {
-                profileSection
-                unitsSection
-                bodyWeightSection
-                progressionSection
-                restTimerSection
-                plateMathSection
-                barsSection
-                machinesSection
-                deloadSection
-                appleHealthSection
-                accountSection
+                Group {
+                    profileSection
+                    unitsSection
+                    bodyWeightSection
+                    progressionSection
+                    restTimerSection
+                }
+                Group {
+                    plateMathSection
+                    barsSection
+                    machinesSection
+                    deloadSection
+                    appleHealthSection
+                    accountSection
+                }
             }
             .navigationTitle("Settings")
             .task { await loadData() }


### PR DESCRIPTION
Split 11 List sections into two Group blocks. Swift compiler can't type-check too many children in one ViewBuilder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)