### PR TITLE
visual: exercise cards, finish screen, plan duration (#482 #485 #487 #488)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Components/WorkoutSummaryView.swift
+++ b/ios/GymTracker/Gym Tracker/Components/WorkoutSummaryView.swift
@@ -67,7 +67,7 @@ struct WorkoutSummaryView: View {
                     StatBox(label: "~kcal", value: "\(estimatedCalories)")
                 }
 
-                // PRs
+                // PRs — amber styling matching web
                 if !prs.isEmpty {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("🏆 Personal Records")
@@ -84,8 +84,12 @@ struct WorkoutSummaryView: View {
                         }
                     }
                     .padding()
-                    .background(.ultraThinMaterial)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .background(Color.orange.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .strokeBorder(Color.orange.opacity(0.2), lineWidth: 1)
+                    )
                 }
 
                 // Exercise breakdown
@@ -289,14 +293,18 @@ struct StatBox: View {
     var body: some View {
         VStack(spacing: 4) {
             Text(value)
-                .font(.title2.bold())
+                .font(.title2.bold().monospacedDigit())
             Text(label)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
         .padding()
-        .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .background(AppColors.zinc900)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(AppColors.zinc800, lineWidth: 1)
+        )
     }
 }

--- a/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
+++ b/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
@@ -44,6 +44,18 @@ struct PlanDay: Codable, Identifiable {
     let day_number: Int
     let day_name: String
     let exercises: [PlanExerciseEntry]
+
+    /// Estimated workout duration in minutes (matching web's estimateDayMinutes)
+    var estimatedMinutes: Int {
+        let avgSetDuration = 40.0 // seconds per set
+        var totalSeconds = 0.0
+        for ex in exercises {
+            let sets = Double(ex.sets ?? 3)
+            let rest = Double(ex.rest_seconds ?? 90)
+            totalSeconds += sets * avgSetDuration + max(sets - 1, 0) * rest
+        }
+        return max(Int(totalSeconds / 60), 1)
+    }
 }
 
 struct WorkoutPlan: Codable, Identifiable {

--- a/ios/GymTracker/Gym Tracker/Views/Plans/PlansView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Plans/PlansView.swift
@@ -386,6 +386,9 @@ private struct PlanDayLinkRow: View {
                     Text("exercises")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                    Text("~\(day.estimatedMinutes)m")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
                 }
             }
             .padding(.vertical, 5)

--- a/ios/GymTracker/Gym Tracker/Views/Workout/ActiveWorkoutView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Workout/ActiveWorkoutView.swift
@@ -530,16 +530,13 @@ struct ActiveWorkoutView: View {
             }
         }
         .padding()
-        .background(
-            allSetsDone
-                ? Color.green.opacity(0.06)
-                : Color(.systemGray6).opacity(0.5)
-        )
+        .background(AppColors.zinc900)
         .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(allSetsDone ? Color.green.opacity(0.3) : Color.clear, lineWidth: 1)
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(allSetsDone ? Color.green.opacity(0.3) : AppColors.zinc800, lineWidth: 1)
         )
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .opacity(allSetsDone ? 0.6 : 1.0)
         .animation(.easeInOut(duration: 0.3), value: allSetsDone)
     }
 


### PR DESCRIPTION
Exercise cards match web (zinc bg, opacity on done, 16px corners).
Finish screen matches web (zinc stat boxes, amber PR section).
Plan cards show estimated duration per day (~Xm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)