### PR TITLE
fix: nutrition search bar not responding to taps (#511)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
@@ -59,7 +59,6 @@ struct AddFoodView: View {
             .navigationTitle("Add Food")
             .navigationBarTitleDisplayMode(.inline)
             .keyboardDoneButton()
-            .dismissKeyboardOnTap()
             .task { await loadRecent(); await loadSavedFoods() }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {


### PR DESCRIPTION
dismissKeyboardOnTap() was swallowing all taps. Removed from AddFoodView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)