### PR TITLE
Add HealthKit workout sync diagnostics

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -215,14 +215,18 @@ final class HealthKitManager: @unchecked Sendable {
     /// Formula: kcal = MET × bodyWeightKg × durationHours
     /// Write a workout from API session data to HealthKit
     func writeWorkoutFromAPI(
+        sessionId: Int? = nil,
         name: String,
         startDate: Date,
         endDate: Date,
         totalCalories: Double,
         totalSets: Int,
         totalVolume: Double
-    ) async {
-        guard isAuthorized else { return }
+    ) async -> Bool {
+        guard isAuthorized else {
+            print("[HealthKit] Refusing workout sync for session \(sessionId.map(String.init) ?? "?") because HealthKit is not authorized")
+            return false
+        }
 
         let calorieQuantity = HKQuantity(unit: .kilocalorie(), doubleValue: totalCalories)
 
@@ -242,6 +246,7 @@ final class HealthKitManager: @unchecked Sendable {
         )
 
         do {
+            print("[HealthKit] Saving workout session \(sessionId.map(String.init) ?? "?") '\(name)' start=\(startDate) end=\(endDate) totalSets=\(totalSets) totalVolumeKg=\(totalVolume)")
             try await store.save(workout)
 
             let energyType = HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!
@@ -253,9 +258,11 @@ final class HealthKitManager: @unchecked Sendable {
             )
             try await store.addSamples([energySample], to: workout)
 
-            print("[HealthKit] Synced workout '\(name)': \(Int(totalCalories)) kcal")
+            print("[HealthKit] Synced workout session \(sessionId.map(String.init) ?? "?") '\(name)': \(Int(totalCalories)) kcal")
+            return true
         } catch {
-            print("[HealthKit] Save workout error: \(error)")
+            print("[HealthKit] Save workout error for session \(sessionId.map(String.init) ?? "?") '\(name)': \(error)")
+            return false
         }
     }
 }

--- a/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
+++ b/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
@@ -30,50 +30,66 @@ class WorkoutSyncService {
 
     /// Fetch recent completed sessions and sync unsynced ones to HealthKit
     func syncRecentWorkouts() async {
-        guard isSyncEnabled else { return }
+        guard isSyncEnabled else {
+            print("[WorkoutSync] Skipping sync because workout sync is disabled")
+            return
+        }
         var authorized = HealthKitManager.shared.isAuthorized
+        print("[WorkoutSync] Starting recent workout sync. authorized=\(authorized) cachedSyncedCount=\(syncedIds.count)")
         if !authorized {
+            print("[WorkoutSync] Requesting HealthKit authorization before workout sync")
             authorized = await HealthKitManager.shared.requestAuthorization()
         }
-        guard authorized else { return }
+        guard authorized else {
+            print("[WorkoutSync] Aborting sync because HealthKit authorization was not granted")
+            return
+        }
 
         do {
             // Fetch recent completed sessions
             let sessions: [WorkoutSession] = try await APIClient.shared.get("/sessions/",
                 query: [.init(name: "limit", value: "20")])
             let completed = sessions.filter { $0.status == "completed" && $0.completed_at != nil }
+            print("[WorkoutSync] Fetched \(sessions.count) recent sessions, \(completed.count) eligible completed sessions")
 
             var newlySynced = 0
             for session in completed {
-                if !syncedIds.contains(session.id) {
-                    await writeSessionToHealthKit(session)
+                if syncedIds.contains(session.id) {
+                    print("[WorkoutSync] Skipping session \(session.id) '\(session.name ?? "Workout")' because it is already marked synced")
+                    continue
+                }
+
+                let didSync = await writeSessionToHealthKit(session)
+                if didSync {
                     syncedIds.insert(session.id)
                     newlySynced += 1
                 }
             }
 
             UserDefaults.standard.set(Date(), forKey: "healthkit_last_sync")
-            if newlySynced > 0 {
-                print("[WorkoutSync] Synced \(newlySynced) workouts to HealthKit")
-            }
+            print("[WorkoutSync] Sync finished. newlySynced=\(newlySynced)")
         } catch {
             print("[WorkoutSync] Error: \(error)")
         }
     }
 
-    private func writeSessionToHealthKit(_ session: WorkoutSession) async {
+    private func writeSessionToHealthKit(_ session: WorkoutSession) async -> Bool {
         // Parse dates
         let iso = ISO8601DateFormatter()
         iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let isoBasic = ISO8601DateFormatter()
 
         guard let startStr = session.started_at,
-              let start = iso.date(from: startStr) ?? isoBasic.date(from: startStr) else { return }
+              let start = iso.date(from: startStr) ?? isoBasic.date(from: startStr) else {
+            print("[WorkoutSync] Skipping session \(session.id) '\(session.name ?? "Workout")' because started_at is missing or unparsable: \(session.started_at ?? "nil")")
+            return false
+        }
         let end: Date
         if let endStr = session.completed_at,
            let parsed = iso.date(from: endStr) ?? isoBasic.date(from: endStr) {
             end = parsed
         } else {
+            print("[WorkoutSync] Session \(session.id) '\(session.name ?? "Workout")' has missing/unparsable completed_at (\(session.completed_at ?? "nil")); defaulting end time to +1 hour")
             end = start.addingTimeInterval(3600) // default 1 hour
         }
 
@@ -84,8 +100,10 @@ class WorkoutSyncService {
         // Simple calorie estimation: avg MET 5.0 for strength training
         let hours = duration / 3600.0
         let calories = max(1, 5.0 * max(bodyWeightKg, 75.0) * hours)
+        print("[WorkoutSync] Writing session \(session.id) '\(session.name ?? "Workout")' to HealthKit start=\(start) end=\(end) durationSeconds=\(Int(duration)) sets=\(totalSets) calories=\(Int(calories))")
 
-        await HealthKitManager.shared.writeWorkoutFromAPI(
+        return await HealthKitManager.shared.writeWorkoutFromAPI(
+            sessionId: session.id,
             name: session.name ?? "Workout",
             startDate: start,
             endDate: end,


### PR DESCRIPTION
## Summary
- add detailed logging around workout sync eligibility, skip reasons, and HealthKit writes
- log whether sessions are skipped because they are already marked synced
- log missing or unparsable timestamps and the exact HealthKit write attempt/result

## Testing
- git diff --check -- 'ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift' 'ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift'
- xcodebuild -project 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj' -scheme 'Gym Tracker' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
