### PR TITLE
fix: respect branch preference in iOS API client (#549)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/APIClient.swift
+++ b/ios/GymTracker/Gym Tracker/Services/APIClient.swift
@@ -4,6 +4,11 @@ import Foundation
 final class APIClient: Sendable {
     static let shared = APIClient()
 
+    private enum BranchPreference: String {
+        case main
+        case dev
+    }
+
     private let baseURL: String = {
         if let url = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String, !url.isEmpty {
             return url
@@ -18,14 +23,6 @@ final class APIClient: Sendable {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 8
         config.timeoutIntervalForResource = 15
-        // Route to the dev container via nginx cookie
-        let cookie = HTTPCookie(properties: [
-            .domain: "lethal.dev",
-            .path: "/",
-            .name: "gymtracker_branch",
-            .value: "dev",
-        ])!
-        config.httpCookieStorage?.setCookie(cookie)
         session = URLSession(configuration: config)
 
         decoder = JSONDecoder()
@@ -53,6 +50,7 @@ final class APIClient: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyBranchRouting(to: &request)
 
         // Attach auth token (access MainActor property)
         if !skipAuth {
@@ -117,6 +115,7 @@ final class APIClient: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyBranchRouting(to: &request)
 
         let token = await AuthService.shared.accessToken
         if let token {
@@ -185,6 +184,22 @@ final class APIClient: Sendable {
     private func encodeToDictionary(_ value: any Encodable) throws -> Any {
         let data = try encoder.encode(EncodableWrapper(value))
         return try JSONSerialization.jsonObject(with: data)
+    }
+
+    private func applyBranchRouting(to request: inout URLRequest) {
+        guard request.url?.host == "lethal.dev" else { return }
+
+        switch currentBranchPreference() {
+        case .dev:
+            request.setValue("gymtracker_branch=dev", forHTTPHeaderField: "Cookie")
+        case .main:
+            request.setValue(nil, forHTTPHeaderField: "Cookie")
+        }
+    }
+
+    private func currentBranchPreference() -> BranchPreference {
+        let raw = UserDefaults.standard.string(forKey: "branchPreference") ?? BranchPreference.main.rawValue
+        return BranchPreference(rawValue: raw) ?? .main
     }
 }
 

--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -4,6 +4,7 @@ import HealthKit
 // MARK: - UserDefaults Keys (shared across views via @AppStorage)
 
 enum SettingsKey {
+    static let branchPreference    = "branchPreference"
     static let weightUnit          = "weightUnit"
     static let heightUnit          = "heightUnit"
     static let heightInches        = "heightInches"
@@ -57,6 +58,7 @@ enum SettingsKey {
 
 /// JSON structure matching the web app's settings format for cross-platform sync.
 struct SettingsJSON: Codable {
+    var branchPreference: String?
     var weightUnit: String?
     var heightUnit: String?
     var progressionStyle: String?
@@ -97,6 +99,7 @@ enum SettingsSync {
             let remote: SettingsJSON = try await APIClient.shared.get("/auth/settings")
             let ud = UserDefaults.standard
 
+            if let v = remote.branchPreference { ud.set(v, forKey: SettingsKey.branchPreference) }
             if let v = remote.weightUnit { ud.set(v, forKey: SettingsKey.weightUnit) }
             if let v = remote.heightUnit { ud.set(v, forKey: SettingsKey.heightUnit) }
             if let v = remote.progressionStyle { ud.set(v, forKey: SettingsKey.progressionStyle) }
@@ -195,6 +198,7 @@ enum SettingsSync {
         ]
 
         let settings = SettingsJSON(
+            branchPreference: ud.string(forKey: SettingsKey.branchPreference) ?? "main",
             weightUnit: ud.string(forKey: SettingsKey.weightUnit) ?? "lbs",
             heightUnit: ud.string(forKey: SettingsKey.heightUnit) ?? "ft",
             progressionStyle: ud.string(forKey: SettingsKey.progressionStyle) ?? "rep",


### PR DESCRIPTION
## Summary
- stop the iOS API client from unconditionally forcing the `gymtracker_branch=dev` cookie
- read the synced `branchPreference` setting from local cache and only attach the dev-routing cookie when the preference is actually `dev`
- sync `branchPreference` through the iOS settings bridge so web and iOS stay aligned

## Testing
- xcodebuild -project "ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj" -scheme "Gym Tracker" -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /tmp/GymTracker549 CODE_SIGNING_ALLOWED=NO build