### PR TITLE
fix: NutritionEntryBody inaccessible from NutritionSheets

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -749,7 +749,7 @@ private struct EntriesResponse: Codable {
     let meals: [String: [NutritionEntry]]
 }
 
-private struct NutritionEntryBody: Encodable {
+struct NutritionEntryBody: Encodable {
     var food_item_id: Int? = nil
     let name: String
     let date: String


### PR DESCRIPTION
Removed private from NutritionEntryBody so NutritionSheets.swift can use it after the file split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)