### PR TITLE
Per-set MET calorie estimation for HealthKit sync

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -53,6 +53,21 @@ def serialize_set(exercise_set: ExerciseSet) -> dict:
             if "exercise" in exercise_set.__dict__ and exercise_set.__dict__["exercise"] is not None
             else None
         ),
+        "movement_type": (
+            exercise_set.exercise.movement_type
+            if "exercise" in exercise_set.__dict__ and exercise_set.__dict__["exercise"] is not None
+            else None
+        ),
+        "body_region": (
+            exercise_set.exercise.body_region
+            if "exercise" in exercise_set.__dict__ and exercise_set.__dict__["exercise"] is not None
+            else None
+        ),
+        "equipment_type": (
+            exercise_set.exercise.equipment_type
+            if "exercise" in exercise_set.__dict__ and exercise_set.__dict__["exercise"] is not None
+            else None
+        ),
         "set_number": exercise_set.set_number,
         "planned_reps": exercise_set.planned_reps,
         "planned_reps_left": exercise_set.planned_reps_left,

--- a/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
+++ b/ios/GymTracker/Gym Tracker/Models/WorkoutModels.swift
@@ -61,6 +61,9 @@ struct ExerciseSet: Codable, Identifiable {
     let completed_at: String?
     let skipped_at: String?
     let set_type: String?
+    let movement_type: String?    // "compound" or "isolation"
+    let body_region: String?       // "upper", "lower", "full_body"
+    let equipment_type: String?    // "barbell", "dumbbell", "cable", "machine", etc.
     let sub_sets: [SubSet]?
     let draft_weight_kg: Double?
     let draft_reps: Int?

--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -290,4 +290,42 @@ final class HealthKitManager: @unchecked Sendable {
             return false
         }
     }
+
+    /// Delete all GymTracker-created workouts from HealthKit
+    func deleteAllGymTrackerWorkouts() async -> Int {
+        guard canWriteWorkouts else {
+            print("[HealthKit] Cannot delete workouts — no write authorization")
+            return 0
+        }
+
+        let workoutType = HKObjectType.workoutType()
+        let predicate = HKQuery.predicateForObjects(withMetadataKey: HKMetadataKeyWorkoutBrandName, allowedValues: ["GymTracker"])
+
+        return await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(sampleType: workoutType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: nil) { [weak self] _, samples, error in
+                guard let self, let workouts = samples as? [HKWorkout], error == nil else {
+                    print("[HealthKit] Error querying workouts for deletion: \(error?.localizedDescription ?? "unknown")")
+                    continuation.resume(returning: 0)
+                    return
+                }
+
+                print("[HealthKit] Found \(workouts.count) GymTracker workouts to delete")
+                guard !workouts.isEmpty else {
+                    continuation.resume(returning: 0)
+                    return
+                }
+
+                let objects = Set(workouts as [HKObject])
+                self.store.delete(objects) { success, deleteError in
+                    if success {
+                        print("[HealthKit] Deleted \(workouts.count) workouts")
+                    } else {
+                        print("[HealthKit] Error deleting workouts: \(deleteError?.localizedDescription ?? "unknown")")
+                    }
+                    continuation.resume(returning: success ? workouts.count : 0)
+                }
+            }
+            store.execute(query)
+        }
+    }
 }

--- a/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
+++ b/ios/GymTracker/Gym Tracker/Services/WorkoutSyncService.swift
@@ -44,6 +44,13 @@ class WorkoutSyncService {
         set { UserDefaults.standard.set(newValue, forKey: "healthkit_workout_sync_enabled") }
     }
 
+    /// Clear all synced state so every workout re-syncs on next launch
+    func resetSyncState() {
+        syncedIds = []
+        UserDefaults.standard.removeObject(forKey: "healthkit_last_sync")
+        print("[WorkoutSync] Reset sync state — all workouts will re-sync")
+    }
+
     /// Fetch recent completed sessions and sync unsynced ones to HealthKit
     func syncRecentWorkouts() async {
         guard isSyncEnabled else {
@@ -108,11 +115,10 @@ class WorkoutSyncService {
 
         let duration = end.timeIntervalSince(start)
         let totalSets = session.total_sets ?? 0
-        let bodyWeightKg = UserDefaults.standard.double(forKey: SettingsKey.lastBodyWeightKg)
+        let bodyWeightKg = max(UserDefaults.standard.double(forKey: SettingsKey.lastBodyWeightKg), 75.0)
 
-        // Simple calorie estimation: avg MET 5.0 for strength training
-        let hours = duration / 3600.0
-        let calories = max(1, 5.0 * max(bodyWeightKg, 75.0) * hours)
+        let result = estimateCalories(session: session, bodyWeightKg: bodyWeightKg)
+        let calories = result.total
         print("[WorkoutSync] Writing session \(session.id) '\(session.name ?? "Workout")' to HealthKit start=\(start) end=\(end) durationSeconds=\(Int(duration)) sets=\(totalSets) calories=\(Int(calories))")
 
         return await HealthKitManager.shared.writeWorkoutFromAPI(
@@ -124,6 +130,106 @@ class WorkoutSyncService {
             totalSets: totalSets,
             totalVolume: session.total_volume_kg ?? 0
         )
+    }
+
+    // MARK: - Calorie Estimation
+
+    /// MET value for a set based on exercise metadata
+    private func metForSet(_ set: ExerciseSet) -> Double {
+        let isCompound = set.movement_type == "compound"
+        let equipType = set.equipment_type ?? "other"
+        let freeWeight = ["barbell", "dumbbell", "kettlebell"].contains(equipType)
+        let plateLoaded = equipType == "plate_loaded"
+        let isWarmup = set.set_type == "warmup"
+
+        let baseMET: Double
+        if set.movement_type == nil {
+            // No metadata — fallback
+            baseMET = 5.0
+        } else if isCompound {
+            if freeWeight { baseMET = 6.0 }
+            else if plateLoaded { baseMET = 5.5 }
+            else { baseMET = 5.0 }
+        } else {
+            // Isolation
+            if freeWeight { baseMET = 4.0 }
+            else { baseMET = 3.5 }
+        }
+
+        return isWarmup ? baseMET * 0.6 : baseMET
+    }
+
+    /// Seconds per rep based on movement type
+    private func secsPerRep(isCompound: Bool) -> Double {
+        isCompound ? 3.0 : 2.0
+    }
+
+    /// Estimate calories for a workout session using per-set MET calculations
+    func estimateCalories(session: WorkoutSession, bodyWeightKg: Double) -> (total: Double, active: Double, rest: Double, epoc: Double) {
+        let sets = (session.sets ?? []).filter {
+            ($0.actual_reps ?? 0) > 0 && $0.skipped_at == nil
+        }
+
+        // Parse session duration
+        let sessionDuration: Double // seconds
+        if let startStr = session.started_at, let endStr = session.completed_at,
+           let start = Self.parseAPITimestamp(startStr), let end = Self.parseAPITimestamp(endStr) {
+            sessionDuration = min(end.timeIntervalSince(start), 3 * 3600) // cap 3 hours
+        } else {
+            // Fallback: estimate from set count
+            sessionDuration = Double(max(sets.count, 1)) * 120 // ~2 min per set avg
+        }
+        let clampedDuration = max(sessionDuration, 300) // min 5 minutes
+
+        guard !sets.isEmpty else {
+            // No set data — fall back to flat MET 5.0
+            let hours = clampedDuration / 3600.0
+            let total = max(1, 5.0 * bodyWeightKg * hours)
+            return (total, total, 0, 0)
+        }
+
+        // Active calories: sum per-set MET × bodyWeight × setDuration
+        var totalActiveSeconds: Double = 0
+        var activeCalories: Double = 0
+        var compoundSets = 0
+        var isolationSets = 0
+
+        for set in sets {
+            let reps = Double(set.actual_reps ?? 0)
+            let isCompound = set.movement_type == "compound"
+            let setDuration = reps * secsPerRep(isCompound: isCompound)
+            let met = metForSet(set)
+
+            activeCalories += met * bodyWeightKg * (setDuration / 3600.0)
+            totalActiveSeconds += setDuration
+
+            if isCompound { compoundSets += 1 } else { isolationSets += 1 }
+        }
+
+        // Rest calories: resting MET 1.2 for time between sets
+        let restSeconds = max(clampedDuration - totalActiveSeconds, 0)
+        let restCalories = 1.2 * bodyWeightKg * (restSeconds / 3600.0)
+
+        // EPOC bonus based on session intensity (volume / minutes)
+        let totalMinutes = clampedDuration / 60.0
+        let volumeKg = session.total_volume_kg ?? 0
+        let intensityPerMin = totalMinutes > 0 ? volumeKg / totalMinutes : 0
+        let epocMultiplier: Double
+        if intensityPerMin > 60 { epocMultiplier = 0.15 }
+        else if intensityPerMin > 30 { epocMultiplier = 0.10 }
+        else { epocMultiplier = 0.06 }
+        let epocCalories = activeCalories * epocMultiplier
+
+        let total = max(1.0, activeCalories + restCalories + epocCalories)
+
+        print("[WorkoutSync] Calorie breakdown for session \(session.id): "
+            + "active=\(Int(activeCalories)) rest=\(Int(restCalories)) "
+            + "epoc=\(Int(epocCalories)) total=\(Int(total)) "
+            + "compound=\(compoundSets) isolation=\(isolationSets) "
+            + "activeTime=\(Int(totalActiveSeconds))s restTime=\(Int(restSeconds))s "
+            + "intensity=\(Int(intensityPerMin))kg/min")
+
+        return (total, activeCalories, restCalories, epocCalories)
     }
 
     private static func parseAPITimestamp(_ value: String) -> Date? {

--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -662,6 +662,15 @@ struct SettingsView: View {
             Button("Sync Now") {
                 Task { await WorkoutSyncService.shared.syncRecentWorkouts() }
             }
+
+            Button("Delete & Re-Sync All Workouts", role: .destructive) {
+                Task {
+                    let deleted = await HealthKitManager.shared.deleteAllGymTrackerWorkouts()
+                    WorkoutSyncService.shared.resetSyncState()
+                    print("[Settings] Deleted \(deleted) workouts from HealthKit, reset sync state")
+                    await WorkoutSyncService.shared.syncRecentWorkouts()
+                }
+            }
         } header: {
             Text("Workout Sync")
         } footer: {


### PR DESCRIPTION
## Summary
- Replace flat MET 5.0 × duration formula with per-set calculation using exercise metadata (compound/isolation × equipment type)
- Active time estimated from actual reps: 3s/rep compound, 2s/rep isolation
- Rest periods calculated as remaining session time at MET 1.2
- EPOC bonus (6-15%) based on volume-per-minute intensity
- API now returns `movement_type`, `body_region`, `equipment_type` on each set
- Add "Delete & Re-Sync All Workouts" button in Settings to replace old inaccurate entries

Closes #642

## Test plan
- [ ] Build iOS app, open Settings → Workout Sync
- [ ] Tap "Delete & Re-Sync All Workouts" — verify old entries removed from Apple Health
- [ ] Check Xcode console for `[WorkoutSync] Calorie breakdown` logs with per-session detail
- [ ] Verify new calorie values in Apple Health are more realistic (~150-250 kcal/hr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)