### PR TITLE
feat: portion scaling + auto-calc carbs/fat (#535 #536)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
@@ -450,8 +450,17 @@ struct AddFoodView: View {
         let qty = Double(manualQty) ?? 100
         let cal = Double(manualCal) ?? 0
         let pro = Double(manualProtein) ?? 0
-        let carb = Double(manualCarbs) ?? 0
-        let fat = Double(manualFat) ?? 0
+        var carb = Double(manualCarbs) ?? 0
+        var fat = Double(manualFat) ?? 0
+
+        // Auto-calc carbs/fat if not specified (#536)
+        // Equal caloric split: fats=9cal/g, carbs=4cal/g
+        if carb == 0 && fat == 0 && cal > 0 {
+            let remainingCal = max(cal - (pro * 4), 0)
+            let halfCal = remainingCal / 2
+            carb = round(halfCal / 4)   // 4 cal per gram of carbs
+            fat = round(halfCal / 9)    // 9 cal per gram of fat
+        }
 
         do {
             // Optionally save to custom food library first

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -875,9 +875,22 @@ struct EditEntrySheet: View {
     @State private var errorMessage: String? = nil
     @Environment(\.dismiss) private var dismiss
 
+    // Store original per-gram ratios for scaling
+    private let originalQty: Double
+    private let calPer100: Double
+    private let proPer100: Double
+    private let carbPer100: Double
+    private let fatPer100: Double
+
     init(entry: NutritionEntry, onSave: @escaping () -> Void, onDelete: @escaping () -> Void) {
         self.entry = entry; self.onSave = onSave; self.onDelete = onDelete
-        _qty = State(initialValue: entry.quantity_g.map { "\(Int($0))" } ?? "100")
+        let q = entry.quantity_g ?? 100
+        self.originalQty = q > 0 ? q : 100
+        self.calPer100 = (entry.calories ?? 0) / (q > 0 ? q : 100) * 100
+        self.proPer100 = (entry.protein ?? 0) / (q > 0 ? q : 100) * 100
+        self.carbPer100 = (entry.carbs ?? 0) / (q > 0 ? q : 100) * 100
+        self.fatPer100 = (entry.fat ?? 0) / (q > 0 ? q : 100) * 100
+        _qty = State(initialValue: "\(Int(q))")
         _cal = State(initialValue: entry.calories.map { "\(Int($0))" } ?? "0")
         _pro = State(initialValue: entry.protein.map { "\(Int($0))" } ?? "0")
         _carb = State(initialValue: entry.carbs.map { "\(Int($0))" } ?? "0")
@@ -896,6 +909,16 @@ struct EditEntrySheet: View {
                             .keyboardType(.decimalPad)
                             .multilineTextAlignment(.trailing)
                             .frame(width: 80)
+                            .onChange(of: qty) { _, newQty in
+                                // Scale macros proportionally (#535)
+                                if let newG = Double(newQty), newG > 0 {
+                                    let scale = newG / 100
+                                    cal = "\(Int(calPer100 * scale))"
+                                    pro = "\(Int(proPer100 * scale))"
+                                    carb = "\(Int(carbPer100 * scale))"
+                                    fat = "\(Int(fatPer100 * scale))"
+                                }
+                            }
                     }
                     Picker("Meal", selection: $meal) {
                         ForEach(["breakfast", "lunch", "dinner", "snack"], id: \.self) {


### PR DESCRIPTION
Portion size change scales all macros. Manual entry auto-splits remaining calories into carbs (4cal/g) and fat (9cal/g) equally by calories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)