### PR TITLE
Sync HealthKit workouts when app becomes active

### DIFF
--- a/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
+++ b/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct GymTrackerApp: App {
+    @Environment(\.scenePhase) private var scenePhase
     @State private var auth = AuthService.shared
 
     var body: some Scene {
@@ -13,6 +14,10 @@ struct GymTrackerApp: App {
                             // Fire-and-forget — don't block app launch
                             Task { await SettingsSync.loadFromDB() }
                             Task { await HealthKitManager.shared.syncBodyWeightOnLaunch() }
+                            Task { await WorkoutSyncService.shared.syncRecentWorkouts() }
+                        }
+                        .onChange(of: scenePhase) { _, newPhase in
+                            guard newPhase == .active else { return }
                             Task { await WorkoutSyncService.shared.syncRecentWorkouts() }
                         }
                 } else {

--- a/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
+++ b/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
@@ -18,7 +18,13 @@ class WorkoutSyncService {
     }
 
     var isSyncEnabled: Bool {
-        get { UserDefaults.standard.bool(forKey: "healthkit_workout_sync_enabled") }
+        get {
+            let defaults = UserDefaults.standard
+            if defaults.object(forKey: "healthkit_workout_sync_enabled") == nil {
+                return true
+            }
+            return defaults.bool(forKey: "healthkit_workout_sync_enabled")
+        }
         set { UserDefaults.standard.set(newValue, forKey: "healthkit_workout_sync_enabled") }
     }
 

--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -1038,6 +1038,10 @@ struct SettingsView: View {
         Task {
             let success = await HealthKitManager.shared.requestAuthorization()
             healthKitAuthorized = success
+            if success {
+                WorkoutSyncService.shared.isSyncEnabled = true
+                await WorkoutSyncService.shared.syncRecentWorkouts()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- default workout sync to enabled unless the user explicitly turns it off
- enable and trigger workout sync immediately after HealthKit authorization succeeds
- rerun recent workout sync when the iOS app becomes active

## Testing
- git diff --check -- 'ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift' 'ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift' 'ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift'
- xcodebuild -project 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj' -scheme 'Gym Tracker' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build

Closes #632
