### PR TITLE
Add plan-level RIR override controls

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -13,7 +13,8 @@ from app.database import get_db
 from app.models.user import User
 from app.models.workout import WorkoutPlan, WorkoutSession, ExerciseSet
 from app.models.exercise import Exercise
-from app.schemas.requests import WorkoutPlanCreate, WorkoutPlanResponse
+from app.schemas.requests import WorkoutPlanCreate, WorkoutPlanResponse, PlanRirOverrides
+from app.services.plan_rir import normalize_rir_overrides
 
 router = APIRouter()
 
@@ -38,6 +39,7 @@ def serialize_plan(plan: WorkoutPlan) -> dict:
         # New format
         days = planned_data.get("days", [])
         number_of_days = planned_data.get("number_of_days") or len(days)
+    rir_overrides = normalize_rir_overrides(planned_data.get("rir_overrides"))
 
     return {
         "id": plan.id,
@@ -48,6 +50,7 @@ def serialize_plan(plan: WorkoutPlan) -> dict:
         "current_week": plan.current_week,
         "number_of_days": number_of_days,
         "days": days,
+        "rir_overrides": rir_overrides,
         "auto_progression": plan.auto_progression,
         "is_draft": plan.is_draft,
         "is_archived": plan.is_archived,
@@ -261,7 +264,8 @@ async def create_plan(
     # Convert days structure to JSON
     planned_data = {
         "number_of_days": plan_data.number_of_days,
-        "days": [d.model_dump() for d in plan_data.days]
+        "days": [d.model_dump() for d in plan_data.days],
+        "rir_overrides": normalize_rir_overrides(plan_data.rir_overrides.model_dump()),
     }
     planned_exercises_json = json.dumps(planned_data)
 
@@ -411,6 +415,39 @@ class PlanUpdate(BaseModel):
     days: list | None = None
     auto_progression: bool | None = None
     is_draft: bool | None = None
+
+
+@router.put("/{plan_id}/rir-overrides", response_model=WorkoutPlanResponse)
+async def update_plan_rir_overrides(
+    plan_id: int,
+    overrides: PlanRirOverrides,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    result = await db.execute(select(WorkoutPlan).where(WorkoutPlan.id == plan_id, WorkoutPlan.user_id == user.id))
+    plan = result.scalar_one_or_none()
+    if not plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Workout plan {plan_id} not found",
+        )
+
+    try:
+        planned_data = json.loads(plan.planned_exercises) if plan.planned_exercises else {}
+    except (json.JSONDecodeError, TypeError):
+        planned_data = {}
+
+    if isinstance(planned_data, list):
+        planned_data = {
+            "number_of_days": len(planned_data) or 1,
+            "days": planned_data,
+        }
+
+    planned_data["rir_overrides"] = normalize_rir_overrides(overrides.model_dump())
+    plan.planned_exercises = json.dumps(planned_data)
+    await db.flush()
+    await db.refresh(plan)
+    return serialize_plan(plan)
 
 
 @router.put("/{plan_id}", response_model=WorkoutPlanResponse)

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -14,7 +14,8 @@ from app.database import get_db
 from app.models.exercise import Exercise
 from app.models.user import User
 from app.models.workout import ExerciseFeedback, ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutSessionAudit, WorkoutStatus
-from app.services.progression import compute_overload
+from app.services.plan_rir import resolve_rir_override
+from app.services.progression import adjust_load_for_target_rir, compute_overload
 from app.schemas.requests import (
     SetCreate,
     SetResponse,
@@ -941,6 +942,7 @@ async def create_session_from_plan(
         prior_planned: int | None,
         target_reps: int,
         ex_model,
+        target_rir: int | None = None,
     ) -> tuple[float | None, int | None]:
         """Compute overload for one side (or a bilateral set) given prior values."""
         if prior_reps is None or prior_reps <= 0:
@@ -964,7 +966,7 @@ async def create_session_from_plan(
             planned      = target_reps
 
         is_assisted = bool(ex_model and ex_model.is_assisted)
-        return compute_overload(
+        suggested_weight, suggested_reps = compute_overload(
             prior_weight=prior_weight,
             prior_reps=prior_reps,
             planned_reps=planned,
@@ -975,6 +977,18 @@ async def create_session_from_plan(
             is_bodyweight=(not is_assisted) and (prior_weight is None or prior_weight <= 0),
             body_weight_kg=body_weight_kg,
         )
+        if target_rir is not None and target_rir > 0:
+            suggested_weight = adjust_load_for_target_rir(
+                prior_weight,
+                prior_reps,
+                target_reps if target_reps > 0 else (suggested_reps or planned),
+                target_rir,
+                is_assisted=is_assisted,
+                body_weight_kg=body_weight_kg,
+            )
+            if target_reps > 0:
+                suggested_reps = target_reps
+        return suggested_weight, suggested_reps
 
     def _overload_for_set(
         exercise_id: int, set_num: int, target_reps: int, ex_model,
@@ -1001,6 +1015,11 @@ async def create_session_from_plan(
             return None, None, None, None
 
         prior_set = matched_sets.get(set_num) or matched_sets.get(1) or matched_sets[min(matched_sets.keys())]
+        target_rir = resolve_rir_override(
+            planned_data,
+            exercise_id,
+            ex_model.primary_muscles if ex_model else None,
+        )
 
         left_reps  = prior_set.get("reps_left")
         right_reps = prior_set.get("reps_right")
@@ -1016,7 +1035,7 @@ async def create_session_from_plan(
             weight_kg, _ = _overload_for_side(
                 prior_weight, ref_reps,
                 prior_set.get("planned_reps_left") or prior_set.get("planned_reps"),
-                target_reps, ex_model,
+                target_reps, ex_model, target_rir,
             )
             _, new_reps_left = _overload_for_side(
                 prior_weight, left_reps,
@@ -1038,7 +1057,7 @@ async def create_session_from_plan(
         # Bilateral: standard single-side logic
         weight_kg, planned_reps = _overload_for_side(
             prior_set["weight"], prior_set["reps"],
-            prior_set.get("planned_reps"), target_reps, ex_model,
+            prior_set.get("planned_reps"), target_reps, ex_model, target_rir,
         )
         return weight_kg, planned_reps, None, None
 

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -198,6 +198,12 @@ class PlannedExercise(BaseModel):
     notes: str | None = None
 
 
+class PlanRirOverrides(BaseModel):
+    plan: int | None = None
+    muscles: dict[str, int] = Field(default_factory=dict)
+    exercises: dict[str, int] = Field(default_factory=dict)
+
+
 class PlannedDay(BaseModel):
     day_number: int
     day_name: str
@@ -224,6 +230,7 @@ class WorkoutPlanCreate(BaseModel):
     days: list[PlannedDay] = []
     auto_progression: bool = True
     is_draft: bool = False
+    rir_overrides: PlanRirOverrides = Field(default_factory=PlanRirOverrides)
 
 
 class WorkoutPlanResponse(BaseModel):
@@ -235,6 +242,7 @@ class WorkoutPlanResponse(BaseModel):
     current_week: int
     number_of_days: int
     days: list[PlannedDay]
+    rir_overrides: PlanRirOverrides = Field(default_factory=PlanRirOverrides)
     auto_progression: bool
     is_draft: bool = False
     is_archived: bool = False

--- a/app/services/plan_rir.py
+++ b/app/services/plan_rir.py
@@ -1,0 +1,62 @@
+"""Helpers for persisted plan-level RIR overrides."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _normalize_rir_value(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        rir = int(value)
+    except (TypeError, ValueError):
+        return None
+    if 0 <= rir <= 5:
+        return rir
+    return None
+
+
+def normalize_rir_overrides(raw: Any) -> dict:
+    """Return a stable override shape from untrusted JSON data."""
+    if not isinstance(raw, dict):
+        raw = {}
+
+    muscles_raw = raw.get("muscles")
+    exercises_raw = raw.get("exercises")
+
+    muscles: dict[str, int] = {}
+    if isinstance(muscles_raw, dict):
+        for key, value in muscles_raw.items():
+            rir = _normalize_rir_value(value)
+            if key and rir is not None:
+                muscles[str(key)] = rir
+
+    exercises: dict[str, int] = {}
+    if isinstance(exercises_raw, dict):
+        for key, value in exercises_raw.items():
+            rir = _normalize_rir_value(value)
+            if key and rir is not None:
+                exercises[str(key)] = rir
+
+    return {
+        "plan": _normalize_rir_value(raw.get("plan")),
+        "muscles": muscles,
+        "exercises": exercises,
+    }
+
+
+def resolve_rir_override(planned_data: dict, exercise_id: int, primary_muscles: list[str] | None = None) -> int | None:
+    """Resolve override precedence: exercise > muscle group > whole plan."""
+    overrides = normalize_rir_overrides(planned_data.get("rir_overrides"))
+    exercise_override = overrides["exercises"].get(str(exercise_id))
+    if exercise_override is not None:
+        return exercise_override
+
+    if primary_muscles:
+        for muscle in primary_muscles:
+            muscle_override = overrides["muscles"].get(muscle)
+            if muscle_override is not None:
+                return muscle_override
+
+    return overrides["plan"]

--- a/app/services/progression.py
+++ b/app/services/progression.py
@@ -41,6 +41,39 @@ def epley_weight_for_reps(weight: float, done_reps: int, target_reps: int) -> fl
     return round(new_w / 2.5) * 2.5
 
 
+def adjust_load_for_target_rir(
+    prior_weight: float | None,
+    prior_reps: int | None,
+    target_reps: int,
+    target_rir: int | None,
+    *,
+    is_assisted: bool = False,
+    body_weight_kg: float = 0.0,
+) -> float | None:
+    """Return an easier next-session load for the same target reps at the requested RIR."""
+    if (
+        target_rir is None
+        or target_rir <= 0
+        or prior_weight is None
+        or prior_weight <= 0
+        or prior_reps is None
+        or prior_reps <= 0
+        or target_reps <= 0
+    ):
+        return prior_weight
+
+    if is_assisted:
+        if body_weight_kg <= 0:
+            return prior_weight
+        prior_net = body_weight_kg - prior_weight
+        if prior_net <= 0:
+            return prior_weight
+        easier_net = epley_weight_for_reps(prior_net, prior_reps, target_reps + target_rir)
+        return max(0.0, round((body_weight_kg - easier_net) / 2.5) * 2.5)
+
+    return epley_weight_for_reps(prior_weight, prior_reps, target_reps + target_rir)
+
+
 def compute_overload(
     *,
     prior_weight: float,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -243,6 +243,12 @@ export interface PlannedExercise {
   group_type?: 'superset' | 'circuit' | null;
 }
 
+export interface PlanRirOverrides {
+  plan: number | null;
+  muscles: Record<string, number>;
+  exercises: Record<string, number>;
+}
+
 export interface PlannedDay {
   day_number: number;
   day_name: string;
@@ -258,6 +264,7 @@ export interface WorkoutPlan {
   current_week: number;
   number_of_days: number;
   days: PlannedDay[];
+  rir_overrides: PlanRirOverrides;
   auto_progression: boolean;
   min_technique_score: number;
   is_draft: boolean;
@@ -560,6 +567,11 @@ export async function updatePlan(planId: number, data: {
   is_draft?: boolean;
 }): Promise<WorkoutPlan> {
   const response = await api.put(`/plans/${planId}`, data);
+  return response.data;
+}
+
+export async function updatePlanRirOverrides(planId: number, overrides: PlanRirOverrides): Promise<WorkoutPlan> {
+  const response = await api.put(`/plans/${planId}/rir-overrides`, overrides);
   return response.data;
 }
 

--- a/frontend/src/routes/plans/+page.svelte
+++ b/frontend/src/routes/plans/+page.svelte
@@ -2,8 +2,8 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { workoutPlans, exercises, settings } from '$lib/stores';
-  import { getPlans, deletePlan, getExercises, updatePlan, archivePlan, reusePlan, getTemplates, cloneTemplate, getSessions } from '$lib/api';
-  import type { Exercise, WorkoutPlan, WorkoutTemplate, WorkoutSession, PlannedDay } from '$lib/api';
+  import { getPlans, deletePlan, getExercises, updatePlan, archivePlan, reusePlan, getTemplates, cloneTemplate, getSessions, updatePlanRirOverrides } from '$lib/api';
+  import type { Exercise, WorkoutPlan, WorkoutTemplate, WorkoutSession, PlannedDay, PlanRirOverrides } from '$lib/api';
 
   let avgSetDuration = $state(30); // seconds per set from history, default 30s
 
@@ -12,6 +12,9 @@
   let errorMsg     = $state<string | null>(null);
   let expandedPlan = $state<number | null>(null);
   let expandedDays = $state<Record<string, boolean>>({});
+  let rirPlan = $state<WorkoutPlan | null>(null);
+  let rirOverridesDraft = $state<PlanRirOverrides>({ plan: null, muscles: {}, exercises: {} });
+  let savingRir = $state(false);
 
   // Templates
   let templates = $state<WorkoutTemplate[]>([]);
@@ -112,6 +115,93 @@
 
   function getExerciseName(exerciseId: number): string {
     return allExercises.find(e => e.id === exerciseId)?.display_name || `Exercise ${exerciseId}`;
+  }
+
+  function getExercise(exerciseId: number): Exercise | undefined {
+    return allExercises.find(e => e.id === exerciseId);
+  }
+
+  function cloneOverrides(overrides?: PlanRirOverrides | null): PlanRirOverrides {
+    return {
+      plan: overrides?.plan ?? null,
+      muscles: { ...(overrides?.muscles ?? {}) },
+      exercises: { ...(overrides?.exercises ?? {}) },
+    };
+  }
+
+  function openRirModal(plan: WorkoutPlan) {
+    rirPlan = plan;
+    rirOverridesDraft = cloneOverrides(plan.rir_overrides);
+  }
+
+  function closeRirModal() {
+    rirPlan = null;
+    rirOverridesDraft = { plan: null, muscles: {}, exercises: {} };
+  }
+
+  function getPlanMuscles(plan: WorkoutPlan): string[] {
+    const muscles = new Set<string>();
+    for (const day of plan.days) {
+      for (const ex of day.exercises) {
+        const exercise = getExercise(ex.exercise_id);
+        for (const muscle of exercise?.primary_muscles ?? []) {
+          muscles.add(muscle);
+        }
+      }
+    }
+    return [...muscles].sort();
+  }
+
+  function getPlanExerciseRows(plan: WorkoutPlan): { id: number; name: string; muscles: string[] }[] {
+    const seen = new Set<number>();
+    const rows: { id: number; name: string; muscles: string[] }[] = [];
+    for (const day of plan.days) {
+      for (const ex of day.exercises) {
+        if (seen.has(ex.exercise_id)) continue;
+        seen.add(ex.exercise_id);
+        const exercise = getExercise(ex.exercise_id);
+        rows.push({
+          id: ex.exercise_id,
+          name: exercise?.display_name ?? `Exercise ${ex.exercise_id}`,
+          muscles: exercise?.primary_muscles ?? [],
+        });
+      }
+    }
+    return rows.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  function setDraftPlanRir(value: string) {
+    rirOverridesDraft = { ...rirOverridesDraft, plan: value === '' ? null : Number(value) };
+  }
+
+  function setDraftMuscleRir(muscle: string, value: string) {
+    const muscles = { ...rirOverridesDraft.muscles };
+    if (value === '') delete muscles[muscle];
+    else muscles[muscle] = Number(value);
+    rirOverridesDraft = { ...rirOverridesDraft, muscles };
+  }
+
+  function setDraftExerciseRir(exerciseId: number, value: string) {
+    const exercises = { ...rirOverridesDraft.exercises };
+    const key = String(exerciseId);
+    if (value === '') delete exercises[key];
+    else exercises[key] = Number(value);
+    rirOverridesDraft = { ...rirOverridesDraft, exercises };
+  }
+
+  async function saveRirOverrides() {
+    if (!rirPlan) return;
+    savingRir = true;
+    try {
+      const updated = await updatePlanRirOverrides(rirPlan.id, rirOverridesDraft);
+      localPlans = localPlans.map(plan => plan.id === updated.id ? updated : plan);
+      workoutPlans.set(localPlans);
+      closeRirModal();
+    } catch (error) {
+      showError('Failed to save RIR overrides.');
+    } finally {
+      savingRir = false;
+    }
   }
 
   let filteredTemplates = $derived(
@@ -258,6 +348,10 @@
                         class="btn-secondary text-sm">
                   Edit Week
                 </button>
+                <button onclick={() => openRirModal(plan)}
+                        class="btn-secondary text-sm">
+                  RIR Targets
+                </button>
                 <button onclick={() => goto(`/workout/active?plan=${plan.id}&day=1`)}
                         class="btn-primary text-sm flex-1">
                   Start Workout
@@ -392,6 +486,85 @@
         <button onclick={() => handleClone(previewTmpl!)} disabled={cloning}
                 class="btn-primary w-full !py-3 disabled:opacity-50">
           {cloning ? 'Importing...' : 'Use This Template'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if rirPlan}
+  <div class="fixed inset-0 bg-black/80 z-50 flex items-end sm:items-center justify-center">
+    <div class="bg-zinc-900 w-full sm:max-w-2xl sm:rounded-2xl rounded-t-2xl max-h-[92vh] flex flex-col border border-white/8 shadow-2xl">
+      <div class="flex items-center justify-between px-4 py-4 border-b border-zinc-800">
+        <div>
+          <h3 class="font-semibold text-white">RIR Targets</h3>
+          <p class="text-xs text-zinc-500 mt-0.5">{rirPlan.name}</p>
+        </div>
+        <button onclick={closeRirModal} class="text-zinc-400 hover:text-white text-xl leading-none">✕</button>
+      </div>
+
+      <div class="flex-1 overflow-y-auto px-4 py-4 space-y-5">
+        <div class="space-y-2">
+          <div>
+            <label class="label">Whole Plan</label>
+            <p class="text-xs text-zinc-500">Fallback target for every exercise unless a muscle or exercise override is set.</p>
+          </div>
+          <select class="input" value={rirOverridesDraft.plan ?? ''} onchange={(e) => setDraftPlanRir((e.currentTarget as HTMLSelectElement).value)}>
+            <option value="">Auto</option>
+            {#each [0, 1, 2, 3, 4, 5] as rir}
+              <option value={rir}>{rir === 5 ? '5+' : rir}</option>
+            {/each}
+          </select>
+        </div>
+
+        <div class="space-y-2">
+          <div>
+            <label class="label">Muscle Groups</label>
+            <p class="text-xs text-zinc-500">Applies to all matching exercises in the plan unless a direct exercise override is set.</p>
+          </div>
+          <div class="space-y-2">
+            {#each getPlanMuscles(rirPlan) as muscle}
+              <div class="flex items-center justify-between gap-3 rounded-lg bg-zinc-800/50 px-3 py-2">
+                <div class="text-sm text-zinc-300 capitalize">{muscle.replace(/_/g, ' ')}</div>
+                <select class="input w-28" value={rirOverridesDraft.muscles[muscle] ?? ''} onchange={(e) => setDraftMuscleRir(muscle, (e.currentTarget as HTMLSelectElement).value)}>
+                  <option value="">Auto</option>
+                  {#each [0, 1, 2, 3, 4, 5] as rir}
+                    <option value={rir}>{rir === 5 ? '5+' : rir}</option>
+                  {/each}
+                </select>
+              </div>
+            {/each}
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <div>
+            <label class="label">Exercises</label>
+            <p class="text-xs text-zinc-500">Highest priority override. Use this when only one lift needs to back off.</p>
+          </div>
+          <div class="space-y-2">
+            {#each getPlanExerciseRows(rirPlan) as row}
+              <div class="flex items-center justify-between gap-3 rounded-lg bg-zinc-800/50 px-3 py-2">
+                <div class="min-w-0">
+                  <div class="text-sm text-zinc-300 truncate">{row.name}</div>
+                  <div class="text-xs text-zinc-500 capitalize">{row.muscles.map(m => m.replace(/_/g, ' ')).join(', ') || 'No primary muscles'}</div>
+                </div>
+                <select class="input w-28 shrink-0" value={rirOverridesDraft.exercises[String(row.id)] ?? ''} onchange={(e) => setDraftExerciseRir(row.id, (e.currentTarget as HTMLSelectElement).value)}>
+                  <option value="">Auto</option>
+                  {#each [0, 1, 2, 3, 4, 5] as rir}
+                    <option value={rir}>{rir === 5 ? '5+' : rir}</option>
+                  {/each}
+                </select>
+              </div>
+            {/each}
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center justify-end gap-3 px-4 py-4 border-t border-zinc-800">
+        <button onclick={closeRirModal} class="btn-secondary">Cancel</button>
+        <button onclick={saveRirOverrides} class="btn-primary" disabled={savingRir}>
+          {savingRir ? 'Saving…' : 'Save RIR Targets'}
         </button>
       </div>
     </div>

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -93,6 +93,25 @@ class TestPlansCRUD:
         data = r.json()
         assert data["is_archived"] is True
 
+    async def test_update_plan_rir_overrides(self, client: AsyncClient):
+        """PUT /plans/{id}/rir-overrides persists whole-plan, muscle, and exercise overrides."""
+        ex = await create_exercise(client, primary_muscles=["quadriceps"], secondary_muscles=["glutes"])
+        plan = await create_plan(client, ex["id"])
+
+        r = await client.put(
+            f"/api/plans/{plan['id']}/rir-overrides",
+            json={
+                "plan": 2,
+                "muscles": {"quadriceps": 3},
+                "exercises": {str(ex["id"]): 1},
+            },
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["rir_overrides"]["plan"] == 2
+        assert data["rir_overrides"]["muscles"]["quadriceps"] == 3
+        assert data["rir_overrides"]["exercises"][str(ex["id"])] == 1
+
     async def test_next_workout_defaults_to_first_day(self, client: AsyncClient):
         """GET /plans/next-workout returns day 1 when nothing is completed yet."""
         ex = await create_exercise(client)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -26,6 +26,40 @@ class TestSessionLifecycle:
         assert "id" in data
         assert len(data["sets"]) == 3
 
+    async def test_create_session_from_plan_respects_exercise_rir_override(self, client: AsyncClient):
+        """Exercise RIR override should back off the programmed load for the next session."""
+        ex = await create_exercise(client, primary_muscles=["quadriceps"])
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+        set_id = sess["sets"][0]["id"]
+
+        r1 = await client.patch(
+            f"/api/sessions/{sess['id']}/sets/{set_id}",
+            json={
+                "actual_weight_kg": 100.0,
+                "actual_reps": 8,
+                "completed_at": "2024-01-01T10:00:00",
+            },
+        )
+        assert r1.status_code == 200
+        complete_r = await client.post(f"/api/sessions/{sess['id']}/complete")
+        assert complete_r.status_code == 200
+
+        rir_r = await client.put(
+            f"/api/plans/{plan['id']}/rir-overrides",
+            json={"plan": None, "muscles": {}, "exercises": {str(ex["id"]): 2}},
+        )
+        assert rir_r.status_code == 200, rir_r.text
+
+        next_r = await client.post(
+            f"/api/sessions/from-plan/{plan['id']}",
+            params={"day_number": 1, "overload_style": "rep", "body_weight_kg": 0},
+        )
+        assert next_r.status_code == 201, next_r.text
+        next_set = next_r.json()["sets"][0]
+        assert next_set["planned_reps"] == 8
+        assert next_set["planned_weight_kg"] == 95.0
+
     async def test_start_session(self, client: AsyncClient):
         """POST /sessions/{id}/start transitions status to in_progress."""
         ex = await create_exercise(client)


### PR DESCRIPTION
## Summary
- persist RIR overrides on workout plans with whole-plan, muscle-group, and exercise scopes
- apply those overrides when building the next session from a plan so target reps stay the same while load backs off
- add a plans UI for editing and saving the override hierarchy

## Testing
- ./venv/bin/python -m pytest tests/test_plans.py tests/test_sessions.py -k 'rir_overrides or respects_exercise_rir_override or create_session_from_plan' -vv
- cd frontend && timeout 30s ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
- git diff --check -- app/api/plans.py app/api/sessions.py app/schemas/requests.py app/services/progression.py app/services/plan_rir.py frontend/src/lib/api.ts frontend/src/routes/plans/+page.svelte tests/test_plans.py tests/test_sessions.py

Closes #626