### PR TITLE
fix: 133 exercises missing plate math — wrong equipment_type

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -334,13 +334,21 @@
     if (!exercise) return false;
     if (!$settings.showPlateMath) return false;
     if (exercise.equipment_type === 'barbell' || exercise.equipment_type === 'plate_loaded') return true;
-    // Fallback: check name prefix for exercises that haven't been re-seeded yet
+    // Fallback: check name for plate-loaded exercises with wrong equipment_type
     const n = exercise.name?.toLowerCase() ?? '';
-    const prefix = n.split('_')[0];
-    if (['barbell', 'smith', 'tbar', 'belt', 'plate'].includes(prefix)) return true;
-    // Multi-word prefixes and variants
-    if (n.startsWith('t_bar') || n.startsWith('t-bar') || n.includes('t bar') || n.includes('landmine')) return true;
-    if (n.startsWith('plate_loaded')) return true;
+    const d = (exercise.display_name ?? '').toLowerCase();
+    // Smith machine variants
+    if (n.includes('smith') || d.includes('smith')) return true;
+    // EZ bar / curl bar variants (plate-loaded bars)
+    if (n.includes('ez_bar') || n.includes('ez bar') || d.includes('ez bar')) return true;
+    if (n.includes('axle_bar') || d.includes('axle bar')) return true;
+    if (n.includes('swiss_bar') || d.includes('swiss bar')) return true;
+    if (n.includes('rackable') || d.includes('rackable')) return true;
+    // T-bar row / landmine
+    if (n.includes('t_bar') || n.includes('t-bar') || n.includes('t bar') || d.includes('t-bar') || d.includes('t bar')) return true;
+    if (n.includes('landmine') || d.includes('landmine')) return true;
+    // Belt squat, plate loaded prefix
+    if (n.includes('belt_squat') || n.startsWith('plate_loaded') || d.includes('belt squat')) return true;
     return false;
   }
 

--- a/scripts/seed_all_exercises.py
+++ b/scripts/seed_all_exercises.py
@@ -38,15 +38,18 @@ EQUIPMENT_MAP = {
 
 
 def get_equipment_type(name: str) -> str:
-    """Determine equipment type from exercise name prefix."""
+    """Determine equipment type from exercise name — checks all parts, not just prefix."""
     parts = name.split("_")
-    # Check two-word prefixes first (e.g. t_bar, plate_loaded, safety_squat)
-    if len(parts) >= 2:
-        two_word = f"{parts[0]}_{parts[1]}"
+    # Check two-word combos anywhere in the name (e.g. ez_bar, t_bar, belt_squat)
+    for i in range(len(parts) - 1):
+        two_word = f"{parts[i]}_{parts[i + 1]}"
         if two_word in EQUIPMENT_MAP:
             return EQUIPMENT_MAP[two_word]
-    prefix = parts[0]
-    return EQUIPMENT_MAP.get(prefix, "other")
+    # Check single words anywhere in the name
+    for part in parts:
+        if part in EQUIPMENT_MAP:
+            return EQUIPMENT_MAP[part]
+    return "other"
 
 
 def generate_all_exercises():


### PR DESCRIPTION
get_equipment_type() only checked first word. Smith/EZ bar/T-bar exercises defaulted to 'other'. Now scans all name parts. Fixed 133 exercises + shouldShowPlates() fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)