### PR TITLE
feat: add workout session audit trail

### DIFF
--- a/alembic/versions/1f2e3d4c5b6a_add_workout_session_audit_table.py
+++ b/alembic/versions/1f2e3d4c5b6a_add_workout_session_audit_table.py
@@ -1,0 +1,45 @@
+"""add workout session audit table
+
+Revision ID: 1f2e3d4c5b6a
+Revises: f70bebb5a18c
+Create Date: 2026-03-30 11:48:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1f2e3d4c5b6a"
+down_revision: str | None = "f70bebb5a18c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workout_session_audit",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("workout_session_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("from_status", sa.String(length=20), nullable=True),
+        sa.Column("to_status", sa.String(length=20), nullable=True),
+        sa.Column("reason", sa.String(length=100), nullable=False),
+        sa.Column("endpoint", sa.String(length=100), nullable=False),
+        sa.Column("actor_username", sa.String(length=50), nullable=True),
+        sa.Column("source_device", sa.String(length=50), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["workout_session_id"], ["workout_sessions.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_workout_session_audit_created_at", "workout_session_audit", ["created_at"], unique=False)
+    op.create_index("ix_workout_session_audit_session", "workout_session_audit", ["workout_session_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workout_session_audit_session", table_name="workout_session_audit")
+    op.drop_index("ix_workout_session_audit_created_at", table_name="workout_session_audit")
+    op.drop_table("workout_session_audit")

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -4,7 +4,7 @@ import json
 from datetime import date, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -13,12 +13,13 @@ from app.api.auth import get_current_user
 from app.database import get_db
 from app.models.exercise import Exercise
 from app.models.user import User
-from app.models.workout import ExerciseFeedback, ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutStatus
+from app.models.workout import ExerciseFeedback, ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutSessionAudit, WorkoutStatus
 from app.services.progression import compute_overload
 from app.schemas.requests import (
     SetCreate,
     SetResponse,
     SetUpdate,
+    WorkoutSessionAuditResponse,
     WorkoutSessionCreate,
     WorkoutSessionResponse,
 )
@@ -93,6 +94,20 @@ def serialize_session(workout_session: WorkoutSession) -> dict:
     }
 
 
+def serialize_session_audit(entry: WorkoutSessionAudit) -> dict:
+    return {
+        "id": entry.id,
+        "workout_session_id": entry.workout_session_id,
+        "from_status": entry.from_status,
+        "to_status": entry.to_status,
+        "reason": entry.reason,
+        "endpoint": entry.endpoint,
+        "actor_username": entry.actor_username,
+        "source_device": entry.source_device,
+        "created_at": entry.created_at,
+    }
+
+
 def _set_total_reps(exercise_set: ExerciseSet) -> int:
     if exercise_set.actual_reps is not None:
         return exercise_set.actual_reps
@@ -101,6 +116,29 @@ def _set_total_reps(exercise_set: ExerciseSet) -> int:
 
 def _set_total_volume_kg(exercise_set: ExerciseSet) -> float:
     return _set_total_reps(exercise_set) * (exercise_set.actual_weight_kg or 0)
+
+
+async def record_session_audit(
+    db: AsyncSession,
+    session: WorkoutSession,
+    *,
+    from_status: WorkoutStatus | str | None,
+    to_status: WorkoutStatus | str | None,
+    reason: str,
+    endpoint: str,
+    actor_username: str | None,
+    source_device: str | None,
+) -> None:
+    db.add(WorkoutSessionAudit(
+        workout_session_id=session.id,
+        user_id=session.user_id or 0,
+        from_status=str(from_status.value if isinstance(from_status, WorkoutStatus) else from_status) if from_status is not None else None,
+        to_status=str(to_status.value if isinstance(to_status, WorkoutStatus) else to_status) if to_status is not None else None,
+        reason=reason,
+        endpoint=endpoint,
+        actor_username=actor_username,
+        source_device=source_device,
+    ))
 
 
 @router.get("/", response_model=list[WorkoutSessionResponse])
@@ -131,6 +169,7 @@ async def create_session(
     session_data: WorkoutSessionCreate,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
 ) -> dict:
     """Create a new workout session."""
     workout_session = WorkoutSession(
@@ -142,6 +181,16 @@ async def create_session(
     )
     db.add(workout_session)
     await db.flush()
+    await record_session_audit(
+        db,
+        workout_session,
+        from_status=None,
+        to_status=workout_session.status,
+        reason="session_created",
+        endpoint=request.url.path,
+        actor_username=user.username,
+        source_device=request.headers.get("X-Client-Name") or "web",
+    )
     workout_session = await _get_session_with_sets(db, workout_session.id, user_id=user.id)
     return serialize_session(workout_session)
 
@@ -173,6 +222,7 @@ async def start_session(
     session_id: int,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
 ) -> dict:
     """Start a workout session."""
     result = await db.execute(
@@ -206,8 +256,19 @@ async def start_session(
             },
         )
 
+    prior_status = workout_session.status
     workout_session.status = WorkoutStatus.IN_PROGRESS
     workout_session.started_at = datetime.utcnow()
+    await record_session_audit(
+        db,
+        workout_session,
+        from_status=prior_status,
+        to_status=workout_session.status,
+        reason="session_started",
+        endpoint=request.url.path,
+        actor_username=user.username,
+        source_device=request.headers.get("X-Client-Name") or "web",
+    )
     await db.flush()
     workout_session = await _get_session_with_sets(db, workout_session.id, user_id=user.id)
     return serialize_session(workout_session)
@@ -218,6 +279,7 @@ async def complete_session(
     session_id: int,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
 ) -> dict:
     """Complete a workout session."""
     result = await db.execute(
@@ -233,8 +295,19 @@ async def complete_session(
             detail=f"Workout session {session_id} not found",
         )
 
+    prior_status = workout_session.status
     workout_session.status = WorkoutStatus.COMPLETED
     workout_session.completed_at = datetime.utcnow()
+    await record_session_audit(
+        db,
+        workout_session,
+        from_status=prior_status,
+        to_status=workout_session.status,
+        reason="session_completed",
+        endpoint=request.url.path,
+        actor_username=user.username,
+        source_device=request.headers.get("X-Client-Name") or "web",
+    )
     await db.flush()
     workout_session = await _get_session_with_sets(db, workout_session.id, user_id=user.id)
     return serialize_session(workout_session)
@@ -245,6 +318,7 @@ async def reset_session_to_planned(
     session_id: int,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
 ) -> dict:
     """Reset a session back to a clean planned state for repair/debug workflows."""
     workout_session = await _get_session_with_sets(db, session_id, user_id=user.id)
@@ -254,6 +328,7 @@ async def reset_session_to_planned(
             detail=f"Workout session {session_id} not found",
         )
 
+    prior_status = workout_session.status
     workout_session.status = WorkoutStatus.PLANNED
     workout_session.started_at = None
     workout_session.completed_at = None
@@ -276,6 +351,16 @@ async def reset_session_to_planned(
         exercise_set.draft_reps_left = None
         exercise_set.draft_reps_right = None
 
+    await record_session_audit(
+        db,
+        workout_session,
+        from_status=prior_status,
+        to_status=workout_session.status,
+        reason="session_reset_to_planned",
+        endpoint=request.url.path,
+        actor_username=user.username,
+        source_device=request.headers.get("X-Client-Name") or "web",
+    )
     await db.flush()
     workout_session = await _get_session_with_sets(db, workout_session.id, user_id=user.id)
     return serialize_session(workout_session)
@@ -557,6 +642,7 @@ async def update_set(
     )
     session = session_result.scalar_one_or_none()
     if session:
+        prior_status = session.status
         # Recalculate totals from all sets
         all_sets_result = await db.execute(
             select(ExerciseSet).where(ExerciseSet.workout_session_id == session_id)
@@ -566,9 +652,60 @@ async def update_set(
         session.total_reps = sum(_set_total_reps(s) for s in all_sets)
         session.total_volume_kg = sum(_set_total_volume_kg(s) for s in all_sets)
 
+        has_completed_sets = any(s.completed_at is not None and s.skipped_at is None for s in all_sets)
+        if has_completed_sets and session.status == WorkoutStatus.PLANNED:
+            session.status = WorkoutStatus.IN_PROGRESS
+            session.started_at = session.started_at or datetime.utcnow()
+            await record_session_audit(
+                db,
+                session,
+                from_status=prior_status,
+                to_status=session.status,
+                reason="first_set_completed",
+                endpoint=f"/api/sessions/{session_id}/sets/{set_id}",
+                actor_username=user.username,
+                source_device="web",
+            )
+        elif not has_completed_sets and session.status == WorkoutStatus.IN_PROGRESS and session.completed_at is None:
+            session.status = WorkoutStatus.PLANNED
+            session.started_at = None
+            await record_session_audit(
+                db,
+                session,
+                from_status=prior_status,
+                to_status=session.status,
+                reason="last_completed_set_removed",
+                endpoint=f"/api/sessions/{session_id}/sets/{set_id}",
+                actor_username=user.username,
+                source_device="web",
+            )
+
     await db.flush()
     await db.refresh(exercise_set)
     return serialize_set(exercise_set)
+
+
+@router.get("/{session_id}/audit", response_model=list[WorkoutSessionAuditResponse])
+async def get_session_audit(
+    session_id: int,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[dict]:
+    session = await _get_session_with_sets(db, session_id, user_id=user.id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Workout session {session_id} not found",
+        )
+    result = await db.execute(
+        select(WorkoutSessionAudit)
+        .where(
+            WorkoutSessionAudit.workout_session_id == session_id,
+            WorkoutSessionAudit.user_id == user.id,
+        )
+        .order_by(desc(WorkoutSessionAudit.created_at), desc(WorkoutSessionAudit.id))
+    )
+    return [serialize_session_audit(entry) for entry in result.scalars().all()]
 
 
 @router.delete("/{session_id}/sets/{set_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -647,6 +784,7 @@ async def create_session_from_plan(
     plan_id: int,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
     day_number: int = 1,
     overload_style: str = "rep",
     body_weight_kg: float = 0.0,
@@ -912,6 +1050,16 @@ async def create_session_from_plan(
     )
     db.add(workout_session)
     await db.flush()
+    await record_session_audit(
+        db,
+        workout_session,
+        from_status=None,
+        to_status=workout_session.status,
+        reason="session_created_from_plan",
+        endpoint=request.url.path,
+        actor_username=user.username,
+        source_device=request.headers.get("X-Client-Name") or "web",
+    )
 
     # Create sets for each exercise
     for exercise_data in day_exercises:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -5,7 +5,7 @@ from app.models.exercise_note import ExerciseNote
 from app.models.nutrition import DietPhase, FoodItem, MacroGoal, NutritionEntry, Recipe, RecipeIngredient
 from app.models.template import WorkoutTemplate
 from app.models.user import User
-from app.models.workout import ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutStatus
+from app.models.workout import ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutSessionAudit, WorkoutStatus
 
 __all__ = [
     "BodyWeightEntry",
@@ -22,5 +22,6 @@ __all__ = [
     "ExerciseSet",
     "WorkoutPlan",
     "WorkoutSession",
+    "WorkoutSessionAudit",
     "WorkoutStatus",
 ]

--- a/app/models/workout.py
+++ b/app/models/workout.py
@@ -131,6 +131,38 @@ class WorkoutSession(Base):
     sets: Mapped[list["ExerciseSet"]] = relationship(
         "ExerciseSet", back_populates="workout_session", cascade="all, delete-orphan"
     )
+    audit_entries: Mapped[list["WorkoutSessionAudit"]] = relationship(
+        "WorkoutSessionAudit", back_populates="workout_session", cascade="all, delete-orphan"
+    )
+
+
+class WorkoutSessionAudit(Base):
+    """Audit trail for workout session lifecycle transitions."""
+
+    __tablename__ = "workout_session_audit"
+    __table_args__ = (
+        Index("ix_workout_session_audit_session", "workout_session_id"),
+        Index("ix_workout_session_audit_created_at", "created_at"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workout_session_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("workout_sessions.id"), nullable=False
+    )
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"), nullable=False)
+    from_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    to_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    reason: Mapped[str] = mapped_column(String(100), nullable=False)
+    endpoint: Mapped[str] = mapped_column(String(100), nullable=False)
+    actor_username: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    source_device: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.utcnow(), nullable=False
+    )
+
+    workout_session: Mapped["WorkoutSession"] = relationship(
+        "WorkoutSession", back_populates="audit_entries"
+    )
 
 
 class ExerciseFeedback(Base):

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -171,6 +171,20 @@ class WorkoutSessionResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class WorkoutSessionAuditResponse(BaseModel):
+    id: int
+    workout_session_id: int
+    from_status: str | None
+    to_status: str | None
+    reason: str
+    endpoint: str
+    actor_username: str | None
+    source_device: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 # Workout plan schemas
 class PlannedExercise(BaseModel):
     exercise_id: int

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -217,6 +217,18 @@ export interface WorkoutSession {
   sets: Set[];
 }
 
+export interface WorkoutSessionAuditEntry {
+  id: number;
+  workout_session_id: number;
+  from_status: string | null;
+  to_status: string | null;
+  reason: string;
+  endpoint: string;
+  actor_username: string | null;
+  source_device: string | null;
+  created_at: string;
+}
+
 export interface PlannedExercise {
   exercise_id: number;
   sets: number;
@@ -330,6 +342,11 @@ export async function completeSession(sessionId: number): Promise<WorkoutSession
 
 export async function resetSessionToPlanned(sessionId: number): Promise<WorkoutSession> {
   const response = await api.post(`/sessions/${sessionId}/reset-to-planned`);
+  return response.data;
+}
+
+export async function getSessionAudit(sessionId: number): Promise<WorkoutSessionAuditEntry[]> {
+  const response = await api.get(`/sessions/${sessionId}/audit`);
   return response.data;
 }
 

--- a/frontend/src/routes/settings/session-repair/+page.svelte
+++ b/frontend/src/routes/settings/session-repair/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { deleteSession, getSessions, resetSessionToPlanned, type WorkoutSession } from '$lib/api';
+  import { deleteSession, getSessionAudit, getSessions, resetSessionToPlanned, type WorkoutSession, type WorkoutSessionAuditEntry } from '$lib/api';
 
   let sessions = $state<WorkoutSession[]>([]);
   let loading = $state(true);
   let error = $state('');
   let expandedSessionId = $state<number | null>(null);
   let workingSessionId = $state<number | null>(null);
+  let auditBySessionId = $state<Record<number, WorkoutSessionAuditEntry[]>>({});
 
   function fmtDate(iso: string): string {
     return new Date(`${iso}T00:00:00`).toLocaleDateString('en-US', {
@@ -48,6 +49,21 @@
   }
 
   onMount(loadSessions);
+
+  async function toggleExpanded(sessionId: number) {
+    expandedSessionId = expandedSessionId === sessionId ? null : sessionId;
+    if (expandedSessionId === sessionId && !auditBySessionId[sessionId]) {
+      try {
+        auditBySessionId = {
+          ...auditBySessionId,
+          [sessionId]: await getSessionAudit(sessionId),
+        };
+      } catch (err) {
+        console.error('Failed to load audit trail', err);
+        error = `Failed to load audit trail for session ${sessionId}.`;
+      }
+    }
+  }
 
   async function handleReset(sessionId: number) {
     if (!confirm(`Reset session ${sessionId} back to planned? This clears logged sets and draft values.`)) return;
@@ -149,7 +165,7 @@
             </div>
             <div class="flex flex-wrap gap-2">
               <button
-                onclick={() => expandedSessionId = expandedSessionId === session.id ? null : session.id}
+                onclick={() => toggleExpanded(session.id)}
                 class="px-3 py-2 rounded-lg text-sm font-medium bg-zinc-800 text-zinc-200 hover:bg-zinc-700 transition-colors"
               >
                 {expandedSessionId === session.id ? 'Hide Details' : 'Inspect'}
@@ -219,6 +235,31 @@
                   </div>
                 </div>
               {/each}
+            </div>
+            <div class="rounded-xl border border-zinc-800 bg-zinc-900/60 overflow-hidden mt-3">
+              <div class="px-4 py-2 text-xs uppercase tracking-wide text-zinc-500 border-b border-zinc-800">Audit Trail</div>
+              {#if auditBySessionId[session.id]?.length}
+                <div class="divide-y divide-zinc-800">
+                  {#each auditBySessionId[session.id] as entry}
+                    <div class="px-4 py-3 text-sm">
+                      <div class="flex items-center justify-between gap-3">
+                        <p class="text-zinc-200">
+                          {entry.from_status ?? 'none'} → {entry.to_status ?? 'none'}
+                        </p>
+                        <p class="text-xs text-zinc-500">{fmtTimestamp(entry.created_at)}</p>
+                      </div>
+                      <p class="text-xs text-zinc-400 mt-1">
+                        {entry.reason} · {entry.endpoint} · {entry.actor_username ?? 'unknown'}
+                        {#if entry.source_device}
+                          · {entry.source_device}
+                        {/if}
+                      </p>
+                    </div>
+                  {/each}
+                </div>
+              {:else}
+                <div class="px-4 py-3 text-sm text-zinc-500">No audit entries yet.</div>
+              {/if}
             </div>
           {/if}
         </div>

--- a/tests/test_session_audit.py
+++ b/tests/test_session_audit.py
@@ -1,0 +1,56 @@
+import pytest
+
+from httpx import AsyncClient
+
+from tests.conftest import create_exercise, create_plan, start_session_from_plan
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def test_session_audit_records_create_start_complete(client: AsyncClient):
+    ex = await create_exercise(client)
+    plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+    create_resp = await client.post(
+        f"/api/sessions/from-plan/{plan['id']}",
+        params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+    )
+    assert create_resp.status_code == 201
+    session_id = create_resp.json()["id"]
+
+    start_resp = await client.post(f"/api/sessions/{session_id}/start")
+    assert start_resp.status_code == 200
+
+    complete_resp = await client.post(f"/api/sessions/{session_id}/complete")
+    assert complete_resp.status_code == 200
+
+    audit_resp = await client.get(f"/api/sessions/{session_id}/audit")
+    assert audit_resp.status_code == 200
+    audit = audit_resp.json()
+
+    assert audit[0]["reason"] == "session_completed"
+    assert audit[0]["from_status"] == "in_progress"
+    assert audit[0]["to_status"] == "completed"
+    assert audit[1]["reason"] == "session_started"
+    assert audit[1]["from_status"] == "planned"
+    assert audit[1]["to_status"] == "in_progress"
+    assert audit[2]["reason"] == "session_created_from_plan"
+    assert audit[2]["from_status"] is None
+    assert audit[2]["to_status"] == "planned"
+
+
+async def test_session_audit_records_reset_to_planned(client: AsyncClient):
+    ex = await create_exercise(client)
+    plan = await create_plan(client, ex["id"], sets=1, reps=8)
+    session = await start_session_from_plan(client, plan["id"])
+
+    reset_resp = await client.post(f"/api/sessions/{session['id']}/reset-to-planned")
+    assert reset_resp.status_code == 200
+
+    audit_resp = await client.get(f"/api/sessions/{session['id']}/audit")
+    assert audit_resp.status_code == 200
+    audit = audit_resp.json()
+
+    assert audit[0]["reason"] == "session_reset_to_planned"
+    assert audit[0]["from_status"] == "in_progress"
+    assert audit[0]["to_status"] == "planned"


### PR DESCRIPTION
Closes #579

## Summary
- add a workout session audit table and API endpoint for lifecycle transitions
- record create, start, complete, reset, and set-driven planned/in-progress transitions with actor, device, reason, and endpoint
- surface audit history inside the session repair tool
- add focused backend tests and an Alembic migration for the new table

## Testing
- ./venv/bin/python -m pytest tests/test_session_audit.py tests/test_sessions.py -k 'reset_session_to_planned or start_session or complete_session' -vv
- cd frontend && timeout 30s ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
- git diff --check -- app/models/workout.py app/models/__init__.py app/schemas/requests.py app/api/sessions.py frontend/src/lib/api.ts frontend/src/routes/settings/session-repair/+page.svelte tests/test_session_audit.py alembic/versions/1f2e3d4c5b6a_add_workout_session_audit_table.py
