### PR TITLE
fix: close inlineCalculator computed property — missing brace broke build

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Dashboard/DashboardView.swift
@@ -358,6 +358,12 @@ struct DashboardView: View {
                         .foregroundStyle(AppColors.primary)
                 }
             }
+        }
+        .padding()
+        .background(AppColors.zinc900)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16).strokeBorder(AppColors.zinc800, lineWidth: 1))
+    }
 
     // MARK: - Week Volume Chart (#477)
 


### PR DESCRIPTION
## Summary
- The 1RM Calculator (`inlineCalculator`) computed property in `DashboardView.swift` was missing its closing brace, padding, and background modifiers
- This caused all subsequent `private` functions and types (`countThisWeek`, `DashResult`, `loadData`) to be scoped inside the computed property, producing Swift compiler errors
- Added the missing closing brace and standard card styling (padding, background, corner radius, border)

## Test plan
- [ ] Verify the iOS app builds without errors
- [ ] Verify the 1RM Calculator card renders correctly on the Dashboard
- [ ] Verify other Dashboard functionality (streak, week count, data loading) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)