### PR TITLE
fix: GymTracker title truncated to 'G...'

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -140,14 +140,8 @@ struct DashboardView: View {
                 }
             }
             .background(AppColors.zinc950)
-            .navigationTitle("")
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Text("GymTracker")
-                        .font(.title2.bold())
-                        .foregroundStyle(AppColors.primary)
-                }
-            }
+            .navigationTitle("GymTracker")
+            .navigationBarTitleDisplayMode(.large)
             .task {
                 loadWidgetConfig()
                 await loadData()


### PR DESCRIPTION
Toolbar item was too small for the title. Switched to .navigationTitle with .large display mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)