### PR TITLE
feat: configurable API base URL via Info.plist (#430)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/APIClient.swift
+++ b/ios/GymTracker/Gym Tracker/Services/APIClient.swift
@@ -4,7 +4,12 @@ import Foundation
 final class APIClient: Sendable {
     static let shared = APIClient()
 
-    private let baseURL = "https://lethal.dev/api"
+    private let baseURL: String = {
+        if let url = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String, !url.isEmpty {
+            return url
+        }
+        return "https://lethal.dev/api"
+    }()
     private let session: URLSession
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder


### PR DESCRIPTION
Reads API_BASE_URL from Info.plist, falls back to production URL. Allows per-build-config URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)