### PR TITLE
fix: remove stale armv7 required device capability (#550)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist
+++ b/ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist
@@ -30,10 +30,6 @@
 	<string>GymTracker writes completed workouts, body weight, and nutrition data to Apple Health.</string>
 	<key>UILaunchScreen</key>
 	<dict/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
## Summary
- remove the stale `armv7` required device capability from the iOS app plist
- keep the existing iOS 17 deployment target and project settings unchanged
- align app metadata with current supported hardware

## Testing
- `git diff --check -- ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist`
- `xcodebuild -project 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj' -scheme 'Gym Tracker' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`