### PR TITLE
fix: multi-minute app hang — auth refresh deadlock + faster timeouts

### DIFF
--- a/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
+++ b/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
@@ -10,8 +10,9 @@ struct GymTrackerApp: App {
                 if auth.isAuthenticated {
                     MainTabView()
                         .task {
-                            await SettingsSync.loadFromDB()
-                            await HealthKitManager.shared.syncBodyWeightOnLaunch()
+                            // Fire-and-forget — don't block app launch
+                            Task { await SettingsSync.loadFromDB() }
+                            Task { await HealthKitManager.shared.syncBodyWeightOnLaunch() }
                         }
                 } else {
                     LoginView()

--- a/ios/GymTracker/Gym Tracker/Services/APIClient.swift
+++ b/ios/GymTracker/Gym Tracker/Services/APIClient.swift
@@ -16,8 +16,8 @@ final class APIClient: Sendable {
 
     private init() {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 15
-        config.timeoutIntervalForResource = 30
+        config.timeoutIntervalForRequest = 8
+        config.timeoutIntervalForResource = 15
         // Route to the dev container via nginx cookie
         let cookie = HTTPCookie(properties: [
             .domain: "lethal.dev",

--- a/ios/GymTracker/Gym Tracker/Services/AuthService.swift
+++ b/ios/GymTracker/Gym Tracker/Services/AuthService.swift
@@ -74,8 +74,25 @@ class AuthService {
 
     // MARK: - Refresh
 
+    private var isRefreshing = false
+    private var refreshResult: Bool? = nil
+
     func refreshTokens() async -> Bool {
+        // Prevent multiple concurrent refresh attempts (from parallel API calls)
+        if isRefreshing {
+            // Wait for the in-flight refresh to finish
+            while isRefreshing {
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+            return refreshResult ?? false
+        }
+
         guard let refresh = refreshToken else { return false }
+
+        isRefreshing = true
+        defer {
+            isRefreshing = false
+        }
 
         struct RefreshRequest: Encodable {
             let refresh_token: String
@@ -92,9 +109,11 @@ class AuthService {
                 body: RefreshRequest(refresh_token: refresh)
             )
             saveTokens(access: response.access_token, refresh: response.refresh_token)
+            refreshResult = true
             return true
         } catch {
             logout()
+            refreshResult = false
             return false
         }
     }

--- a/ios/GymTracker/Gym Tracker/Views/Progress/ProgressView_.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Progress/ProgressView_.swift
@@ -610,7 +610,7 @@ struct ProgressView_: View {
             case .recs(let r): recommendations = r
             case .bw(let b): bodyWeights = b
             case .prs(let p): personalRecords = p
-            case .vol(let v): volumeLandmarks = v?.muscles ?? [:]
+            case .vol(let v): volumeLandmarks = v?.muscles ?? []
             }
         }
 


### PR DESCRIPTION
## Root cause
With parallel TaskGroup, 5+ requests get 401 simultaneously → all try refreshTokens() → deadlock on MainActor + server invalidates tokens.

## Fixes
- Auth refresh lock — only one refresh runs, others wait for result
- SettingsSync + HealthKit sync fire-and-forget (don't block launch)
- API timeout 15s → 8s
- Fix [:]  → [] compile error in ProgressView_

🤖 Generated with [Claude Code](https://claude.com/claude-code)