### PR TITLE
feat: image export, lean/fat chart, volume chart (#468 #473 #477)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Components/WorkoutSummaryView.swift
+++ b/ios/GymTracker/Gym Tracker/Components/WorkoutSummaryView.swift
@@ -176,8 +176,11 @@ struct WorkoutSummaryView: View {
 
                 // Share + Home buttons
                 HStack(spacing: 16) {
-                    ShareLink(item: summaryText) {
-                        Label("Share", systemImage: "square.and.arrow.up")
+                    // Image share (#468)
+                    Button {
+                        shareAsImage()
+                    } label: {
+                        Label("Share Image", systemImage: "photo")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.bordered)
@@ -283,6 +286,37 @@ struct WorkoutSummaryView: View {
         }
         let suffix = groups.count > 2 ? " …" : ""
         return parts.joined(separator: ", ") + suffix
+    }
+
+    @MainActor
+    private func shareAsImage() {
+        let renderer = ImageRenderer(content:
+            VStack(spacing: 12) {
+                Text("🎉 Workout Complete!").font(.title2.bold())
+                Text(workoutName).font(.headline)
+                HStack(spacing: 16) {
+                    VStack { Text("\(totalSets)").font(.title3.bold()); Text("Sets").font(.caption) }
+                    VStack { Text(formatDuration(duration)).font(.title3.bold()); Text("Duration").font(.caption) }
+                    VStack { Text(formatVolume(totalVolume)).font(.title3.bold()); Text("Volume").font(.caption) }
+                }
+                if !prs.isEmpty {
+                    Text("🏆 \(prs.count) PR\(prs.count > 1 ? "s" : "")!").font(.subheadline.bold()).foregroundStyle(.yellow)
+                }
+                Text("GymTracker").font(.caption2).foregroundStyle(.secondary)
+            }
+            .padding(24)
+            .background(AppColors.zinc900)
+            .frame(width: 350)
+        )
+        renderer.scale = 3.0
+
+        if let image = renderer.uiImage {
+            let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let root = windowScene.windows.first?.rootViewController {
+                root.present(activityVC, animated: true)
+            }
+        }
     }
 }
 

--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Charts
 
 // MARK: - Dashboard Widget Identifiers
 
@@ -143,7 +144,10 @@ struct DashboardView: View {
                             nutritionSnapshot(ns)
                         }
 
-                        // 10. Inline 1RM Calculator (#476)
+                        // 10. Week Volume Chart (#477)
+                        weekVolumeChart
+
+                        // 11. Inline 1RM Calculator (#476)
                         inlineCalculator
                     }
                     .padding(.horizontal)
@@ -341,6 +345,47 @@ struct DashboardView: View {
                         .foregroundStyle(AppColors.primary)
                 }
             }
+
+    // MARK: - Week Volume Chart (#477)
+
+    private var weekVolumeChart: some View {
+        let cal = Calendar.current
+        let today = Date()
+        let days = (0..<7).map { cal.date(byAdding: .day, value: -6 + $0, to: today)! }
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        let dayLabels = DateFormatter()
+        dayLabels.dateFormat = "E"
+
+        struct DayVolume: Identifiable {
+            let id: String
+            let label: String
+            let volume: Double
+        }
+
+        let data: [DayVolume] = days.map { day in
+            let dateStr = df.string(from: day)
+            let vol = recentSessions
+                .filter { $0.date == dateStr && $0.status == "completed" }
+                .compactMap(\.total_volume_kg)
+                .reduce(0, +)
+            let dispVol = weightUnit == "lbs" ? vol * 2.20462 : vol
+            return DayVolume(id: dateStr, label: dayLabels.string(from: day), volume: dispVol)
+        }
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("This Week")
+                .font(.subheadline.bold())
+            Chart(data) { day in
+                BarMark(
+                    x: .value("Day", day.label),
+                    y: .value("Volume", day.volume)
+                )
+                .foregroundStyle(AppColors.primary.gradient)
+                .cornerRadius(4)
+            }
+            .chartYAxisLabel(weightUnit)
+            .frame(height: 120)
         }
         .padding()
         .background(AppColors.zinc900)

--- a/ios/GymTracker/Gym Tracker/Views/Progress/ProgressView_.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Progress/ProgressView_.swift
@@ -219,21 +219,49 @@ struct ProgressView_: View {
     }
 
     private var bodyWeightLineChart: some View {
-        Chart(bodyWeights.reversed()) { entry in
-            LineMark(
-                x: .value("Date", String(entry.recorded_at?.prefix(10) ?? "")),
-                y: .value("Weight", displayWeight(entry.weight_kg))
-            )
-            .interpolationMethod(.catmullRom)
-            .foregroundStyle(.blue)
-            PointMark(
-                x: .value("Date", String(entry.recorded_at?.prefix(10) ?? "")),
-                y: .value("Weight", displayWeight(entry.weight_kg))
-            )
-            .foregroundStyle(.blue)
-            .symbolSize(30)
+        let entries = bodyWeights.reversed()
+        let hasBodyFat = entries.contains { $0.body_fat_pct != nil }
+
+        return Chart {
+            ForEach(Array(entries), id: \.id) { entry in
+                let dateStr = String(entry.recorded_at?.prefix(10) ?? "")
+                let weight = displayWeight(entry.weight_kg)
+
+                // Total weight line
+                LineMark(x: .value("Date", dateStr), y: .value("Weight", weight))
+                    .interpolationMethod(.catmullRom)
+                    .foregroundStyle(.blue)
+                PointMark(x: .value("Date", dateStr), y: .value("Weight", weight))
+                    .foregroundStyle(.blue)
+                    .symbolSize(30)
+
+                // Lean mass line (#473)
+                if let bf = entry.body_fat_pct {
+                    let lean = displayWeight(entry.weight_kg * (1 - bf / 100))
+                    LineMark(x: .value("Date", dateStr), y: .value("Lean", lean))
+                        .interpolationMethod(.catmullRom)
+                        .foregroundStyle(.green)
+                    PointMark(x: .value("Date", dateStr), y: .value("Lean", lean))
+                        .foregroundStyle(.green)
+                        .symbolSize(20)
+
+                    // Fat mass line
+                    let fat = displayWeight(entry.weight_kg * bf / 100)
+                    LineMark(x: .value("Date", dateStr), y: .value("Fat", fat))
+                        .interpolationMethod(.catmullRom)
+                        .foregroundStyle(.orange)
+                    PointMark(x: .value("Date", dateStr), y: .value("Fat", fat))
+                        .foregroundStyle(.orange)
+                        .symbolSize(20)
+                }
+            }
         }
         .chartYAxisLabel(weightUnit)
+        .chartForegroundStyleScale([
+            "Weight": .blue,
+            "Lean": .green,
+            "Fat": .orange,
+        ])
         .frame(height: 220)
     }
 


### PR DESCRIPTION
3 medium parity items:
- **#468**: Workout summary image export (ImageRenderer → share sheet)
- **#473**: Lean/fat mass lines on body weight chart (green/orange)
- **#477**: 7-day volume bar chart widget on dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)