### PR TITLE
feat: add settings sync metadata

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,6 +1,7 @@
 """Authentication API — register, login, refresh, current user, and settings."""
 
 import json
+from datetime import UTC, datetime
 from typing import Annotated
 
 import jwt
@@ -216,6 +217,18 @@ async def save_settings(
 ) -> dict:
     """Save the user's app settings to the database."""
     body = await request.json()
+    incoming_meta = body.get("settingsMeta") if isinstance(body.get("settingsMeta"), dict) else {}
+    source_device = (
+        request.headers.get("X-Client-Name")
+        or incoming_meta.get("source_device")
+        or "web"
+    )
+    body["settingsMeta"] = {
+        "schema_version": 1,
+        "updated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "updated_by": user.username,
+        "source_device": source_device,
+    }
     user.settings_json = json.dumps(body)
     await db.flush()
     return body

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -140,7 +140,9 @@ export async function getSettings(): Promise<Record<string, any>> {
 }
 
 export async function saveSettings(settings: Record<string, any>): Promise<void> {
-  await api.put('/auth/settings', settings);
+  await api.put('/auth/settings', settings, {
+    headers: { 'X-Client-Name': 'web' },
+  });
 }
 
 export function getStoredUser(): AuthUser | null {

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -40,6 +40,13 @@ export interface DashboardWidget {
   enabled: boolean;
 }
 
+export interface SettingsMeta {
+  updated_at: string | null;
+  updated_by: string | null;
+  source_device: string | null;
+  schema_version: number;
+}
+
 export interface DeloadSettings {
   sessions: number;         // how many deload sessions (1-7, 0 = match plan days)
   weightPercent: number;    // % of working weight (50-90, default 70)
@@ -60,6 +67,7 @@ export interface AppSettings {
   deload: DeloadSettings;
   progression: ProgressionSettings;
   dashboardWidgets: DashboardWidget[];
+  settingsMeta?: SettingsMeta;
 }
 
 const SETTINGS_KEY = 'hgt_settings';
@@ -135,6 +143,12 @@ const defaultSettings: AppSettings = {
     minRepsForIncrease: 8,
     maxRepsForIncrease: 12,
   },
+  settingsMeta: {
+    updated_at: null,
+    updated_by: null,
+    source_device: null,
+    schema_version: 1,
+  },
 };
 
 function deepMergeSettings(stored: any): AppSettings {
@@ -155,6 +169,7 @@ function deepMergeSettings(stored: any): AppSettings {
     deload: { ...defaultSettings.deload, ...(stored.deload ?? {}) },
     progression: { ...defaultSettings.progression, ...(stored.progression ?? {}) },
     dashboardWidgets: mergedWidgets,
+    settingsMeta: { ...defaultSettings.settingsMeta, ...(stored.settingsMeta ?? {}) },
   };
 }
 
@@ -177,35 +192,57 @@ function hasSettingValue(value: unknown): boolean {
 // Debounce timer for DB saves
 let dbSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
+function withSettingsMeta(value: AppSettings): AppSettings {
+  return {
+    ...value,
+    settingsMeta: {
+      schema_version: 1,
+      updated_at: new Date().toISOString(),
+      updated_by: typeof localStorage !== 'undefined'
+        ? JSON.parse(localStorage.getItem('hgt_user') ?? 'null')?.username ?? null
+        : null,
+      source_device: 'web',
+    },
+  };
+}
+
+function isLocalNewer(local: any, remote: any): boolean {
+  const localTs = local?.settingsMeta?.updated_at ? Date.parse(local.settingsMeta.updated_at) : NaN;
+  const remoteTs = remote?.settingsMeta?.updated_at ? Date.parse(remote.settingsMeta.updated_at) : NaN;
+  if (Number.isNaN(localTs)) return false;
+  if (Number.isNaN(remoteTs)) return true;
+  return localTs > remoteTs;
+}
+
 function createSettingsStore() {
   const { subscribe, set, update } = writable<AppSettings>(loadSettings());
 
   function persist(value: AppSettings) {
+    const withMeta = withSettingsMeta(value);
     // Always save to localStorage (instant, offline-capable)
     if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(SETTINGS_KEY, JSON.stringify(value));
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify(withMeta));
     }
     // Debounce save to DB (500ms) — avoids hammering API on rapid changes
     if (dbSaveTimer) clearTimeout(dbSaveTimer);
     dbSaveTimer = setTimeout(async () => {
       try {
         const { saveSettings } = await import('$lib/api');
-        await saveSettings(value);
+        await saveSettings(withMeta);
       } catch { /* offline or not logged in — localStorage has it */ }
     }, 500);
+    return withMeta;
   }
 
   return {
     subscribe,
     set(value: AppSettings) {
-      persist(value);
-      set(value);
+      set(persist(value));
     },
     update(fn: (s: AppSettings) => AppSettings) {
       update(s => {
         const next = fn(s);
-        persist(next);
-        return next;
+        return persist(next);
       });
     },
     /** Load settings from DB (call after login) */
@@ -214,17 +251,22 @@ function createSettingsStore() {
         const { getSettings } = await import('$lib/api');
         const remote = await getSettings();
         if (remote && Object.keys(remote).length > 0) {
-          const merged = deepMergeSettings(remote);
+          let merged = deepMergeSettings(remote);
           let shouldBackfillRemote = false;
 
           if (typeof localStorage !== 'undefined') {
             try {
               const local = JSON.parse(localStorage.getItem(SETTINGS_KEY) ?? '{}');
-              if (!hasSettingValue(remote.dashboardWidgets) && hasSettingValue(local.dashboardWidgets)) {
+              if (isLocalNewer(local, remote)) {
+                merged = deepMergeSettings(local);
+                shouldBackfillRemote = true;
+              } else if (!hasSettingValue(remote.dashboardWidgets) && hasSettingValue(local.dashboardWidgets)) {
                 merged.dashboardWidgets = local.dashboardWidgets;
                 shouldBackfillRemote = true;
-              }
-              if (!hasSettingValue(remote.branchPreference) && hasSettingValue(local.branchPreference)) {
+                if (!hasSettingValue(remote.branchPreference) && hasSettingValue(local.branchPreference)) {
+                  merged.branchPreference = local.branchPreference;
+                }
+              } else if (!hasSettingValue(remote.branchPreference) && hasSettingValue(local.branchPreference)) {
                 merged.branchPreference = local.branchPreference;
                 shouldBackfillRemote = true;
               }

--- a/tests/test_settings_sync.py
+++ b/tests/test_settings_sync.py
@@ -1,0 +1,29 @@
+"""Tests for settings metadata and sync behavior."""
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+class TestSettingsSync:
+    async def test_save_settings_stamps_metadata(self, client: AsyncClient):
+        r = await client.put("/api/auth/settings", json={
+            "weightUnit": "lbs",
+            "branchPreference": "dev",
+        })
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["weightUnit"] == "lbs"
+        assert data["settingsMeta"]["schema_version"] == 1
+        assert data["settingsMeta"]["updated_by"] == "testrunner"
+        assert data["settingsMeta"]["source_device"] == "web"
+        assert data["settingsMeta"]["updated_at"].endswith("Z")
+
+    async def test_save_settings_prefers_explicit_client_name_header(self, client: AsyncClient):
+        r = await client.put(
+            "/api/auth/settings",
+            headers={"X-Client-Name": "ios"},
+            json={"weightUnit": "kg"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["settingsMeta"]["source_device"] == "ios"


### PR DESCRIPTION
Closes #582\n\n## Summary\n- stamp synced settings with metadata including updated_at, updated_by, source_device, and schema_version\n- have the web client prefer the newer local vs remote settings payload by metadata timestamp instead of blindly replacing state\n- send an explicit client name from the web settings save path\n- add focused backend tests for settings metadata stamping\n\n## Testing\n- ./venv/bin/python -m pytest tests/test_settings_sync.py -vv\n- git diff --check -- frontend/src/lib/stores.ts frontend/src/lib/api.ts app/api/auth.py tests/test_settings_sync.py