### PR TITLE
Fix HealthKit delete API type mismatch

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -315,14 +315,15 @@ final class HealthKitManager: @unchecked Sendable {
                     return
                 }
 
-                let objects = Set(workouts as [HKObject])
-                self.store.delete(objects) { success, deleteError in
-                    if success {
+                Task {
+                    do {
+                        try await self.store.delete(workouts)
                         print("[HealthKit] Deleted \(workouts.count) workouts")
-                    } else {
-                        print("[HealthKit] Error deleting workouts: \(deleteError?.localizedDescription ?? "unknown")")
+                        continuation.resume(returning: workouts.count)
+                    } catch {
+                        print("[HealthKit] Error deleting workouts: \(error.localizedDescription)")
+                        continuation.resume(returning: 0)
                     }
-                    continuation.resume(returning: success ? workouts.count : 0)
                 }
             }
             store.execute(query)


### PR DESCRIPTION
## Summary
- Fix compile error: `No exact matches in call to instance method 'delete'` on `HKHealthStore`
- Replace completion handler `store.delete(Set<HKObject>)` with async `store.delete([HKObject])` API

Follow-up to #643

## Test plan
- [ ] Build iOS — verify no compile errors in HealthKitManager
- [ ] Tap "Delete & Re-Sync All Workouts" in Settings — verify workouts are deleted from Apple Health

🤖 Generated with [Claude Code](https://claude.com/claude-code)