### PR TITLE
feat: quick parity — custom rest, alcohol presets, activity, repeat, 1RM (#470-481)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -57,6 +57,10 @@ struct DashboardView: View {
     @State private var activeSession: WorkoutSession? = nil
     private var hasActiveSession: Bool { activeSession != nil }
 
+    // 1RM calculator
+    @State private var calcWeight: Double? = nil
+    @State private var calcReps: Int? = nil
+
     // Widget ordering & visibility
     @State private var widgetOrder: [DashboardWidget] = DashboardWidget.allCases
     @State private var hiddenWidgets: Set<String> = []
@@ -124,15 +128,23 @@ struct DashboardView: View {
                         // 6. Training Log
                         trainingLogSection
 
-                        // 7. Insights
+                        // 7. Repeat Last Workout (#475)
+                        if let lastSession = recentSessions.first {
+                            repeatLastWorkoutButton(lastSession)
+                        }
+
+                        // 8. Insights
                         if !insights.isEmpty {
                             insightsSection
                         }
 
-                        // 8. Nutrition
+                        // 9. Nutrition
                         if let ns = nutritionSummary {
                             nutritionSnapshot(ns)
                         }
+
+                        // 10. Inline 1RM Calculator (#476)
+                        inlineCalculator
                     }
                     .padding(.horizontal)
                     .padding(.top, 8)
@@ -255,6 +267,86 @@ struct DashboardView: View {
     }
 
     // MARK: - Manage Plans Row
+
+    // MARK: - Repeat Last Workout (#475)
+
+    private func repeatLastWorkoutButton(_ session: WorkoutSession) -> some View {
+        NavigationLink {
+            ActiveWorkoutView(
+                planId: session.workout_plan_id,
+                planName: session.name ?? "Workout",
+                dayNumber: session.day_number ?? 1
+            )
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.title3)
+                    .foregroundStyle(AppColors.primary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Repeat Last Workout")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(AppColors.zinc300)
+                    Text(session.name ?? "Workout")
+                        .font(.caption2)
+                        .foregroundStyle(AppColors.zinc500)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(AppColors.zinc600)
+            }
+            .padding()
+            .background(AppColors.zinc900)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(AppColors.zinc800, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - 1RM Calculator (#476)
+
+    private var inlineCalculator: some View {
+        let oneRM: Double? = {
+            guard let w = calcWeight, let r = calcReps, w > 0, r > 0 else { return nil }
+            return w * (1 + Double(r) / 30)
+        }()
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("1RM Calculator")
+                .font(.subheadline.bold())
+            HStack(spacing: 12) {
+                HStack {
+                    TextField("Weight", value: $calcWeight, format: .number)
+                        .keyboardType(.decimalPad)
+                        .textFieldStyle(.roundedBorder)
+                    Text(weightUnit).font(.caption).foregroundStyle(AppColors.zinc500)
+                }
+                HStack {
+                    TextField("Reps", value: $calcReps, format: .number)
+                        .keyboardType(.numberPad)
+                        .textFieldStyle(.roundedBorder)
+                    Text("reps").font(.caption).foregroundStyle(AppColors.zinc500)
+                }
+            }
+            if let rm = oneRM {
+                HStack {
+                    Text("Estimated 1RM:")
+                        .font(.subheadline)
+                        .foregroundStyle(AppColors.zinc400)
+                    Text("\(Int(rm)) \(weightUnit)")
+                        .font(.title3.bold().monospacedDigit())
+                        .foregroundStyle(AppColors.primary)
+                }
+            }
+        }
+        .padding()
+        .background(AppColors.zinc900)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).strokeBorder(AppColors.zinc800, lineWidth: 1))
+    }
 
     private var managePlansRow: some View {
         NavigationLink {

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
@@ -554,6 +554,23 @@ struct AlcoholCalculatorView: View {
     var body: some View {
         NavigationStack {
             Form {
+                Section("Quick Presets") {
+                    HStack(spacing: 8) {
+                        Button("🍺 Beer") {
+                            drinkType = .beer; volumeText = "12"; volumeUnit = .oz
+                        }
+                        .buttonStyle(.bordered).controlSize(.small)
+                        Button("🍷 Wine") {
+                            drinkType = .wine; volumeText = "5"; volumeUnit = .oz
+                        }
+                        .buttonStyle(.bordered).controlSize(.small)
+                        Button("🥃 Spirit") {
+                            drinkType = .spirits; volumeText = "1.5"; volumeUnit = .oz
+                        }
+                        .buttonStyle(.bordered).controlSize(.small)
+                    }
+                }
+
                 Section("Drink Type") {
                     Picker("Type", selection: $drinkType) {
                         ForEach(DrinkType.allCases) { type in

--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -360,6 +360,18 @@ struct SettingsView: View {
             }
 
             heightRow
+
+            // Activity level (#481)
+            Picker("Activity Level", selection: Binding(
+                get: { UserDefaults.standard.double(forKey: "activityLevel") },
+                set: { UserDefaults.standard.set($0, forKey: "activityLevel") }
+            )) {
+                Text("Sedentary (1.0)").tag(1.0)
+                Text("Lightly Active (1.2)").tag(1.2)
+                Text("Moderate (1.4)").tag(1.4)
+                Text("Active (1.6)").tag(1.6)
+                Text("Very Active (1.8)").tag(1.8)
+            }
         }
     }
 

--- a/ios/GymTracker/Gym Tracker/Views/Workout/ActiveWorkoutView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Workout/ActiveWorkoutView.swift
@@ -391,6 +391,17 @@ struct ActiveWorkoutView: View {
                     Text(exercise.name)
                         .font(.headline)
                         .foregroundStyle(allSetsDone ? .green : .primary)
+                        .contextMenu {
+                            // Custom rest timer (#470)
+                            Menu("Rest Timer") {
+                                ForEach([30, 60, 90, 120, 150, 180, 240, 300], id: \.self) { secs in
+                                    Button("\(secs / 60):\(String(format: "%02d", secs % 60))") {
+                                        exercises[exIdx].customRestSeconds = secs
+                                    }
+                                }
+                                Button("Default") { exercises[exIdx].customRestSeconds = nil }
+                            }
+                        }
                     HStack(spacing: 6) {
                         if !exercise.muscleGroup.isEmpty {
                             Text(exercise.muscleGroup)


### PR DESCRIPTION
5 quick feature parity items:
- **#470**: Long-press exercise → custom rest timer
- **#479**: Alcohol calc quick presets (beer/wine/spirit)
- **#481**: Activity level picker in settings
- **#475**: Repeat last workout button on dashboard
- **#476**: Inline 1RM calculator widget on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)