### PR TITLE
fix: black screen deadlock — shared refresh Task replaces spin-loop

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/AuthService.swift
+++ b/ios/GymTracker/Gym Tracker/Services/AuthService.swift
@@ -74,48 +74,43 @@ class AuthService {
 
     // MARK: - Refresh
 
-    private var isRefreshing = false
-    private var refreshResult: Bool? = nil
+    private var refreshTask: Task<Bool, Never>? = nil
 
     func refreshTokens() async -> Bool {
-        // Prevent multiple concurrent refresh attempts (from parallel API calls)
-        if isRefreshing {
-            // Wait for the in-flight refresh to finish
-            while isRefreshing {
-                try? await Task.sleep(for: .milliseconds(50))
-            }
-            return refreshResult ?? false
+        // If a refresh is already in flight, wait for it (no spin-loop)
+        if let existing = refreshTask {
+            return await existing.value
         }
 
         guard let refresh = refreshToken else { return false }
 
-        isRefreshing = true
-        defer {
-            isRefreshing = false
-        }
+        // Create a single refresh task — all concurrent callers share it
+        let task = Task<Bool, Never> { @MainActor in
+            struct RefreshRequest: Encodable {
+                let refresh_token: String
+            }
 
-        struct RefreshRequest: Encodable {
-            let refresh_token: String
-        }
+            struct RefreshResponse: Decodable {
+                let access_token: String
+                let refresh_token: String
+            }
 
-        struct RefreshResponse: Decodable {
-            let access_token: String
-            let refresh_token: String
+            do {
+                let response: RefreshResponse = try await APIClient.shared.post(
+                    "/auth/refresh",
+                    body: RefreshRequest(refresh_token: refresh)
+                )
+                saveTokens(access: response.access_token, refresh: response.refresh_token)
+                return true
+            } catch {
+                logout()
+                return false
+            }
         }
-
-        do {
-            let response: RefreshResponse = try await APIClient.shared.post(
-                "/auth/refresh",
-                body: RefreshRequest(refresh_token: refresh)
-            )
-            saveTokens(access: response.access_token, refresh: response.refresh_token)
-            refreshResult = true
-            return true
-        } catch {
-            logout()
-            refreshResult = false
-            return false
-        }
+        refreshTask = task
+        let result = await task.value
+        refreshTask = nil
+        return result
     }
 
     // MARK: - Logout

--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -134,9 +134,9 @@ struct DashboardView: View {
                     }
                 }
             }
-            .onAppear {
+            .task {
                 loadWidgetConfig()
-                Task { await loadData() }
+                await loadData()
             }
             .refreshable { await loadData() }
         }

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -44,7 +44,9 @@ struct NutritionView: View {
                         heroHeader
 
                         if loading {
-                            ProgressView().padding(.top, 60)
+                            ProgressView()
+                                .tint(.white)
+                                .padding(.top, 60)
                         } else {
                             VStack(spacing: 16) {
                                 // Macro bars


### PR DESCRIPTION
## Root cause
The while/sleep spin-loop in refreshTokens() deadlocked MainActor. With 5+ parallel API calls all getting 401, multiple callers entered the spin-loop, blocking the first refresh from ever completing.

## Fix
Replaced with a shared `Task<Bool, Never>` — first caller creates it, all others await the same task. No blocking, no spinning.

Also: DashboardView .onAppear → .task, white spinner on black nutrition bg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)