### PR TITLE
fix: only advance next workout after completed sessions (#569)

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -77,7 +77,7 @@
 
     function sessionsForPlan(plan: WorkoutPlan) {
       return sessions.filter(s =>
-        s.status !== 'skipped' &&
+        s.status === 'completed' &&
         (s.total_sets > 0 || s.total_reps > 0) &&
         (s.workout_plan_id === plan.id || (s.name && s.name.startsWith(plan.name + ' - ')))
       );


### PR DESCRIPTION
## Summary
- stop planned sessions from advancing the dashboard next-workout pointer
- only count completed plan sessions when resolving the next day/week to run
- keep the existing current-session resume path unchanged

## Testing
- logic fix validated by inspection against the regression: planned sessions created after removing in-progress state no longer count as completed progress
- local worktree is currently contaminated with unrelated in-progress changes, so I published this patch directly from remote `dev` as an isolated one-line fix