### PR TITLE
Fix PWA favicon after icon update

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%sveltekit.assets%/icons/icon.svg" type="image/svg+xml" />
+    <link rel="icon" href="%sveltekit.assets%/icons/icon-192.png" type="image/png" />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/icons/icon-192.png" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <meta name="theme-color" content="#0f172a" />
+    <meta name="theme-color" content="#0170B9" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="GymTracker" />
+    <meta name="apple-mobile-web-app-title" content="Onyx" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="description" content="Track workouts, nutrition, and progress with science-based programming" />
     %sveltekit.head%


### PR DESCRIPTION
## Summary
- Favicon was pointing to deleted `icon.svg`, updated to `icon-192.png`
- Updated theme-color from old navy to Onyx blue (#0170B9)
- Updated apple-mobile-web-app-title to "Onyx"

Closes #658

## Test plan
- [ ] Load PWA — favicon shows in browser tab
- [ ] Check mobile home screen icon renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)