### PR TITLE
feat: add canonical next-workout endpoint

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -55,6 +55,67 @@ def serialize_plan(plan: WorkoutPlan) -> dict:
     }
 
 
+def session_matches_plan(session: WorkoutSession, plan: dict) -> bool:
+    if session.workout_plan_id == plan["id"]:
+        return True
+    return bool(session.name and session.name.startswith(f"{plan['name']} - "))
+
+
+def resolve_next_workout(sessions: list[WorkoutSession], plans: list[dict]) -> dict | None:
+    active_plans = [p for p in plans if not p["is_archived"] and not p["is_draft"]]
+    if not active_plans:
+        return None
+
+    def completed_sessions_for_plan(plan: dict) -> list[WorkoutSession]:
+        return [
+            s for s in sessions
+            if s.status == "completed"
+            and ((s.total_sets or 0) > 0 or (s.total_reps or 0) > 0)
+            and session_matches_plan(s, plan)
+        ]
+
+    recent_with_plan = next(
+        (
+            s for s in sessions
+            if s.status != "skipped" and any(session_matches_plan(s, plan) for plan in active_plans)
+        ),
+        None,
+    )
+
+    if recent_with_plan:
+        plan = next(
+            (p for p in active_plans if session_matches_plan(recent_with_plan, p)),
+            active_plans[0],
+        )
+    else:
+        plan = active_plans[0]
+
+    if not plan["days"]:
+        return None
+
+    completed_sessions = completed_sessions_for_plan(plan)
+    done_count = len(completed_sessions)
+    total_needed = plan["duration_weeks"] * len(plan["days"])
+    is_complete = done_count >= total_needed
+    next_day_idx = 0 if is_complete else done_count % len(plan["days"])
+    week_number = plan["duration_weeks"] if is_complete else (done_count // len(plan["days"])) + 1
+    day_number = next_day_idx + 1
+
+    return {
+        "plan": plan,
+        "day": plan["days"][next_day_idx],
+        "week_number": week_number,
+        "day_number": day_number,
+        "is_complete": is_complete,
+        "debug": {
+            "selected_plan_id": plan["id"],
+            "completed_session_count": done_count,
+            "total_sessions_needed": total_needed,
+            "recent_session_id": recent_with_plan.id if recent_with_plan else None,
+        },
+    }
+
+
 @router.get("/", response_model=list[WorkoutPlanResponse])
 async def list_plans(
     user: Annotated[User, Depends(get_current_user)],
@@ -68,6 +129,31 @@ async def list_plans(
     result = await db.execute(stmt.order_by(WorkoutPlan.created_at.desc()))
     plans = result.scalars().all()
     return [serialize_plan(p) for p in plans]
+
+
+@router.get("/next-workout")
+async def get_next_workout(
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict | None:
+    """Return the canonical next workout for the current user."""
+    plans_result = await db.execute(
+        select(WorkoutPlan)
+        .where(WorkoutPlan.user_id == user.id, WorkoutPlan.is_draft.is_(False))
+        .order_by(WorkoutPlan.created_at.desc())
+    )
+    plans = [serialize_plan(p) for p in plans_result.scalars().all()]
+    if not plans:
+        return None
+
+    sessions_result = await db.execute(
+        select(WorkoutSession)
+        .where(WorkoutSession.user_id == user.id)
+        .order_by(WorkoutSession.date.desc(), WorkoutSession.id.desc())
+    )
+    sessions = sessions_result.scalars().all()
+
+    return resolve_next_workout(sessions, plans)
 
 
 @router.get("/exercises/recent", response_model=list[dict])

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -250,6 +250,20 @@ export interface WorkoutPlan {
   is_archived: boolean;
 }
 
+export interface NextWorkoutResolution {
+  plan: WorkoutPlan;
+  day: PlannedDay;
+  week_number: number;
+  day_number: number;
+  is_complete: boolean;
+  debug: {
+    selected_plan_id: number;
+    completed_session_count: number;
+    total_sessions_needed: number;
+    recent_session_id: number | null;
+  };
+}
+
 export interface ProgressMetric {
   exercise_id: number;
   exercise_name: string;
@@ -457,6 +471,11 @@ export async function getRecommendations(daysBack: number = 30): Promise<Progres
 // Plans
 export async function getPlans(): Promise<WorkoutPlan[]> {
   const response = await api.get('/plans/');
+  return response.data;
+}
+
+export async function getNextWorkout(): Promise<NextWorkoutResolution | null> {
+  const response = await api.get('/plans/next-workout');
   return response.data;
 }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2,9 +2,9 @@
   import { onMount } from 'svelte';
   import { activeDietPhase, currentSession, settings, workoutPlans, nextWorkoutUrl } from '$lib/stores';
   import type { DashboardWidget } from '$lib/stores';
-  import { getSessions, archivePlan, getPlans, getDailySummary, getInsights, saveSettings } from '$lib/api';
+  import { getSessions, archivePlan, getPlans, getDailySummary, getInsights, getNextWorkout, saveSettings } from '$lib/api';
   import { localDateString } from '$lib/date';
-  import type { DailySummary, Insight, WorkoutPlan, PlannedDay, WorkoutSession } from '$lib/api';
+  import type { DailySummary, Insight, NextWorkoutResolution, WorkoutSession } from '$lib/api';
 
   const KG_TO_LBS = 2.20462;
   function volDisplay(kg: number): number {
@@ -14,23 +14,12 @@
     return $settings.weightUnit === 'lbs' ? 'lbs' : 'kg';
   }
 
-  interface NextWorkout {
-    plan: WorkoutPlan;
-    day: PlannedDay;
-    weekNumber: number;
-    dayNumber: number;
-    isComplete: boolean;
-  }
-
   let allSessions    = $state<WorkoutSession[]>([]);
   let loading        = $state(true);
   let archiving      = $state(false);
   let nutritionSummary = $state<DailySummary | null>(null);
   let insights = $state<Insight[]>([]);
-
-  let nextWorkout = $derived(
-    loading ? null : resolveNextWorkout(allSessions, $workoutPlans)
-  );
+  let nextWorkout = $state<NextWorkoutResolution | null>(null);
 
   let hasActiveCurrentSession = $derived(
     !!$currentSession && ($currentSession.status === 'in_progress' || !!$currentSession.started_at)
@@ -41,7 +30,7 @@
   $effect(() => {
     if (hasActiveCurrentSession) {
       nextWorkoutUrl.set('/workout/active');
-    } else if (nextWorkout && !nextWorkout.isComplete) {
+    } else if (nextWorkout && !nextWorkout.is_complete) {
       nextWorkoutUrl.set(`/workout/active?plan=${nextWorkout.plan.id}&day=${nextWorkout.day.day_number}`);
     } else {
       nextWorkoutUrl.set('/workout/active');
@@ -59,14 +48,16 @@
 
   onMount(async () => {
     try {
-      const [sessions, plans, nutrition, insightData] = await Promise.all([
+      const [sessions, plans, next, nutrition, insightData] = await Promise.all([
         getSessions({ limit: 200 }),
         getPlans(),
+        getNextWorkout().catch(() => null),
         getDailySummary(localDateString()).catch(() => null),
         getInsights().catch(() => []),
       ]);
       allSessions = sessions;
       workoutPlans.set(plans);
+      nextWorkout = next;
       nutritionSummary = nutrition;
       insights = insightData;
     } catch (e) {
@@ -76,52 +67,14 @@
     }
   });
 
-  function resolveNextWorkout(sessions: WorkoutSession[], plans: WorkoutPlan[]): NextWorkout | null {
-    const activePlans = plans.filter(p => !p.is_archived);
-    if (!activePlans.length) return null;
-
-    function sessionsForPlan(plan: WorkoutPlan) {
-      return sessions.filter(s =>
-        s.status === 'completed' &&
-        (s.total_sets > 0 || s.total_reps > 0) &&
-        (s.workout_plan_id === plan.id || (s.name && s.name.startsWith(plan.name + ' - ')))
-      );
-    }
-
-    let plan: WorkoutPlan;
-    const recentWithPlan = sessions.find(s =>
-      s.status !== 'skipped' && (
-        activePlans.some(p => p.id === s.workout_plan_id) ||
-        activePlans.some(p => s.name?.startsWith(p.name + ' - '))
-      )
-    );
-    if (recentWithPlan) {
-      plan = activePlans.find(p =>
-        p.id === recentWithPlan.workout_plan_id ||
-        recentWithPlan.name?.startsWith(p.name + ' - ')
-      ) ?? activePlans[0];
-    } else {
-      plan = activePlans[0];
-    }
-
-    if (!plan.days.length) return null;
-
-    const doneCount   = sessionsForPlan(plan).length;
-    const totalNeeded = plan.duration_weeks * plan.days.length;
-    const isComplete  = doneCount >= totalNeeded;
-    const nextDayIdx  = isComplete ? 0 : doneCount % plan.days.length;
-    const weekNumber  = isComplete ? plan.duration_weeks : Math.floor(doneCount / plan.days.length) + 1;
-    const dayNumber   = nextDayIdx + 1;
-    return { plan, day: plan.days[nextDayIdx], weekNumber, dayNumber, isComplete };
-  }
-
   async function handleArchive(planId: number) {
     archiving = true;
     try {
       await archivePlan(planId);
-      const [sessions, plans] = await Promise.all([getSessions({ limit: 200 }), getPlans()]);
+      const [sessions, plans, next] = await Promise.all([getSessions({ limit: 200 }), getPlans(), getNextWorkout().catch(() => null)]);
       allSessions = sessions;
       workoutPlans.set(plans);
+      nextWorkout = next;
     } catch (e) {
       console.error('Failed to archive plan:', e);
     } finally {
@@ -604,7 +557,7 @@
   {:else if loading}
     <div class="card h-28 animate-pulse bg-zinc-800/50"></div>
 
-  {:else if nextWorkout?.isComplete}
+  {:else if nextWorkout?.is_complete}
     <div class="card border border-amber-500/30"
          style="background: linear-gradient(135deg, rgba(217,119,6,0.15), rgba(0,0,0,0));">
       <div class="flex items-start justify-between gap-4">
@@ -650,10 +603,10 @@
           <h3 class="text-2xl font-bold truncate">{nextWorkout.day.day_name}</h3>
           <div class="flex items-center gap-2 mt-2 flex-wrap">
             <span class="badge bg-primary-900/60 text-primary-300 border border-primary-700/50">
-              Week {nextWorkout.weekNumber}
+              Week {nextWorkout.week_number}
             </span>
             <span class="badge bg-zinc-800 text-zinc-300">
-              Day {nextWorkout.dayNumber}
+              Day {nextWorkout.day_number}
             </span>
             <span class="text-xs text-zinc-500">
               {nextWorkout.day.exercises.length} exercise{nextWorkout.day.exercises.length !== 1 ? 's' : ''}

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2,7 +2,7 @@
 import pytest
 from httpx import AsyncClient
 
-from tests.conftest import create_exercise, create_plan
+from tests.conftest import create_exercise, create_plan, start_session_from_plan, log_set
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
 
@@ -92,6 +92,80 @@ class TestPlansCRUD:
         assert r.status_code == 200
         data = r.json()
         assert data["is_archived"] is True
+
+    async def test_next_workout_defaults_to_first_day(self, client: AsyncClient):
+        """GET /plans/next-workout returns day 1 when nothing is completed yet."""
+        ex = await create_exercise(client)
+        r = await client.post(
+            "/api/plans/",
+            json={
+                "name": "Two Day Plan",
+                "block_type": "hypertrophy",
+                "duration_weeks": 4,
+                "number_of_days": 2,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Monday",
+                        "exercises": [{"exercise_id": ex["id"], "sets": 3, "reps": 8, "starting_weight_kg": 0, "progression_type": "linear"}],
+                    },
+                    {
+                        "day_number": 2,
+                        "day_name": "Tuesday",
+                        "exercises": [{"exercise_id": ex["id"], "sets": 3, "reps": 8, "starting_weight_kg": 0, "progression_type": "linear"}],
+                    },
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+
+        next_r = await client.get("/api/plans/next-workout")
+        assert next_r.status_code == 200
+        data = next_r.json()
+        assert data["plan"]["name"] == "Two Day Plan"
+        assert data["day"]["day_name"] == "Monday"
+        assert data["day_number"] == 1
+        assert data["week_number"] == 1
+        assert data["is_complete"] is False
+
+    async def test_next_workout_advances_after_completed_day(self, client: AsyncClient):
+        """GET /plans/next-workout advances to the next day after a completion."""
+        ex = await create_exercise(client)
+        r = await client.post(
+            "/api/plans/",
+            json={
+                "name": "Two Day Plan",
+                "block_type": "hypertrophy",
+                "duration_weeks": 4,
+                "number_of_days": 2,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Monday",
+                        "exercises": [{"exercise_id": ex["id"], "sets": 1, "reps": 8, "starting_weight_kg": 0, "progression_type": "linear"}],
+                    },
+                    {
+                        "day_number": 2,
+                        "day_name": "Tuesday",
+                        "exercises": [{"exercise_id": ex["id"], "sets": 1, "reps": 8, "starting_weight_kg": 0, "progression_type": "linear"}],
+                    },
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+        plan = r.json()
+
+        sess = await start_session_from_plan(client, plan["id"], day=1)
+        await log_set(client, sess["id"], sess["sets"][0]["id"], 100.0, 8)
+        complete_r = await client.post(f"/api/sessions/{sess['id']}/complete")
+        assert complete_r.status_code == 200, complete_r.text
+
+        next_r = await client.get("/api/plans/next-workout")
+        assert next_r.status_code == 200
+        data = next_r.json()
+        assert data["day"]["day_name"] == "Tuesday"
+        assert data["day_number"] == 2
+        assert data["week_number"] == 1
 
     async def test_reuse_plan(self, client: AsyncClient):
         """POST /plans/{id}/reuse creates new unarchived copy."""


### PR DESCRIPTION
Closes #584\n\n## Summary\n- add a backend endpoint that resolves the canonical next workout from plan and session state\n- return debug metadata explaining why that workout was selected\n- switch the web dashboard to use the server response instead of duplicating the resolver logic locally\n- add backend tests covering default day selection and advancement after a completed day\n\n## Testing\n- ./venv/bin/python -m pytest tests/test_plans.py -k next_workout -vv\n- git diff --check -- app/api/plans.py frontend/src/lib/api.ts frontend/src/routes/+page.svelte tests/test_plans.py