### PR TITLE
Add smart plan recommendations

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -5,16 +5,17 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import select, func
+from sqlalchemy import select, func, desc
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import get_current_user
 from app.database import get_db
 from app.models.user import User
-from app.models.workout import WorkoutPlan, WorkoutSession, ExerciseSet
+from app.models.workout import WorkoutPlan, WorkoutSession, ExerciseSet, ExerciseFeedback, WorkoutStatus
 from app.models.exercise import Exercise
 from app.schemas.requests import WorkoutPlanCreate, WorkoutPlanResponse, PlanRirOverrides
 from app.services.plan_rir import normalize_rir_overrides
+from app.api.progress import VOLUME_LANDMARKS
 
 router = APIRouter()
 
@@ -252,6 +253,101 @@ async def get_plan(
             detail=f"Workout plan {plan_id} not found",
         )
     return serialize_plan(plan)
+
+
+@router.get("/{plan_id}/recommendations")
+async def get_plan_recommendations(
+    plan_id: int,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[dict]:
+    result = await db.execute(select(WorkoutPlan).where(WorkoutPlan.id == plan_id, WorkoutPlan.user_id == user.id))
+    plan = result.scalar_one_or_none()
+    if not plan:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Workout plan {plan_id} not found")
+
+    try:
+        planned_data = json.loads(plan.planned_exercises) if plan.planned_exercises else {}
+    except (json.JSONDecodeError, TypeError):
+        planned_data = {}
+    days = planned_data.get("days", []) if isinstance(planned_data, dict) else []
+
+    planned_set_counts: dict[int, int] = {}
+    muscle_planned_sets: dict[str, int] = {}
+    plan_exercise_ids: set[int] = set()
+    for day in days:
+        for ex in day.get("exercises", []):
+            ex_id = ex.get("exercise_id")
+            if not ex_id:
+                continue
+            plan_exercise_ids.add(ex_id)
+            planned_set_counts[ex_id] = planned_set_counts.get(ex_id, 0) + max(0, int(ex.get("sets", 0) or 0))
+
+    if not plan_exercise_ids:
+        return []
+
+    ex_rows = await db.execute(select(Exercise).where(Exercise.id.in_(plan_exercise_ids)))
+    exercises = {exercise.id: exercise for exercise in ex_rows.scalars().all()}
+    for ex_id, count in planned_set_counts.items():
+        exercise = exercises.get(ex_id)
+        for muscle in exercise.primary_muscles or [] if exercise else []:
+            muscle_planned_sets[muscle] = muscle_planned_sets.get(muscle, 0) + count
+
+    feedback_rows = await db.execute(
+        select(ExerciseFeedback, WorkoutSession)
+        .join(WorkoutSession, ExerciseFeedback.session_id == WorkoutSession.id)
+        .where(
+            ExerciseFeedback.user_id == user.id,
+            WorkoutSession.workout_plan_id == plan_id,
+            WorkoutSession.status == WorkoutStatus.COMPLETED,
+        )
+        .order_by(desc(WorkoutSession.date), desc(WorkoutSession.id), desc(ExerciseFeedback.id))
+    )
+
+    latest_feedback_by_exercise: dict[int, tuple[ExerciseFeedback, WorkoutSession]] = {}
+    for feedback, session in feedback_rows.all():
+        if feedback.exercise_id not in latest_feedback_by_exercise:
+            latest_feedback_by_exercise[feedback.exercise_id] = (feedback, session)
+
+    recommendations: list[dict] = []
+    for exercise_id, (feedback, session) in latest_feedback_by_exercise.items():
+        exercise = exercises.get(exercise_id)
+        if not exercise:
+            continue
+        if feedback.rir is None:
+            continue
+
+        primary_muscle = (exercise.primary_muscles or [None])[0]
+        muscle_landmarks = VOLUME_LANDMARKS.get(primary_muscle or "", {"mev": 4, "mav": 10, "mrv": 16})
+        weekly_sets = muscle_planned_sets.get(primary_muscle or "", 0)
+
+        if feedback.rir <= 1 and feedback.recovery_rating in {"poor", "ok"}:
+            add_set = weekly_sets < muscle_landmarks["mav"]
+            recommendations.append({
+                "type": "backoff_rir",
+                "exercise_id": exercise_id,
+                "exercise_name": exercise.display_name,
+                "muscle_group": primary_muscle,
+                "current_rir": feedback.rir,
+                "recovery_rating": feedback.recovery_rating,
+                "recommended_rir": 2,
+                "add_set": add_set,
+                "set_delta": 1 if add_set else 0,
+                "weekly_sets": weekly_sets,
+                "mav_sets": muscle_landmarks["mav"],
+                "reason": (
+                    f"{exercise.display_name} hit {feedback.rir} RIR with {feedback.recovery_rating} recovery. "
+                    f"Backing off to 2 RIR should improve recovery consistency."
+                ),
+                "detail": (
+                    f"{primary_muscle.replace('_', ' ').title() if primary_muscle else 'This muscle group'} is at "
+                    f"{weekly_sets} planned sets/week. "
+                    + ("Add 1 set to keep growth stimulus while easing effort." if add_set else "Hold set count steady for now.")
+                ),
+                "source_session_id": session.id,
+            })
+
+    return recommendations
 
 
 @router.post("/", response_model=WorkoutPlanResponse, status_code=status.HTTP_201_CREATED)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -285,6 +285,23 @@ export interface NextWorkoutResolution {
   };
 }
 
+export interface PlanRecommendation {
+  type: 'backoff_rir';
+  exercise_id: number;
+  exercise_name: string;
+  muscle_group: string | null;
+  current_rir: number;
+  recovery_rating: string | null;
+  recommended_rir: number;
+  add_set: boolean;
+  set_delta: number;
+  weekly_sets: number;
+  mav_sets: number;
+  reason: string;
+  detail: string;
+  source_session_id: number;
+}
+
 export interface ProgressMetric {
   exercise_id: number;
   exercise_name: string;
@@ -514,6 +531,11 @@ export async function getNextWorkout(): Promise<NextWorkoutResolution | null> {
 
 export async function getPlan(planId: number): Promise<WorkoutPlan> {
   const response = await api.get(`/plans/${planId}`);
+  return response.data;
+}
+
+export async function getPlanRecommendations(planId: number): Promise<PlanRecommendation[]> {
+  const response = await api.get(`/plans/${planId}/recommendations`);
   return response.data;
 }
 

--- a/frontend/src/routes/plans/+page.svelte
+++ b/frontend/src/routes/plans/+page.svelte
@@ -2,8 +2,8 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { workoutPlans, exercises, settings } from '$lib/stores';
-  import { getPlans, deletePlan, getExercises, updatePlan, archivePlan, reusePlan, getTemplates, cloneTemplate, getSessions, updatePlanRirOverrides } from '$lib/api';
-  import type { Exercise, WorkoutPlan, WorkoutTemplate, WorkoutSession, PlannedDay, PlanRirOverrides } from '$lib/api';
+  import { getPlans, deletePlan, getExercises, updatePlan, archivePlan, reusePlan, getTemplates, cloneTemplate, getSessions, updatePlanRirOverrides, getPlanRecommendations } from '$lib/api';
+  import type { Exercise, WorkoutPlan, WorkoutTemplate, WorkoutSession, PlannedDay, PlanRirOverrides, PlanRecommendation } from '$lib/api';
 
   let avgSetDuration = $state(30); // seconds per set from history, default 30s
 
@@ -15,6 +15,9 @@
   let rirPlan = $state<WorkoutPlan | null>(null);
   let rirOverridesDraft = $state<PlanRirOverrides>({ plan: null, muscles: {}, exercises: {} });
   let savingRir = $state(false);
+  let recommendationsByPlan = $state<Record<number, PlanRecommendation[]>>({});
+  let loadingRecommendations = $state<Record<number, boolean>>({});
+  let applyingRecommendation = $state<string | null>(null);
 
   // Templates
   let templates = $state<WorkoutTemplate[]>([]);
@@ -259,6 +262,8 @@
 
   function togglePlan(planId: number) {
     expandedPlan = expandedPlan === planId ? null : planId;
+    if (expandedPlan === planId) return;
+    void loadRecommendations(planId);
   }
 
   function toggleDay(planId: number, dayNum: number) {
@@ -268,6 +273,51 @@
 
   function isDayExpanded(planId: number, dayNum: number): boolean {
     return !!expandedDays[`${planId}-${dayNum}`];
+  }
+
+  async function loadRecommendations(planId: number) {
+    if (recommendationsByPlan[planId] || loadingRecommendations[planId]) return;
+    loadingRecommendations = { ...loadingRecommendations, [planId]: true };
+    try {
+      const recs = await getPlanRecommendations(planId);
+      recommendationsByPlan = { ...recommendationsByPlan, [planId]: recs };
+    } catch {
+      showError('Failed to load plan recommendations.');
+    } finally {
+      loadingRecommendations = { ...loadingRecommendations, [planId]: false };
+    }
+  }
+
+  async function applyRecommendation(plan: WorkoutPlan, recommendation: PlanRecommendation) {
+    const applyKey = `${plan.id}-${recommendation.exercise_id}`;
+    applyingRecommendation = applyKey;
+    try {
+      const nextOverrides = cloneOverrides(plan.rir_overrides);
+      nextOverrides.exercises[String(recommendation.exercise_id)] = recommendation.recommended_rir;
+      let nextPlan = await updatePlanRirOverrides(plan.id, nextOverrides);
+
+      if (recommendation.add_set && recommendation.set_delta > 0) {
+        const nextDays = nextPlan.days.map(day => ({
+          ...day,
+          exercises: day.exercises.map(ex => ex.exercise_id === recommendation.exercise_id
+            ? { ...ex, sets: Math.min((ex.sets ?? 1) + recommendation.set_delta, 12) }
+            : ex
+          ),
+        }));
+        nextPlan = await updatePlan(plan.id, { days: nextDays, number_of_days: nextPlan.number_of_days });
+      }
+
+      localPlans = localPlans.map(existing => existing.id === nextPlan.id ? nextPlan : existing);
+      workoutPlans.set(localPlans);
+      recommendationsByPlan = {
+        ...recommendationsByPlan,
+        [plan.id]: (recommendationsByPlan[plan.id] ?? []).filter(rec => rec.exercise_id !== recommendation.exercise_id),
+      };
+    } catch {
+      showError('Failed to apply recommendation.');
+    } finally {
+      applyingRecommendation = null;
+    }
   }
 </script>
 
@@ -341,6 +391,42 @@
                   {/if}
                 </div>
               {/each}
+
+              <div class="space-y-2">
+                <div class="flex items-center justify-between">
+                  <h4 class="text-sm font-semibold text-zinc-300">Recommendations</h4>
+                  {#if loadingRecommendations[plan.id]}
+                    <span class="text-xs text-zinc-500">Loading…</span>
+                  {/if}
+                </div>
+                {#if (recommendationsByPlan[plan.id]?.length ?? 0) > 0}
+                  <div class="space-y-2">
+                    {#each recommendationsByPlan[plan.id] as recommendation}
+                      <div class="rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-3">
+                        <div class="flex items-start justify-between gap-3">
+                          <div class="min-w-0">
+                            <p class="text-sm font-medium text-amber-300">{recommendation.exercise_name}</p>
+                            <p class="text-xs text-zinc-300 mt-1">{recommendation.reason}</p>
+                            <p class="text-xs text-zinc-500 mt-1">{recommendation.detail}</p>
+                            <p class="text-[11px] text-zinc-500 mt-2">
+                              Apply: {recommendation.recommended_rir} RIR{recommendation.add_set ? ` and +${recommendation.set_delta} set` : ''}
+                            </p>
+                          </div>
+                          <button
+                            onclick={() => applyRecommendation(plan, recommendation)}
+                            class="btn-primary text-sm shrink-0"
+                            disabled={applyingRecommendation === `${plan.id}-${recommendation.exercise_id}`}
+                          >
+                            {applyingRecommendation === `${plan.id}-${recommendation.exercise_id}` ? 'Applying…' : 'Apply'}
+                          </button>
+                        </div>
+                      </div>
+                    {/each}
+                  </div>
+                {:else if !loadingRecommendations[plan.id]}
+                  <p class="text-xs text-zinc-500">No autoregulation recommendations yet.</p>
+                {/if}
+              </div>
 
               <!-- Actions -->
               <div class="flex items-center gap-2 pt-2 border-t border-zinc-800">

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -112,6 +112,35 @@ class TestPlansCRUD:
         assert data["rir_overrides"]["muscles"]["quadriceps"] == 3
         assert data["rir_overrides"]["exercises"][str(ex["id"])] == 1
 
+    async def test_get_plan_recommendations_flags_low_recovery_low_rir(self, client: AsyncClient):
+        """GET /plans/{id}/recommendations suggests backing off and adding a set when effort is too high."""
+        ex = await create_exercise(client, display_name="Squat", primary_muscles=["quadriceps"], secondary_muscles=["glutes"])
+        plan = await create_plan(client, ex["id"], sets=3, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess["id"], sess["sets"][0]["id"], 100.0, 8)
+        complete_r = await client.post(f"/api/sessions/{sess['id']}/complete")
+        assert complete_r.status_code == 200, complete_r.text
+        feedback_r = await client.post(
+            f"/api/sessions/{sess['id']}/feedback",
+            json={
+                "exercise_id": ex["id"],
+                "recovery_rating": "poor",
+                "rir": 0,
+                "pump_rating": "good",
+                "suggestion": "ease",
+                "suggestion_detail": "Hold steady — recovery needs time",
+            },
+        )
+        assert feedback_r.status_code == 201, feedback_r.text
+
+        r = await client.get(f"/api/plans/{plan['id']}/recommendations")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert len(data) == 1
+        assert data[0]["type"] == "backoff_rir"
+        assert data[0]["recommended_rir"] == 2
+        assert data[0]["add_set"] is True
+
     async def test_next_workout_defaults_to_first_day(self, client: AsyncClient):
         """GET /plans/next-workout returns day 1 when nothing is completed yet."""
         ex = await create_exercise(client)


### PR DESCRIPTION
## Summary
- generate plan-specific recommendations from recent low-recovery, low-RIR feedback
- show those recommendations in the plans UI with one-click apply actions
- apply recommendations by setting the exercise RIR target and optionally adding a set

## Testing
- ./venv/bin/python -m pytest tests/test_plans.py -k 'recommendations or rir_overrides' -vv
- cd frontend && timeout 30s ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
- git diff --check -- app/api/plans.py frontend/src/lib/api.ts frontend/src/routes/plans/+page.svelte tests/test_plans.py

Closes #625