### PR TITLE
Restore rest timer after set completion

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -393,6 +393,15 @@
     return isNamedOneSidedPlateExercise(exercise);
   }
 
+  function clearPlateBannerFocus() {
+    focusedWeightSetId = null;
+    focusedExerciseId = null;
+    const active = document.activeElement;
+    if (active instanceof HTMLInputElement) {
+      active.blur();
+    }
+  }
+
   // Derived: plate banner data for the currently focused weight input
   let plateBanner = $derived.by(() => {
     if (!focusedWeightSetId || !focusedExerciseId) return null;
@@ -1429,6 +1438,7 @@
   let highlightTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function handlePostSetCompletion(exUiId: string) {
+    clearPlateBannerFocus();
     const ex = uiExercises.find(e => e.uiId === exUiId);
     if (!ex?.groupId) {
       startRestTimer(exUiId);


### PR DESCRIPTION
## Summary
- clear focused weight-input state before the post-set rest flow runs
- collapse the plate-math banner when a set is completed so the rest timer is visible again
- preserve the current timer logic and only fix the overlay regression

## Validation
- git diff --check -- frontend/src/routes/workout/active/+page.svelte
- cd frontend && timeout 30s ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json

Closes #614