### PR TITLE
fix: withTaskGroup compile errors — typed enum results

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -668,69 +668,62 @@ struct DashboardView: View {
 
     // MARK: - Data Loading
 
+    private enum DashResult: Sendable {
+        case plans([WorkoutPlan])
+        case sessions([WorkoutSession])
+        case bodyWeight(BodyWeightEntry?)
+        case nutrition(DailySummary?)
+        case insights([DashboardInsight])
+    }
+
     private func loadData() async {
-        // Parallel fetch using TaskGroup — safe because @State is only
-        // written AFTER all tasks complete (no async let runtime bug)
-        do {
-            var plansResult: [WorkoutPlan] = []
-            var sessionsResult: [WorkoutSession] = []
-            var bwResult: BodyWeightEntry? = nil
-            var nsResult: DailySummary? = nil
-            var insResult: [DashboardInsight] = []
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        let todayStr = df.string(from: Date())
 
-            await withTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    plansResult = (try? await APIClient.shared.get("/plans/")) ?? []
-                }
-                group.addTask {
-                    sessionsResult = (try? await APIClient.shared.get("/sessions/",
-                        query: [.init(name: "limit", value: "30")])) ?? []
-                }
-                group.addTask {
-                    let entries: [BodyWeightEntry]? = try? await APIClient.shared.get("/body-weight/",
-                        query: [.init(name: "limit", value: "1")])
-                    bwResult = entries?.first
-                }
-                group.addTask {
-                    let df = DateFormatter()
-                    df.dateFormat = "yyyy-MM-dd"
-                    nsResult = try? await APIClient.shared.get("/nutrition/summary",
-                        query: [.init(name: "date", value: df.string(from: Date()))])
-                }
-                group.addTask {
-                    insResult = (try? await APIClient.shared.get("/progress/insights")) ?? []
-                }
+        let results = await withTaskGroup(of: DashResult.self, returning: [DashResult].self) { group in
+            group.addTask { .plans((try? await APIClient.shared.get("/plans/")) ?? []) }
+            group.addTask { .sessions((try? await APIClient.shared.get("/sessions/", query: [.init(name: "limit", value: "30")])) ?? []) }
+            group.addTask {
+                let entries: [BodyWeightEntry] = (try? await APIClient.shared.get("/body-weight/", query: [.init(name: "limit", value: "1")])) ?? []
+                return .bodyWeight(entries.first)
             }
+            group.addTask { .nutrition(try? await APIClient.shared.get("/nutrition/summary", query: [.init(name: "date", value: todayStr)])) }
+            group.addTask { .insights((try? await APIClient.shared.get("/progress/insights")) ?? []) }
 
-            // All tasks complete — now assign @State on the calling actor
-            plans = plansResult
-            let allSessions = sessionsResult
-            recentSessions = allSessions.filter { $0.status == "completed" }
-            activeSession = allSessions.first { s in
-                s.status == "in_progress" || (s.started_at != nil && s.completed_at == nil)
-            }
-            if let plan = plansResult.first {
-                let planSessions = allSessions.filter {
-                    $0.status == "completed" && $0.workout_plan_id == plan.id
-                }
-                let totalDays = plan.dayCount
-                if totalDays > 0 {
-                    nextDay = (planSessions.count % totalDays) + 1
-                }
-            }
-            streak = calculateStreak(allSessions)
-            weekCount = countThisWeek(allSessions)
-            latestBodyWeight = bwResult
-            nutritionSummary = nsResult
-            insights = insResult
-            loading = false
-        } catch is CancellationError {
-            return
-        } catch {
-            self.error = error.localizedDescription
-            loading = false
-            print("[Dashboard] Load error: \(error)")
+            var collected: [DashResult] = []
+            for await result in group { collected.append(result) }
+            return collected
         }
+
+        // Unpack results and assign @State
+        var allSessions: [WorkoutSession] = []
+        for result in results {
+            switch result {
+            case .plans(let p): plans = p
+            case .sessions(let s): allSessions = s
+            case .bodyWeight(let bw): latestBodyWeight = bw
+            case .nutrition(let ns): nutritionSummary = ns
+            case .insights(let ins): insights = ins
+            }
+        }
+
+        recentSessions = allSessions.filter { $0.status == "completed" }
+        activeSession = allSessions.first { s in
+            s.status == "in_progress" || (s.started_at != nil && s.completed_at == nil)
+        }
+        if let plan = plans.first {
+            let planSessions = allSessions.filter {
+                $0.status == "completed" && $0.workout_plan_id == plan.id
+            }
+            let totalDays = plan.dayCount
+            if totalDays > 0 {
+                nextDay = (planSessions.count % totalDays) + 1
+            }
+        }
+        streak = calculateStreak(allSessions)
+        weekCount = countThisWeek(allSessions)
+        loading = false
     }
 }
 

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -642,29 +642,31 @@ struct NutritionView: View {
 
     // MARK: - Data Loading (fully sequential — no async let)
 
-    private func loadAll() async {
-        var s: DailySummary? = nil
-        var e: EntriesResponse? = nil
-        var w: WaterSummary? = nil
+    private enum NutrResult: Sendable {
+        case summary(DailySummary?)
+        case entries(EntriesResponse?)
+        case water(WaterSummary?)
+    }
 
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                s = try? await APIClient.shared.get("/nutrition/summary",
-                    query: [.init(name: "date", value: self.dateString)])
-            }
-            group.addTask {
-                e = try? await APIClient.shared.get("/nutrition/entries",
-                    query: [.init(name: "date", value: self.dateString)])
-            }
-            group.addTask {
-                w = try? await APIClient.shared.get("/nutrition/water",
-                    query: [.init(name: "date", value: self.dateString)])
-            }
+    private func loadAll() async {
+        let ds = dateString
+        let results = await withTaskGroup(of: NutrResult.self, returning: [NutrResult].self) { group in
+            group.addTask { .summary(try? await APIClient.shared.get("/nutrition/summary", query: [.init(name: "date", value: ds)])) }
+            group.addTask { .entries(try? await APIClient.shared.get("/nutrition/entries", query: [.init(name: "date", value: ds)])) }
+            group.addTask { .water(try? await APIClient.shared.get("/nutrition/water", query: [.init(name: "date", value: ds)])) }
+
+            var collected: [NutrResult] = []
+            for await r in group { collected.append(r) }
+            return collected
         }
 
-        summary = s
-        mealEntries = e?.meals ?? [:]
-        waterSummary = w
+        for result in results {
+            switch result {
+            case .summary(let s): summary = s
+            case .entries(let e): mealEntries = e?.meals ?? [:]
+            case .water(let w): waterSummary = w
+            }
+        }
         loading = false
     }
 

--- a/ios/GymTracker/Gym Tracker/Views/Progress/ProgressView_.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Progress/ProgressView_.swift
@@ -583,49 +583,41 @@ struct ProgressView_: View {
         let startStr = fmt.string(from: startDate)
         let endStr   = fmt.string(from: endDate)
 
-        do {
-            var pts2: [ProgressDataPoint] = []
-            var recs2: [ProgressRecommendation] = []
-            var bw2: [BodyWeightEntry] = []
-            var prs2: [PersonalRecord] = []
-            var vol2: VolumeLandmarksResponse? = nil
+        enum ProgResult: Sendable {
+            case points([ProgressDataPoint])
+            case recs([ProgressRecommendation])
+            case bw([BodyWeightEntry])
+            case prs([PersonalRecord])
+            case vol(VolumeLandmarksResponse?)
+        }
 
-            await withTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    pts2 = (try? await APIClient.shared.get("/progress/",
-                        query: [.init(name: "start_date", value: startStr),
-                                .init(name: "end_date", value: endStr)])) ?? []
-                }
-                group.addTask {
-                    recs2 = (try? await APIClient.shared.get("/progress/recommendations",
-                        query: [.init(name: "days_back", value: "\(timeRange)")])) ?? []
-                }
-                group.addTask {
-                    bw2 = (try? await APIClient.shared.get("/body-weight/",
-                        query: [.init(name: "limit", value: "90")])) ?? []
-                }
-                group.addTask {
-                    prs2 = (try? await APIClient.shared.get("/progress/records")) ?? []
-                }
-                group.addTask {
-                    vol2 = try? await APIClient.shared.get("/progress/volume-landmarks",
-                        query: [.init(name: "days", value: "\(timeRange)")])
-                }
+        let results = await withTaskGroup(of: ProgResult.self, returning: [ProgResult].self) { group in
+            group.addTask { .points((try? await APIClient.shared.get("/progress/", query: [.init(name: "start_date", value: startStr), .init(name: "end_date", value: endStr)])) ?? []) }
+            group.addTask { .recs((try? await APIClient.shared.get("/progress/recommendations", query: [.init(name: "days_back", value: "\(timeRange)")])) ?? []) }
+            group.addTask { .bw((try? await APIClient.shared.get("/body-weight/", query: [.init(name: "limit", value: "90")])) ?? []) }
+            group.addTask { .prs((try? await APIClient.shared.get("/progress/records")) ?? []) }
+            group.addTask { .vol(try? await APIClient.shared.get("/progress/volume-landmarks", query: [.init(name: "days", value: "\(timeRange)")])) }
+
+            var collected: [ProgResult] = []
+            for await r in group { collected.append(r) }
+            return collected
+        }
+
+        var pts2: [ProgressDataPoint] = []
+        for result in results {
+            switch result {
+            case .points(let p): pts2 = p; dataPoints = p
+            case .recs(let r): recommendations = r
+            case .bw(let b): bodyWeights = b
+            case .prs(let p): personalRecords = p
+            case .vol(let v): volumeLandmarks = v?.muscles ?? [:]
             }
+        }
 
-            dataPoints      = pts2
-            recommendations = recs2
-            bodyWeights     = bw2
-            personalRecords = prs2
-            volumeLandmarks = vol2?.muscles ?? [:]
-
-            let names = Set(pts2.map { $0.exercise_name }).sorted()
-            allExerciseNames = names
-            if selectedExercise != "All" && !names.contains(selectedExercise) {
-                selectedExercise = "All"
-            }
-        } catch {
-            print("[Progress] Load error: \(error)")
+        let names = Set(pts2.map { $0.exercise_name }).sorted()
+        allExerciseNames = names
+        if selectedExercise != "All" && !names.contains(selectedExercise) {
+            selectedExercise = "All"
         }
         loading = false
     }


### PR DESCRIPTION
Tasks can't mutate captured vars. Switched to typed enum results pattern. Fixes 34 compile errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)