### PR TITLE
fix: remove no-data weigh-in suggestion

### DIFF
--- a/app/services/diet_phase.py
+++ b/app/services/diet_phase.py
@@ -176,7 +176,7 @@ def weekly_adjustment(
     Returns {status, actual_rate_pct, suggestion, cal_adjustment}.
     """
     if current_avg is None or previous_avg is None or previous_avg <= 0:
-        return {"status": "no_data", "actual_rate_pct": None, "suggestion": "Log more weigh-ins for tracking.", "cal_adjustment": 0}
+        return {"status": "no_data", "actual_rate_pct": None, "suggestion": None, "cal_adjustment": 0}
 
     # Actual weekly rate of change (% of body weight)
     change_kg = previous_avg - current_avg  # positive = weight loss

--- a/tests/test_diet_phase.py
+++ b/tests/test_diet_phase.py
@@ -1,0 +1,15 @@
+from app.services.diet_phase import weekly_adjustment
+
+
+def test_weekly_adjustment_no_data_has_no_suggestion():
+    result = weekly_adjustment(
+        current_avg=None,
+        previous_avg=None,
+        phase_type="cut",
+        target_rate_pct=0.7,
+    )
+
+    assert result["status"] == "no_data"
+    assert result["actual_rate_pct"] is None
+    assert result["suggestion"] is None
+    assert result["cal_adjustment"] == 0


### PR DESCRIPTION
Closes #605

## Summary
- stop returning a no-data diet-phase suggestion when there are not enough weigh-ins
- remove the stray "Log more weigh-ins for tracking" prompt from the web nutrition phase card
- add a focused regression test for the no-data adjustment case

## Testing
- ./venv/bin/python -m pytest tests/test_diet_phase.py -vv
- git diff --check -- app/services/diet_phase.py tests/test_diet_phase.py
