### PR TITLE
Fix iOS HealthKit workout session sync

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -11,6 +11,10 @@ final class HealthKitManager: @unchecked Sendable {
     // Protected by MainActor access pattern — only mutated from async functions
     // called from .task modifiers which run on MainActor
     private(set) var isAuthorized = false
+    private(set) var isBodyWeightAuthorized = false
+    private(set) var isWorkoutAuthorized = false
+    private(set) var isEnergyAuthorized = false
+    var canWriteWorkouts: Bool { isWorkoutAuthorized && isEnergyAuthorized }
 
     // MARK: - Types we read/write
 
@@ -31,13 +35,37 @@ final class HealthKitManager: @unchecked Sendable {
 
     var isAvailable: Bool { HKHealthStore.isHealthDataAvailable() }
 
+    private func refreshAuthorizationState() {
+        guard isAvailable else {
+            isAuthorized = false
+            isBodyWeightAuthorized = false
+            isWorkoutAuthorized = false
+            isEnergyAuthorized = false
+            return
+        }
+
+        let bodyWeightStatus = store.authorizationStatus(
+            for: HKObjectType.quantityType(forIdentifier: .bodyMass)!
+        )
+        let workoutStatus = store.authorizationStatus(
+            for: HKObjectType.workoutType()
+        )
+        let energyStatus = store.authorizationStatus(
+            for: HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!
+        )
+
+        isBodyWeightAuthorized = (bodyWeightStatus == .sharingAuthorized)
+        isWorkoutAuthorized = (workoutStatus == .sharingAuthorized)
+        isEnergyAuthorized = (energyStatus == .sharingAuthorized)
+        isAuthorized = isBodyWeightAuthorized || canWriteWorkouts
+    }
+
     func requestAuthorization() async -> Bool {
         guard isAvailable else { return false }
         do {
             try await store.requestAuthorization(toShare: typesToWrite, read: typesToRead)
-            let status = store.authorizationStatus(
-                for: HKObjectType.quantityType(forIdentifier: .bodyMass)!)
-            isAuthorized = (status == .sharingAuthorized)
+            refreshAuthorizationState()
+            print("[HealthKit] Authorization refreshed. bodyWeight=\(isBodyWeightAuthorized) workout=\(isWorkoutAuthorized) energy=\(isEnergyAuthorized)")
             return isAuthorized
         } catch {
             print("[HealthKit] Auth error: \(error)")
@@ -46,10 +74,7 @@ final class HealthKitManager: @unchecked Sendable {
     }
 
     func checkAuthorization() {
-        guard isAvailable else { return }
-        let status = store.authorizationStatus(
-            for: HKObjectType.quantityType(forIdentifier: .bodyMass)!)
-        isAuthorized = (status == .sharingAuthorized)
+        refreshAuthorizationState()
     }
 
     // MARK: - Auto Sync
@@ -58,7 +83,7 @@ final class HealthKitManager: @unchecked Sendable {
     /// from HealthKit and syncs to backend if it's newer than what we have cached.
     func syncBodyWeightOnLaunch() async {
         checkAuthorization()
-        guard isAuthorized else { return }
+        guard isBodyWeightAuthorized else { return }
 
         guard let hkWeight = await readLatestBodyWeight() else { return }
 
@@ -128,7 +153,7 @@ final class HealthKitManager: @unchecked Sendable {
 
     /// Write a body weight sample to HealthKit
     func writeBodyWeight(kg: Double, date: Date = Date()) async {
-        guard isAuthorized else { return }
+        guard isBodyWeightAuthorized else { return }
         let type = HKObjectType.quantityType(forIdentifier: .bodyMass)!
         let quantity = HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: kg)
         let sample = HKQuantitySample(type: type, quantity: quantity, start: date, end: date)
@@ -223,8 +248,8 @@ final class HealthKitManager: @unchecked Sendable {
         totalSets: Int,
         totalVolume: Double
     ) async -> Bool {
-        guard isAuthorized else {
-            print("[HealthKit] Refusing workout sync for session \(sessionId.map(String.init) ?? "?") because HealthKit is not authorized")
+        guard canWriteWorkouts else {
+            print("[HealthKit] Refusing workout sync for session \(sessionId.map(String.init) ?? "?") because workout authorization is incomplete. workout=\(isWorkoutAuthorized) energy=\(isEnergyAuthorized)")
             return false
         }
 

--- a/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
+++ b/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
@@ -7,6 +7,22 @@ class WorkoutSyncService {
     static let shared = WorkoutSyncService()
 
     private let syncedKey = "healthkit_synced_session_ids"
+    private static let apiDateFormatterWithFractionalSeconds: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS"
+        return formatter
+    }()
+    private static let apiDateFormatterWithoutFractionalSeconds: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        return formatter
+    }()
 
     private var syncedIds: Set<Int> {
         get { Set(UserDefaults.standard.array(forKey: syncedKey) as? [Int] ?? []) }
@@ -34,14 +50,16 @@ class WorkoutSyncService {
             print("[WorkoutSync] Skipping sync because workout sync is disabled")
             return
         }
-        var authorized = HealthKitManager.shared.isAuthorized
-        print("[WorkoutSync] Starting recent workout sync. authorized=\(authorized) cachedSyncedCount=\(syncedIds.count)")
+        HealthKitManager.shared.checkAuthorization()
+        var authorized = HealthKitManager.shared.canWriteWorkouts
+        print("[WorkoutSync] Starting recent workout sync. canWriteWorkouts=\(authorized) cachedSyncedCount=\(syncedIds.count)")
         if !authorized {
             print("[WorkoutSync] Requesting HealthKit authorization before workout sync")
-            authorized = await HealthKitManager.shared.requestAuthorization()
+            _ = await HealthKitManager.shared.requestAuthorization()
+            authorized = HealthKitManager.shared.canWriteWorkouts
         }
         guard authorized else {
-            print("[WorkoutSync] Aborting sync because HealthKit authorization was not granted")
+            print("[WorkoutSync] Aborting sync because workout write authorization was not granted")
             return
         }
 
@@ -74,19 +92,14 @@ class WorkoutSyncService {
     }
 
     private func writeSessionToHealthKit(_ session: WorkoutSession) async -> Bool {
-        // Parse dates
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let isoBasic = ISO8601DateFormatter()
-
         guard let startStr = session.started_at,
-              let start = iso.date(from: startStr) ?? isoBasic.date(from: startStr) else {
+              let start = Self.parseAPITimestamp(startStr) else {
             print("[WorkoutSync] Skipping session \(session.id) '\(session.name ?? "Workout")' because started_at is missing or unparsable: \(session.started_at ?? "nil")")
             return false
         }
         let end: Date
         if let endStr = session.completed_at,
-           let parsed = iso.date(from: endStr) ?? isoBasic.date(from: endStr) {
+           let parsed = Self.parseAPITimestamp(endStr) {
             end = parsed
         } else {
             print("[WorkoutSync] Session \(session.id) '\(session.name ?? "Workout")' has missing/unparsable completed_at (\(session.completed_at ?? "nil")); defaulting end time to +1 hour")
@@ -111,5 +124,22 @@ class WorkoutSyncService {
             totalSets: totalSets,
             totalVolume: session.total_volume_kg ?? 0
         )
+    }
+
+    private static func parseAPITimestamp(_ value: String) -> Date? {
+        let isoWithFractionalSeconds = ISO8601DateFormatter()
+        isoWithFractionalSeconds.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let isoBasic = ISO8601DateFormatter()
+
+        if let date = isoWithFractionalSeconds.date(from: value) ?? isoBasic.date(from: value) {
+            return date
+        }
+
+        if let date = apiDateFormatterWithFractionalSeconds.date(from: value)
+            ?? apiDateFormatterWithoutFractionalSeconds.date(from: value) {
+            return date
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
## Summary
- parse the backend's naive workout session timestamps as UTC in iOS workout sync
- separate HealthKit body-weight authorization from workout/energy write authorization
- log the actual workout authorization state when sync is skipped

## Testing
- git diff --check -- 'ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift' 'ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift'
- xcodebuild -project 'ios/GymTracker/Gym Tracker/Gym Tracker.xcodeproj' -scheme 'Gym Tracker' -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build

Closes #640
