### PR TITLE
fix: link app brand to training page

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -191,7 +191,11 @@
           style="padding-top: env(safe-area-inset-top);"
   >
     <div class="flex items-center justify-between px-4 h-14">
-      <span class="text-lg font-bold gradient-text tracking-tight">GymTracker</span>
+      <a href="/"
+         class="text-lg font-bold gradient-text tracking-tight hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary-500/60 rounded-sm"
+      >
+        GymTracker
+      </a>
 
       <div class="flex items-center gap-3">
         <!-- Desktop nav links (hidden on mobile) -->


### PR DESCRIPTION
## Summary\n- make the top-left GymTracker brand a real link\n- send it to the training dashboard route\n- keep the change isolated to the shared layout\n\n## Testing\n- git diff --check -- frontend/src/routes/+layout.svelte