### PR TITLE
fix: preserve scanned serving size for custom foods (#568)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
@@ -33,6 +33,7 @@ struct AddFoodView: View {
     @State private var manualCarbs = ""
     @State private var manualFat = ""
     @State private var manualQty = "100"
+    @State private var manualServingLabel = ""
     @State private var saveAsCustom = true
     @State private var saving = false
 
@@ -93,6 +94,10 @@ struct AddFoodView: View {
                     manualProtein = scanned.protein > 0 ? "\(Int(scanned.protein))" : ""
                     manualCarbs = scanned.carbs > 0 ? "\(Int(scanned.carbs))" : ""
                     manualFat = scanned.fat > 0 ? "\(Int(scanned.fat))" : ""
+                    manualServingLabel = scanned.servingSize.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if let servingQty = parseServingSizeInGrams(from: scanned.servingSize) {
+                        manualQty = formatServingQuantity(servingQty)
+                    }
                     activeTab = .manual
                 }
             }
@@ -361,6 +366,18 @@ struct AddFoodView: View {
                 }
             }
 
+            if !manualServingLabel.isEmpty {
+                HStack {
+                    Text("Scanned serving")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(manualServingLabel)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Protein").font(.caption).foregroundStyle(.secondary)
@@ -482,7 +499,7 @@ struct AddFoodView: View {
                     carbs_per_100g: carb * scale,
                     fat_per_100g: fat * scale,
                     serving_size_g: qty,
-                    serving_label: "\(Int(qty))g serving"
+                    serving_label: normalizedServingLabel(for: qty)
                 ))
             }
 
@@ -500,6 +517,33 @@ struct AddFoodView: View {
             dismiss()
         } catch { print("[Food] Manual: \(error)") }
         saving = false
+    }
+
+    private func parseServingSizeInGrams(from label: String) -> Double? {
+        let nsRange = NSRange(label.startIndex..<label.endIndex, in: label)
+
+        if let gramsRegex = try? NSRegularExpression(pattern: #"(\d+(?:\.\d+)?)\s*g\b"#, options: [.caseInsensitive]),
+           let match = gramsRegex.firstMatch(in: label, range: nsRange),
+           let range = Range(match.range(at: 1), in: label) {
+            return Double(label[range])
+        }
+
+        if let leadingNumberRegex = try? NSRegularExpression(pattern: #"(\d+(?:\.\d+)?)"#),
+           let match = leadingNumberRegex.firstMatch(in: label, range: nsRange),
+           let range = Range(match.range(at: 1), in: label) {
+            return Double(label[range])
+        }
+
+        return nil
+    }
+
+    private func formatServingQuantity(_ qty: Double) -> String {
+        qty.rounded(.towardZero) == qty ? "\(Int(qty))" : String(qty)
+    }
+
+    private func normalizedServingLabel(for qty: Double) -> String {
+        let scanned = manualServingLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        return scanned.isEmpty ? "\(Int(qty))g serving" : scanned
     }
 
     private func lookupBarcode(_ barcode: String) async {


### PR DESCRIPTION
## Summary
- carry the scanned serving size into the manual food form after nutrition-label OCR
- parse grams from the scanned serving text so custom foods no longer fall back to the default 100g quantity
- preserve the scanned serving label when saving to My Foods instead of rewriting it to a generic gram label

## Testing
- `git diff --check -- ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift`
- `xcodebuild -project 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj' -scheme 'Gym Tracker' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`