### PR TITLE
Fix partial-rep set saves

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -634,6 +634,8 @@ async def update_set(
         # Strip timezone info — DB uses naive timestamps
         if isinstance(value, datetime) and value.tzinfo is not None:
             value = value.replace(tzinfo=None)
+        if field == "sub_sets" and isinstance(value, list):
+            value = json.dumps(value)
         setattr(exercise_set, field, value)
 
     # Update session totals

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -106,7 +106,7 @@ class SetUpdate(BaseModel):
     reps_left: int | None = None
     reps_right: int | None = None
     set_type: str | None = None
-    sub_sets: str | None = None  # JSON for drop set entries
+    sub_sets: list | str | None = None
     notes: str | None = None
     completed_at: datetime | None = None
     started_at: datetime | None = None

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -98,6 +98,28 @@ class TestSessionLifecycle:
         assert data["actual_weight_kg"] == 80.0
         assert data["actual_reps"] == 10
 
+    async def test_log_set_with_partials(self, client: AsyncClient):
+        """PATCH /sessions/{id}/sets/{set_id} accepts partial-rep sub_sets payloads."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        set_id = sess["sets"][0]["id"]
+        r = await client.patch(
+            f"/api/sessions/{sess['id']}/sets/{set_id}",
+            json={
+                "actual_weight_kg": 35.0,
+                "actual_reps": 10,
+                "set_type": "standard_partials",
+                "sub_sets": [{"weight_kg": 35.0, "reps": 4, "type": "partial"}],
+                "completed_at": "2024-01-01T10:00:00",
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["set_type"] == "standard_partials"
+        assert data["sub_sets"] == [{"weight_kg": 35.0, "reps": 4, "type": "partial"}]
+
     async def test_unilateral_set_updates_session_rep_totals(self, client: AsyncClient):
         """Unilateral reps should contribute to session total_reps and volume."""
         ex = await create_exercise(client, is_unilateral=True)


### PR DESCRIPTION
## Summary
- allow structured sub_sets payloads in the set update schema
- serialize list payloads before storing them on exercise sets
- add a regression test for saving a standard-partials set

## Validation
- ./venv/bin/python -m pytest tests/test_sessions.py -k 'test_log_set or test_log_set_with_partials' -vv
- git diff --check -- app/schemas/requests.py app/api/sessions.py tests/test_sessions.py

Closes #618