### PR TITLE
fix: respect saved training level in overload api

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -1,5 +1,6 @@
 """Progress tracking API endpoints."""
 
+import json
 from datetime import date, datetime, timedelta
 from typing import Annotated
 
@@ -19,6 +20,20 @@ from app.models.workout import ExerciseSet, WorkoutSession, WorkoutStatus
 from app.services.overload import OverloadInput, calculate_overload, epley_1rm
 
 router = APIRouter()
+
+
+def get_training_level(user: User) -> str:
+    """Read the saved progression training level from user settings."""
+    if not user.settings_json:
+        return "intermediate"
+
+    try:
+        settings = json.loads(user.settings_json)
+    except json.JSONDecodeError:
+        return "intermediate"
+
+    training_level = settings.get("progression", {}).get("trainingLevel")
+    return training_level if training_level in {"beginner", "intermediate", "advanced"} else "intermediate"
 
 
 @router.get("/")
@@ -589,7 +604,7 @@ async def get_overload_suggestion(
         select(Exercise).where(Exercise.id == body.exercise_id)
     )
     exercise = ex_result.scalar_one_or_none()
-    exercise_type = exercise.category if exercise else "compound"
+    exercise_type = exercise.movement_type if exercise else "compound"
 
     # Get recent completed sets for this exercise (last 5 sessions)
     recent_sets_q = await db.execute(
@@ -640,7 +655,7 @@ async def get_overload_suggestion(
         baseline_reps=baseline_reps,
         target_reps=body.target_reps,
         exercise_type=exercise_type,
-        training_level="intermediate",  # TODO: get from user settings
+        training_level=get_training_level(user),
         rolling_e1rm_trend=rolling_trend,
         weight_increment=weight_increment,
     ))

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -65,3 +65,40 @@ class TestProgressAPI:
         assert "current_weight" in rec
         assert "recommended_weight" in rec
         assert "reason" in rec
+
+    async def test_overload_uses_saved_training_level(self, client: AsyncClient):
+        """POST /progress/overload should respect the user's saved training level."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess["id"], sess["sets"][0]["id"], 36.29, 8)
+        await client.post(f"/api/sessions/{sess['id']}/complete")
+
+        settings_res = await client.put("/api/auth/settings", json={
+            "progression": {"trainingLevel": "beginner"}
+        })
+        assert settings_res.status_code == 200, settings_res.text
+
+        beginner_res = await client.post("/api/progress/overload", json={
+            "exercise_id": ex["id"],
+            "current_weight": 100.0,
+            "current_reps": 15,
+            "target_reps": 8,
+            "weight_unit": "lbs",
+        })
+        assert beginner_res.status_code == 200, beginner_res.text
+
+        settings_res = await client.put("/api/auth/settings", json={
+            "progression": {"trainingLevel": "advanced"}
+        })
+        assert settings_res.status_code == 200, settings_res.text
+
+        advanced_res = await client.post("/api/progress/overload", json={
+            "exercise_id": ex["id"],
+            "current_weight": 100.0,
+            "current_reps": 15,
+            "target_reps": 8,
+            "weight_unit": "lbs",
+        })
+        assert advanced_res.status_code == 200, advanced_res.text
+        assert beginner_res.json()["next_weight"] > advanced_res.json()["next_weight"]


### PR DESCRIPTION
Closes #586\n\n## Summary\n- read progression.trainingLevel from the authenticated user's saved settings when calculating overload suggestions\n- default to intermediate only when the setting is missing or invalid\n- fix the overload endpoint to use exercise.movement_type instead of a nonexistent category field\n- add a regression test proving saved training level changes the suggestion output\n\n## Testing\n- ./venv/bin/python -m pytest tests/test_progress.py -k overload_uses_saved_training_level -vv\n- git diff --check -- app/api/progress.py tests/test_progress.py