### PR TITLE
Allow scrolling on workout complete screen

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -2312,8 +2312,8 @@
 
 <!-- ─── Finished screen ────────────────────────────────────────────────── -->
 {:else if finished}
-  <div class="flex items-center justify-center flex-1 p-4">
-    <div class="card max-w-lg w-full" bind:this={summaryCardEl}>
+  <div class="flex-1 overflow-y-auto px-4 py-4">
+    <div class="card max-w-lg w-full mx-auto mb-8" bind:this={summaryCardEl}>
       <div class="text-center mb-6">
         <div class="text-6xl mb-3">🎉</div>
         <h2 class="text-3xl font-bold">Workout done!</h2>


### PR DESCRIPTION
## Summary
- allow the finished workout screen in the PWA to scroll normally
- remove the centered flex layout that trapped the completion card viewport
- keep the completion card centered while restoring bottom reachability

## Testing
- git diff --check -- frontend/src/routes/workout/active/+page.svelte
- cd frontend && timeout 30s ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json

Closes #621