### PR TITLE
Return nutrition entries newest first

### DIFF
--- a/app/api/nutrition.py
+++ b/app/api/nutrition.py
@@ -357,7 +357,7 @@ async def list_entries(
     result = await db.execute(
         select(NutritionEntry)
         .where(NutritionEntry.date == target_date, NutritionEntry.user_id == user.id)
-        .order_by(NutritionEntry.logged_at)
+        .order_by(desc(NutritionEntry.logged_at), desc(NutritionEntry.id))
     )
     entries = result.scalars().all()
 

--- a/tests/test_nutrition.py
+++ b/tests/test_nutrition.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+from app.models.nutrition import NutritionEntry
+
+
+async def test_list_entries_returns_newest_first(client, db):
+    entry_older = NutritionEntry(
+        user_id=1,
+        name="Greek Yogurt",
+        date=datetime(2026, 3, 30, tzinfo=timezone.utc).date(),
+        meal="breakfast",
+        quantity_g=200,
+        calories=150,
+        protein=20,
+        carbs=8,
+        fat=2,
+        logged_at=datetime(2026, 3, 30, 8, 0, tzinfo=timezone.utc),
+    )
+    entry_newer = NutritionEntry(
+        user_id=1,
+        name="Blueberries",
+        date=datetime(2026, 3, 30, tzinfo=timezone.utc).date(),
+        meal="breakfast",
+        quantity_g=100,
+        calories=60,
+        protein=1,
+        carbs=14,
+        fat=0,
+        logged_at=datetime(2026, 3, 30, 8, 5, tzinfo=timezone.utc),
+    )
+    db.add_all([entry_older, entry_newer])
+    await db.commit()
+
+    response = await client.get("/api/nutrition/entries", params={"date": "2026-03-30"})
+    assert response.status_code == 200, response.text
+
+    breakfast = response.json()["meals"]["breakfast"]
+    assert [entry["name"] for entry in breakfast] == ["Blueberries", "Greek Yogurt"]


### PR DESCRIPTION
## Summary
- return daily nutrition entries in newest-first order from the API
- break ties by id so food logs stay stable
- add a regression test for breakfast entry ordering

## Testing
- ./venv/bin/python -m pytest tests/test_nutrition.py -vv
- git diff --check -- app/api/nutrition.py tests/test_nutrition.py

Closes #635
