### PR TITLE
Allow editing saved foods from the desktop nutrition app

### DIFF
--- a/app/api/nutrition.py
+++ b/app/api/nutrition.py
@@ -14,7 +14,7 @@ from app.database import get_db
 from app.models.body_weight import BodyWeightEntry
 from app.models.nutrition import COMMUNITY_THRESHOLD, FoodItem, FoodSubmission, MacroGoal, NutritionEntry, TDEEHistory, WaterEntry
 from app.models.user import User
-from app.schemas.requests import FoodItemCreate, MacroGoalsUpdate, NutritionEntryCreate, NutritionEntryUpdate, WaterEntryCreate
+from app.schemas.requests import FoodItemCreate, FoodItemUpdate, MacroGoalsUpdate, NutritionEntryCreate, NutritionEntryUpdate, WaterEntryCreate
 from app.services.expenditure import compute_adaptive_tdee
 
 router = APIRouter()
@@ -342,6 +342,35 @@ async def delete_food(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Food not found")
     await db.delete(food)
     await db.flush()
+
+
+@router.put("/foods/{food_id}")
+async def update_food(
+    food_id: int,
+    data: FoodItemUpdate,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Update a saved food owned by the current user."""
+    result = await db.execute(select(FoodItem).where(FoodItem.id == food_id, FoodItem.user_id == user.id))
+    food = result.scalar_one_or_none()
+    if not food:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Food not found")
+
+    food.name = data.name
+    food.brand = data.brand
+    food.barcode = data.barcode
+    food.calories_per_100g = data.calories_per_100g
+    food.protein_per_100g = data.protein_per_100g
+    food.carbs_per_100g = data.carbs_per_100g
+    food.fat_per_100g = data.fat_per_100g
+    food.serving_size_g = data.serving_size_g
+    food.serving_label = data.serving_label
+    food.micronutrients = json.dumps(data.micronutrients) if data.micronutrients else None
+
+    await db.flush()
+    await db.refresh(food)
+    return serialize_food_item(food)
 
 
 # ── Nutrition entries (daily log) ─────────────────────────────────────────────

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -306,6 +306,10 @@ class FoodItemCreate(BaseModel):
     micronutrients: dict | None = None
 
 
+class FoodItemUpdate(FoodItemCreate):
+    pass
+
+
 class NutritionEntryCreate(BaseModel):
     food_item_id: int | None = None
     name: str

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -763,6 +763,21 @@ export async function createCustomFood(data: {
   return response.data;
 }
 
+export async function updateCustomFood(id: number, data: {
+  name: string;
+  brand?: string;
+  barcode?: string;
+  calories_per_100g: number;
+  protein_per_100g: number;
+  carbs_per_100g: number;
+  fat_per_100g: number;
+  serving_size_g?: number;
+  serving_label?: string;
+}): Promise<FoodItem> {
+  const response = await api.put(`/nutrition/foods/${id}`, data);
+  return response.data;
+}
+
 export async function deleteCustomFood(id: number): Promise<void> {
   await api.delete(`/nutrition/foods/${id}`);
 }

--- a/frontend/src/routes/nutrition/+page.svelte
+++ b/frontend/src/routes/nutrition/+page.svelte
@@ -4,7 +4,7 @@
   import {
     getNutritionEntries, addNutritionEntry, deleteNutritionEntry,
     getDailySummary, setMacroGoals,
-    searchFoods, lookupBarcode, getCustomFoods, createCustomFood, deleteCustomFood, createCommunityFood,
+    searchFoods, lookupBarcode, getCustomFoods, createCustomFood, updateCustomFood, deleteCustomFood, createCommunityFood,
     getActivePhase, createPhase, endPhase, recalculatePhase,
     getRecipes, logRecipe, createRecipe, deleteRecipe,
   } from '$lib/api';
@@ -42,13 +42,16 @@
 
   // Manual tab
   let manualName = $state('');
+  let manualBrand = $state('');
   let manualCal = $state<number | null>(null);
   let manualProtein = $state<number | null>(null);
   let manualCarbs = $state<number | null>(null);
   let manualFat = $state<number | null>(null);
   let manualQty = $state(100);
+  let manualServingLabel = $state('');
   let saveAsCustom = $state(false);
   let showFullMacros = $state(false);
+  let editingFood = $state<FoodItem | null>(null);
 
   // Quick-add tab
   let quickCal = $state<number | null>(null);
@@ -319,13 +322,16 @@
     searchResults = [];
     selectedFood = null;
     manualName = '';
+    manualBrand = '';
     manualCal = null;
     manualProtein = null;
     manualCarbs = null;
     manualFat = null;
     manualQty = 100;
+    manualServingLabel = '';
     saveAsCustom = false;
     showFullMacros = false;
+    editingFood = null;
     showAddModal = true;
   }
 
@@ -398,15 +404,56 @@
       const scale = 100 / qty;
       await createCustomFood({
         name: manualName.trim(),
+        brand: manualBrand.trim() || undefined,
         calories_per_100g: (manualCal ?? 0) * scale,
         protein_per_100g: (manualProtein ?? 0) * scale,
         carbs_per_100g: (manualCarbs ?? 0) * scale,
         fat_per_100g: (manualFat ?? 0) * scale,
         serving_size_g: qty,
+        serving_label: manualServingLabel.trim() || undefined,
       });
     }
     showAddModal = false;
     await loadDay();
+  }
+
+  function startEditingFood(food: FoodItem) {
+    const qty = food.serving_size_g || 100;
+    const scale = qty / 100;
+    activeTab = 'manual';
+    editingFood = food;
+    selectedFood = null;
+    manualName = food.name;
+    manualBrand = food.brand ?? '';
+    manualQty = qty;
+    manualServingLabel = food.serving_label ?? '';
+    manualCal = Math.round((food.calories_per_100g ?? 0) * scale);
+    manualProtein = Math.round((food.protein_per_100g ?? 0) * scale * 10) / 10;
+    manualCarbs = Math.round((food.carbs_per_100g ?? 0) * scale * 10) / 10;
+    manualFat = Math.round((food.fat_per_100g ?? 0) * scale * 10) / 10;
+    showFullMacros = !!((food.carbs_per_100g ?? 0) || (food.fat_per_100g ?? 0));
+    saveAsCustom = false;
+    showAddModal = true;
+  }
+
+  async function saveEditedFood() {
+    if (!editingFood || !manualName.trim()) return;
+    const qty = manualQty || 100;
+    const scale = 100 / qty;
+    const updated = await updateCustomFood(editingFood.id, {
+      name: manualName.trim(),
+      brand: manualBrand.trim() || undefined,
+      barcode: editingFood.barcode ?? undefined,
+      calories_per_100g: (manualCal ?? 0) * scale,
+      protein_per_100g: (manualProtein ?? 0) * scale,
+      carbs_per_100g: (manualCarbs ?? 0) * scale,
+      fat_per_100g: (manualFat ?? 0) * scale,
+      serving_size_g: qty,
+      serving_label: manualServingLabel.trim() || undefined,
+    });
+    customFoods = customFoods.map((food) => food.id === updated.id ? updated : food);
+    editingFood = null;
+    showAddModal = false;
   }
 
   async function removeEntry(id: number) {
@@ -986,7 +1033,7 @@
         {:else}
           <h3 class="font-semibold text-white">Add Food</h3>
         {/if}
-        <button onclick={() => { stopScanner(); showAddModal = false; selectedFood = null; }} class="text-zinc-400 hover:text-white text-xl">✕</button>
+        <button onclick={() => { stopScanner(); showAddModal = false; selectedFood = null; editingFood = null; }} class="text-zinc-400 hover:text-white text-xl">✕</button>
       </div>
 
       {#if selectedFood}
@@ -1288,6 +1335,10 @@
                 <label class="text-xs text-zinc-400 block mb-1">Food name</label>
                 <input type="text" bind:value={manualName} placeholder="e.g. Chicken breast" class="input" />
               </div>
+              <div>
+                <label class="text-xs text-zinc-400 block mb-1">Brand <span class="text-zinc-600">(optional)</span></label>
+                <input type="text" bind:value={manualBrand} placeholder="e.g. Kirkland" class="input" />
+              </div>
               <div class="grid grid-cols-2 gap-3">
                 <div>
                   <label class="text-xs text-zinc-400 block mb-1">Calories</label>
@@ -1322,13 +1373,19 @@
                 <label class="text-xs text-zinc-400 block mb-1">Quantity (g)</label>
                 <input type="number" bind:value={manualQty} min="1" class="input" />
               </div>
+              <div>
+                <label class="text-xs text-zinc-400 block mb-1">Serving Label <span class="text-zinc-600">(optional)</span></label>
+                <input type="text" bind:value={manualServingLabel} placeholder="e.g. 1 cup" class="input" />
+              </div>
+              {#if !editingFood}
               <label class="flex items-center gap-2 text-sm text-zinc-400">
                 <input type="checkbox" bind:checked={saveAsCustom} class="rounded bg-zinc-800 border-zinc-700" />
                 Save as custom food
               </label>
-              <button onclick={logManualEntry} disabled={!manualName.trim()}
+              {/if}
+              <button onclick={editingFood ? saveEditedFood : logManualEntry} disabled={!manualName.trim()}
                       class="btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed">
-                Log Food
+                {editingFood ? 'Save Changes' : 'Log Food'}
               </button>
             </div>
 
@@ -1394,6 +1451,11 @@
                         · {Math.round(food.calories_per_100g)} cal/100g
                       {/if}
                     </p>
+                  </button>
+                  <button onclick={() => startEditingFood(food)}
+                          class="px-2 py-2 text-zinc-600 hover:text-blue-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                          title="Edit saved food">
+                    ✎
                   </button>
                   <button onclick={async () => {
                             if (!confirm(`Delete "${food.name}"?`)) return;

--- a/tests/test_nutrition.py
+++ b/tests/test_nutrition.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 
+from app.models.nutrition import FoodItem
 from app.models.nutrition import NutritionEntry
 
 
@@ -36,3 +37,42 @@ async def test_list_entries_returns_newest_first(client, db):
 
     breakfast = response.json()["meals"]["breakfast"]
     assert [entry["name"] for entry in breakfast] == ["Blueberries", "Greek Yogurt"]
+
+
+async def test_update_custom_food(client, db):
+    food = FoodItem(
+        user_id=1,
+        name="Chicken Breast",
+        brand="Store Brand",
+        source="custom",
+        is_custom=True,
+        calories_per_100g=165,
+        protein_per_100g=31,
+        carbs_per_100g=0,
+        fat_per_100g=3.6,
+        serving_size_g=100,
+        serving_label="100g",
+    )
+    db.add(food)
+    await db.commit()
+    await db.refresh(food)
+
+    response = await client.put(f"/api/nutrition/foods/{food.id}", json={
+        "name": "Chicken Breast, Cooked",
+        "brand": "Store Brand",
+        "barcode": "123456789012",
+        "calories_per_100g": 180,
+        "protein_per_100g": 32,
+        "carbs_per_100g": 1,
+        "fat_per_100g": 4,
+        "serving_size_g": 112,
+        "serving_label": "4 oz",
+    })
+    assert response.status_code == 200, response.text
+
+    payload = response.json()
+    assert payload["name"] == "Chicken Breast, Cooked"
+    assert payload["barcode"] == "123456789012"
+    assert payload["calories_per_100g"] == 180
+    assert payload["serving_size_g"] == 112
+    assert payload["serving_label"] == "4 oz"


### PR DESCRIPTION
## Summary
- add a backend update route for user-owned saved foods
- expose a client helper for updating food records
- let the desktop nutrition modal edit saved foods from the custom-foods list using the existing manual form

## Testing
- cd /tmp/home-gym-650 && PYTHONPATH=/tmp/home-gym-650 /Users/calebmorton/home-gym-tracker/venv/bin/python -m pytest tests/test_nutrition.py -vv
- cd /tmp/home-gym-650/frontend && ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
  - passes with 0 errors; existing repo warnings unchanged
- git diff --check -- app/api/nutrition.py app/schemas/requests.py frontend/src/lib/api.ts frontend/src/routes/nutrition/+page.svelte tests/test_nutrition.py

Closes #650
