### PR TITLE
feat: add session repair tool

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -240,6 +240,47 @@ async def complete_session(
     return serialize_session(workout_session)
 
 
+@router.post("/{session_id}/reset-to-planned", response_model=WorkoutSessionResponse)
+async def reset_session_to_planned(
+    session_id: int,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Reset a session back to a clean planned state for repair/debug workflows."""
+    workout_session = await _get_session_with_sets(db, session_id, user_id=user.id)
+    if not workout_session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Workout session {session_id} not found",
+        )
+
+    workout_session.status = WorkoutStatus.PLANNED
+    workout_session.started_at = None
+    workout_session.completed_at = None
+    workout_session.total_volume_kg = 0
+    workout_session.total_sets = 0
+    workout_session.total_reps = 0
+    workout_session.duration_minutes = None
+
+    for exercise_set in workout_session.sets:
+        exercise_set.actual_reps = None
+        exercise_set.actual_weight_kg = None
+        exercise_set.reps_left = None
+        exercise_set.reps_right = None
+        exercise_set.started_at = None
+        exercise_set.completed_at = None
+        exercise_set.skipped_at = None
+        exercise_set.sub_sets = None
+        exercise_set.draft_weight_kg = None
+        exercise_set.draft_reps = None
+        exercise_set.draft_reps_left = None
+        exercise_set.draft_reps_right = None
+
+    await db.flush()
+    workout_session = await _get_session_with_sets(db, workout_session.id, user_id=user.id)
+    return serialize_session(workout_session)
+
+
 @router.patch("/{session_id}", response_model=WorkoutSessionResponse)
 async def update_session(
     session_id: int,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -326,12 +326,19 @@ export async function completeSession(sessionId: number): Promise<WorkoutSession
   return response.data;
 }
 
+export async function resetSessionToPlanned(sessionId: number): Promise<WorkoutSession> {
+  const response = await api.post(`/sessions/${sessionId}/reset-to-planned`);
+  return response.data;
+}
+
 export async function patchSession(sessionId: number, data: { notes?: string; name?: string }): Promise<WorkoutSession> {
   const response = await api.patch(`/sessions/${sessionId}`, data);
   return response.data;
 }
 
-export async function syncSessionToPlan(sessionId: number): Promise<{ updated: number }> {
+export async function syncSessionToPlan(
+  sessionId: number
+): Promise<{ updated: number; structural_changes?: number }> {
   const response = await api.post(`/sessions/${sessionId}/sync-to-plan`);
   return response.data;
 }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -171,14 +171,16 @@
 
   let recentSessions = $derived(allSessions.filter(s => s.status === 'completed').slice(0, 5));
   let nextWorkoutInspectorSessions = $derived(
-    nextWorkout
-      ? allSessions
-          .filter(s =>
-            s.workout_plan_id === nextWorkout.plan.id ||
-            (s.name && s.name.startsWith(`${nextWorkout.plan.name} - `))
-          )
-          .slice(0, 6)
-      : []
+    (() => {
+      const activeNextWorkout = nextWorkout;
+      if (!activeNextWorkout) return [];
+      return allSessions
+        .filter(s =>
+          s.workout_plan_id === activeNextWorkout.plan.id ||
+          (s.name && s.name.startsWith(`${activeNextWorkout.plan.name} - `))
+        )
+        .slice(0, 6);
+    })()
   );
 
   // Last completed session with a plan — for "Repeat Last" button
@@ -556,7 +558,7 @@
       <div class="p-5 flex items-center justify-between gap-4">
         <div>
           <p class="text-xs font-bold uppercase tracking-widest text-primary-400 mb-1">▶ Continue Workout</p>
-          <h3 class="text-xl font-bold text-white">{$currentSession.name ?? 'Workout'}</h3>
+          <h3 class="text-xl font-bold text-white">{$currentSession?.name ?? 'Workout'}</h3>
           <p class="text-sm text-zinc-400 mt-1">Resume where you left off</p>
         </div>
         <div class="w-14 h-14 rounded-2xl bg-primary-600/30 border border-primary-500/40

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -909,6 +909,18 @@
           Update Now
         </button>
       </div>
+      <div class="flex items-center justify-between pt-2 border-t border-zinc-800">
+        <div>
+          <p class="text-sm text-zinc-300">Session repair tool</p>
+          <p class="text-xs text-zinc-500">Inspect and repair bad planned or in-progress workout state</p>
+        </div>
+        <a
+          href="/settings/session-repair"
+          class="px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-zinc-800 text-zinc-200 hover:bg-zinc-700"
+        >
+          Open
+        </a>
+      </div>
     </div>
   {/if}
 

--- a/frontend/src/routes/settings/session-repair/+page.svelte
+++ b/frontend/src/routes/settings/session-repair/+page.svelte
@@ -1,0 +1,228 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { deleteSession, getSessions, resetSessionToPlanned, type WorkoutSession } from '$lib/api';
+
+  let sessions = $state<WorkoutSession[]>([]);
+  let loading = $state(true);
+  let error = $state('');
+  let expandedSessionId = $state<number | null>(null);
+  let workingSessionId = $state<number | null>(null);
+
+  function fmtDate(iso: string): string {
+    return new Date(`${iso}T00:00:00`).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  function fmtTimestamp(value: string | null): string {
+    if (!value) return '—';
+    return new Date(value).toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+  }
+
+  function setCount(session: WorkoutSession): number {
+    return session.sets?.length ?? 0;
+  }
+
+  function completedSetCount(session: WorkoutSession): number {
+    return session.sets?.filter((set) => !!set.completed_at && !set.skipped_at).length ?? 0;
+  }
+
+  async function loadSessions() {
+    loading = true;
+    error = '';
+    try {
+      sessions = await getSessions({ limit: 50 });
+    } catch (err) {
+      console.error('Failed to load sessions for repair tool', err);
+      error = 'Failed to load recent sessions.';
+    } finally {
+      loading = false;
+    }
+  }
+
+  onMount(loadSessions);
+
+  async function handleReset(sessionId: number) {
+    if (!confirm(`Reset session ${sessionId} back to planned? This clears logged sets and draft values.`)) return;
+    workingSessionId = sessionId;
+    error = '';
+    try {
+      const updated = await resetSessionToPlanned(sessionId);
+      sessions = sessions.map((session) => session.id === sessionId ? updated : session);
+    } catch (err) {
+      console.error('Failed to reset session', err);
+      error = `Failed to reset session ${sessionId}.`;
+    } finally {
+      workingSessionId = null;
+    }
+  }
+
+  async function handleDelete(sessionId: number) {
+    if (!confirm(`Delete session ${sessionId}? This cannot be undone.`)) return;
+    workingSessionId = sessionId;
+    error = '';
+    try {
+      await deleteSession(sessionId);
+      sessions = sessions.filter((session) => session.id !== sessionId);
+      if (expandedSessionId === sessionId) expandedSessionId = null;
+    } catch (err) {
+      console.error('Failed to delete session', err);
+      error = `Failed to delete session ${sessionId}.`;
+    } finally {
+      workingSessionId = null;
+    }
+  }
+</script>
+
+<svelte:head>
+  <title>Session Repair</title>
+</svelte:head>
+
+<div class="space-y-4">
+  <div class="card space-y-2">
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <a href="/settings" class="text-xs text-zinc-500 hover:text-zinc-300 transition-colors">← Back to Settings</a>
+        <h1 class="text-2xl font-bold mt-2">Session Repair</h1>
+        <p class="text-sm text-zinc-400">
+          Inspect recent workout sessions and repair bad state without direct SQL.
+        </p>
+      </div>
+      <button
+        onclick={loadSessions}
+        class="px-3 py-2 rounded-lg text-sm font-medium bg-zinc-800 text-zinc-200 hover:bg-zinc-700 transition-colors"
+      >
+        Refresh
+      </button>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 pt-2">
+      <div class="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+        <p class="text-xs uppercase tracking-wide text-zinc-500">Loaded</p>
+        <p class="text-lg font-semibold">{sessions.length}</p>
+      </div>
+      <div class="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+        <p class="text-xs uppercase tracking-wide text-zinc-500">In Progress</p>
+        <p class="text-lg font-semibold">{sessions.filter((session) => session.status === 'in_progress').length}</p>
+      </div>
+      <div class="rounded-xl border border-zinc-800 bg-zinc-900/60 p-3">
+        <p class="text-xs uppercase tracking-wide text-zinc-500">Planned With Data</p>
+        <p class="text-lg font-semibold">{sessions.filter((session) => session.status === 'planned' && (session.total_sets > 0 || session.total_reps > 0)).length}</p>
+      </div>
+    </div>
+    {#if error}
+      <p class="text-sm text-red-400">{error}</p>
+    {/if}
+  </div>
+
+  {#if loading}
+    <div class="card text-sm text-zinc-400">Loading recent sessions...</div>
+  {:else if !sessions.length}
+    <div class="card text-sm text-zinc-400">No sessions found.</div>
+  {:else}
+    <div class="space-y-3">
+      {#each sessions as session (session.id)}
+        <div class="card space-y-3">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div class="space-y-1">
+              <div class="flex flex-wrap items-center gap-2">
+                <h2 class="text-lg font-semibold">{session.name || `Session ${session.id}`}</h2>
+                <span class="px-2 py-0.5 rounded-full text-xs font-medium border border-zinc-700 bg-zinc-900/70 text-zinc-300">
+                  {session.status}
+                </span>
+              </div>
+              <p class="text-sm text-zinc-400">
+                Session #{session.id} · {fmtDate(session.date)} · Plan {session.workout_plan_id ?? '—'}
+              </p>
+              <p class="text-xs text-zinc-500">
+                {completedSetCount(session)}/{setCount(session)} completed sets · totals {session.total_sets} sets / {session.total_reps} reps
+              </p>
+              <p class="text-xs text-zinc-500">
+                Started {fmtTimestamp(session.started_at)} · Completed {fmtTimestamp(session.completed_at)}
+              </p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                onclick={() => expandedSessionId = expandedSessionId === session.id ? null : session.id}
+                class="px-3 py-2 rounded-lg text-sm font-medium bg-zinc-800 text-zinc-200 hover:bg-zinc-700 transition-colors"
+              >
+                {expandedSessionId === session.id ? 'Hide Details' : 'Inspect'}
+              </button>
+              <button
+                onclick={() => handleReset(session.id)}
+                disabled={workingSessionId === session.id}
+                class="px-3 py-2 rounded-lg text-sm font-medium bg-amber-500/10 text-amber-300 border border-amber-500/20 hover:bg-amber-500/20 disabled:opacity-50 transition-colors"
+              >
+                Reset to Planned
+              </button>
+              <button
+                onclick={() => handleDelete(session.id)}
+                disabled={workingSessionId === session.id}
+                class="px-3 py-2 rounded-lg text-sm font-medium bg-red-500/10 text-red-300 border border-red-500/20 hover:bg-red-500/20 disabled:opacity-50 transition-colors"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+
+          {#if expandedSessionId === session.id}
+            <div class="rounded-xl border border-zinc-800 bg-zinc-900/60 overflow-hidden">
+              <div class="grid grid-cols-[64px_minmax(0,1fr)_100px_100px_100px] gap-3 px-4 py-2 text-xs uppercase tracking-wide text-zinc-500 border-b border-zinc-800">
+                <div>Set</div>
+                <div>Exercise</div>
+                <div>Planned</div>
+                <div>Actual</div>
+                <div>State</div>
+              </div>
+              {#each session.sets as set}
+                <div class="grid grid-cols-[64px_minmax(0,1fr)_100px_100px_100px] gap-3 px-4 py-3 text-sm border-b border-zinc-900 last:border-b-0">
+                  <div class="text-zinc-400">#{set.set_number}</div>
+                  <div class="min-w-0">
+                    <p class="truncate">{set.exercise_name || `Exercise ${set.exercise_id}`}</p>
+                    {#if set.draft_weight_kg !== null || set.draft_reps !== null || set.draft_reps_left !== null || set.draft_reps_right !== null}
+                      <p class="text-xs text-amber-400">
+                        Draft:
+                        {#if set.draft_weight_kg !== null}{set.draft_weight_kg}kg {/if}
+                        {#if set.draft_reps !== null}{set.draft_reps} reps{/if}
+                        {#if set.draft_reps_left !== null || set.draft_reps_right !== null}
+                          {set.draft_reps_left ?? 0}L/{set.draft_reps_right ?? 0}R
+                        {/if}
+                      </p>
+                    {/if}
+                  </div>
+                  <div class="text-zinc-400">
+                    {set.planned_weight_kg ?? '—'}kg
+                    <br />
+                    {set.planned_reps ?? '—'} reps
+                  </div>
+                  <div class="text-zinc-300">
+                    {set.actual_weight_kg ?? '—'}kg
+                    <br />
+                    {set.actual_reps ?? (set.reps_left !== null || set.reps_right !== null ? `${set.reps_left ?? 0}/${set.reps_right ?? 0}` : '—')}
+                  </div>
+                  <div class="text-zinc-400">
+                    {#if set.completed_at}
+                      <span class="text-green-400">Completed</span>
+                    {:else if set.started_at}
+                      <span class="text-blue-400">Started</span>
+                    {:else if set.skipped_at}
+                      <span class="text-zinc-500">Skipped</span>
+                    {:else}
+                      <span>Planned</span>
+                    {/if}
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -246,3 +246,44 @@ class TestSessionLifecycle:
         set_id = sess1["sets"][0]["id"]
         r = await client.delete(f"/api/sessions/{sess2['id']}/sets/{set_id}")
         assert r.status_code == 404
+
+    async def test_reset_session_to_planned_clears_progress_and_drafts(self, client: AsyncClient):
+        """Resetting a session should clear started/completed state and set progress."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+        set_id = sess["sets"][0]["id"]
+
+        r = await client.patch(
+            f"/api/sessions/{sess['id']}/sets/{set_id}",
+            json={
+                "actual_weight_kg": 100.0,
+                "actual_reps": 8,
+                "draft_weight_kg": 95.0,
+                "draft_reps": 9,
+                "started_at": "2024-01-01T09:00:00",
+                "completed_at": "2024-01-01T10:00:00",
+            },
+        )
+        assert r.status_code == 200
+
+        r2 = await client.post(f"/api/sessions/{sess['id']}/reset-to-planned")
+        assert r2.status_code == 200
+        data = r2.json()
+        assert data["status"] == "planned"
+        assert data["started_at"] is None
+        assert data["completed_at"] is None
+        assert data["total_volume_kg"] == 0
+        assert data["total_sets"] == 0
+        assert data["total_reps"] == 0
+        assert data["sets"][0]["actual_weight_kg"] is None
+        assert data["sets"][0]["actual_reps"] is None
+        assert data["sets"][0]["draft_weight_kg"] is None
+        assert data["sets"][0]["draft_reps"] is None
+        assert data["sets"][0]["started_at"] is None
+        assert data["sets"][0]["completed_at"] is None
+
+    async def test_reset_session_to_planned_not_found(self, client: AsyncClient):
+        """Resetting an unknown session should return 404."""
+        r = await client.post("/api/sessions/999999/reset-to-planned")
+        assert r.status_code == 404


### PR DESCRIPTION
Closes #587

## Summary
- add a session repair page under Settings > Developer for inspecting and repairing recent sessions
- add a backend reset-to-planned endpoint that clears logged set progress and draft values
- add targeted session reset tests and clean up related frontend type mismatches discovered during validation

## Testing
- ./venv/bin/python -m pytest tests/test_sessions.py -k 'reset_session_to_planned or delete_set_wrong_session' -vv
- cd frontend && timeout 30s ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
- git diff --check -- app/api/sessions.py frontend/src/lib/api.ts frontend/src/routes/+page.svelte frontend/src/routes/settings/+page.svelte frontend/src/routes/settings/session-repair/+page.svelte tests/test_sessions.py
