### PR TITLE
Add App Store submission assets for iOS app

### DIFF
--- a/ios/AppStore/AppStoreSubmission.md
+++ b/ios/AppStore/AppStoreSubmission.md
@@ -1,0 +1,70 @@
+# GymTracker App Store Submission Pack
+
+Last updated: March 30, 2026
+
+## Repo Deliverables Included
+
+- Privacy policy draft: [`/Users/calebmorton/home-gym-tracker/ios/AppStore/PrivacyPolicy.md`](/Users/calebmorton/home-gym-tracker/ios/AppStore/PrivacyPolicy.md)
+- iOS bundle display name aligned to `GymTracker`
+- HealthKit usage descriptions aligned to current app behavior
+- Stale `armv7` required-device capability removed
+
+## App Store Connect Metadata Draft
+
+App Name:
+`GymTracker`
+
+Subtitle:
+`Track workouts, food, and progress`
+
+Category:
+`Health & Fitness`
+
+Promotional Text:
+`Log lifting sessions, food, and body weight in one place with built-in progression tools and Apple Health sync.`
+
+Keywords:
+`gym,workout,fitness,nutrition,macros,bodyweight,healthkit,strength,training`
+
+Description:
+`GymTracker helps lifters track training, nutrition, and body-weight progress without juggling separate apps. Build multi-day workout plans, log sets with plate math and rest timers, scan foods by barcode or label, and monitor estimated one-rep max trends over time. If Apple Health access is enabled, GymTracker can read body-weight data and write completed workouts and body-weight entries to keep your health data in sync.`
+
+## Screenshot Plan
+
+Prepare at least one complete screenshot set for the required iPhone sizes in App Store Connect.
+
+Recommended sequence:
+
+1. Dashboard showing next workout, recent progress, and nutrition summary
+2. Active workout screen with set logging and plate math
+3. Nutrition logging screen with barcode or OCR flow
+4. Body-weight or progress chart screen
+5. Settings or Apple Health connection screen
+
+## App Privacy / Review Notes Draft
+
+Use this reviewer note:
+
+`GymTracker is a workout and nutrition tracker. HealthKit access is optional. When permission is granted, the app reads body weight and body fat percentage, and writes completed workouts and body-weight entries. HealthKit data is used only for user-facing fitness tracking features and not for advertising or profiling.`
+
+## Manual Steps Still Required
+
+These steps cannot be completed from the repo alone:
+
+1. Publish the privacy policy at a public HTTPS URL and use that URL in App Store Connect.
+2. Confirm Apple Developer Program membership is active for the submission account.
+3. Create or update the App Store Connect app record.
+4. Upload screenshots for the required iPhone sizes.
+5. Fill in support URL, marketing URL if used, privacy nutrition answers, and age rating.
+6. Archive and upload the signed build from Xcode or Transporter.
+7. Submit the build for App Review.
+
+## Pre-Submission Verification
+
+Before upload, verify:
+
+1. HealthKit capability is enabled in the target entitlements.
+2. HealthKit permission strings match actual read/write behavior.
+3. The displayed app name is `GymTracker`.
+4. A production support contact is available in the privacy policy and App Store listing.
+5. The final build runs on a current iPhone simulator/device without debug-only behavior.

--- a/ios/AppStore/PrivacyPolicy.md
+++ b/ios/AppStore/PrivacyPolicy.md
@@ -1,0 +1,79 @@
+# GymTracker Privacy Policy
+
+Last updated: March 30, 2026
+
+## Overview
+
+GymTracker is a workout and nutrition tracking application. This policy explains what data the app accesses, how that data is used, and what user controls exist.
+
+## Data We Collect
+
+GymTracker stores account and usage data required to provide the product:
+
+- Account data such as username, email address, and authentication tokens
+- Workout plans, workout sessions, set logs, exercise feedback, and notes
+- Nutrition logs, body-weight entries, body-fat entries, and diet phase settings
+- App settings such as units, base equipment weights, dashboard layout, and developer branch preference
+
+## Apple Health / HealthKit Data
+
+If the user grants HealthKit permission, GymTracker may:
+
+- Read body weight
+- Read body fat percentage
+- Read step count
+- Write completed strength-training workouts
+- Write body weight entries
+
+GymTracker uses this information only to support user-visible fitness tracking features such as syncing body weight, writing completed workouts, and improving progress views inside the app.
+
+GymTracker does not use HealthKit data for advertising, profiling, or data mining.
+
+## Camera Access
+
+If the user grants camera permission, GymTracker may use the camera to:
+
+- Scan food barcodes
+- Scan nutrition labels with OCR
+
+Camera data is used only to complete the requested scan flow.
+
+## How Data Is Used
+
+GymTracker uses collected data to:
+
+- Authenticate users and keep accounts secure
+- Save workout, nutrition, and body-weight history
+- Calculate progress metrics, estimated one-rep max values, and macro targets
+- Sync HealthKit-authorized body-weight and workout data when the user enables those features
+- Operate the app across web and iOS clients
+
+## Data Sharing
+
+GymTracker does not sell user data.
+
+User data is not shared with advertisers. Third-party services are limited to infrastructure or product functionality needed to operate the app, such as barcode lookup providers and Apple Health integration.
+
+## Data Retention
+
+User-entered workout, nutrition, and body-weight data is retained until the user deletes it or requests account removal, subject to operational backup and legal requirements.
+
+## User Controls
+
+Users can:
+
+- Disconnect Apple Health permissions through iOS Settings
+- Stop using camera-based scanning by denying camera access
+- Update or remove workout, nutrition, and body-weight entries from the app
+
+## Security
+
+GymTracker uses authenticated API access and standard application security controls to protect user data. No system is perfect, but reasonable efforts are made to protect stored information.
+
+## Children
+
+GymTracker is not intended for children under 13.
+
+## Contact
+
+For privacy questions or deletion requests, publish a support contact before App Store submission and replace this placeholder with the real support email or support URL.

--- a/ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj/project.pbxproj
+++ b/ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = dev.lethal.gymtracker.native;
-				PRODUCT_NAME = "Food Log";
+				PRODUCT_NAME = GymTracker;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -433,7 +433,7 @@
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = dev.lethal.gymtracker.native;
-				PRODUCT_NAME = "Food Log";
+				PRODUCT_NAME = GymTracker;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist
+++ b/ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Food Log</string>
+	<string>GymTracker</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -23,17 +23,13 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>Food Log uses the camera to scan food barcodes for nutrition lookup.</string>
+	<string>GymTracker uses the camera to scan food barcodes and nutrition labels for faster food logging.</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>Food Log reads your health data to show body weight trends and sync workout history.</string>
+	<string>GymTracker reads your Apple Health body weight and body fat data to keep progress tracking current.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>Food Log writes completed workouts, body weight, and nutrition data to Apple Health.</string>
+	<string>GymTracker writes completed workouts and body weight entries to Apple Health when you choose to sync them.</string>
 	<key>UILaunchScreen</key>
 	<dict/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/GymTracker/Gym Tracker/project.yml
+++ b/ios/GymTracker/Gym Tracker/project.yml
@@ -25,6 +25,7 @@ targets:
       base:
         INFOPLIST_FILE: Gym-Tracker-Info.plist
         PRODUCT_BUNDLE_IDENTIFIER: dev.lethal.gymtracker.native
+        PRODUCT_NAME: GymTracker
         CODE_SIGN_STYLE: Automatic
     entitlements:
       path: "Gym Tracker/Gym Tracker.entitlements"


### PR DESCRIPTION
## Summary
- add an App Store submission pack with privacy policy and metadata/checklist docs
- align the iOS bundle and build product branding to GymTracker
- update HealthKit permission strings and remove the stale armv7 device requirement

## Validation
- plutil -lint 'ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist'
- xcodebuild -project 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj' -scheme 'Gym Tracker' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
- git diff --check -- 'ios/GymTracker/Gym Tracker/Gym-Tracker-Info.plist' 'ios/GymTracker/Gym Tracker/project.yml' 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj/project.pbxproj' ios/AppStore/PrivacyPolicy.md ios/AppStore/AppStoreSubmission.md

Addresses #166. The external Apple Developer/App Store Connect submission steps still remain after this PR.