### PR TITLE
fix: remove debug auto-login from iOS app launch (#547)

### DIFF
--- a/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
+++ b/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
@@ -17,12 +17,6 @@ struct GymTrackerApp: App {
                         }
                 } else {
                     LoginView()
-                        .task {
-                            // AUTO-LOGIN FOR UI TESTING — REMOVE BEFORE SHIPPING
-                            #if DEBUG
-                            try? await auth.login(username: "claude_test", password: "TestPass123")
-                            #endif
-                        }
                 }
             }
             .environment(auth)


### PR DESCRIPTION
## Summary
- remove the debug-only auto-login task from app launch
- ensure unauthenticated launches stay on the real login screen
- keep the authenticated launch startup tasks unchanged

## Testing
- xcodebuild -project "ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj" -scheme "Gym Tracker" -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /tmp/GymTracker547 CODE_SIGNING_ALLOWED=NO build