### PR TITLE
Configurable quick chart count (2-12 exercises)

### DIFF
--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -70,6 +70,7 @@ export interface AppSettings {
   deload: DeloadSettings;
   progression: ProgressionSettings;
   dashboardWidgets: DashboardWidget[];
+  quickChartCount: number;
   settingsMeta?: SettingsMeta;
 }
 
@@ -138,6 +139,7 @@ const defaultSettings: AppSettings = {
     { id: 'repeatLast', enabled: false },
     { id: 'pinnedCharts', enabled: false },
   ],
+  quickChartCount: 4,
   progression: {
     trainingLevel: 'intermediate',
     upperWeightIncrement: 2.5,

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -237,7 +237,7 @@
       })
       .filter((card): card is NonNullable<typeof card> => !!card)
       .sort((a, b) => b.points - a.points || b.latest - a.latest)
-      .slice(0, 4);
+      .slice(0, $settings.quickChartCount ?? 4);
   });
   let progressMetricsByExerciseId = $derived.by(() => {
     const grouped = new Map<number, ProgressMetric[]>();
@@ -1045,7 +1045,18 @@
   <!-- ── Pinned Charts ─────────────────────────────────────────────── -->
   <div class="card">
     <div class="flex items-center justify-between mb-3">
-      <h3 class="font-semibold text-zinc-200">Quick Charts</h3>
+      <div class="flex items-center gap-2">
+        <h3 class="font-semibold text-zinc-200">Quick Charts</h3>
+        <select
+          value={$settings.quickChartCount ?? 4}
+          onchange={(e) => settings.update(s => ({ ...s, quickChartCount: Number((e.target as HTMLSelectElement).value) }))}
+          class="bg-zinc-800 text-zinc-400 text-xs rounded px-1.5 py-0.5 border border-zinc-700 cursor-pointer"
+        >
+          {#each [2, 4, 6, 8, 10, 12] as n}
+            <option value={n}>{n}</option>
+          {/each}
+        </select>
+      </div>
       <a href="/progress" class="text-xs text-primary-400 hover:text-primary-300 transition-colors">
         Full Progress →
       </a>


### PR DESCRIPTION
## Summary
- Add dropdown next to "Quick Charts" header to select 2, 4, 6, 8, 10, or 12 exercises
- `quickChartCount` added to AppSettings (default 4, persists and syncs)
- Replaces hardcoded `.slice(0, 4)`

Closes #662

## Test plan
- [ ] Dashboard shows dropdown next to Quick Charts
- [ ] Changing selection immediately updates number of charts shown
- [ ] Setting persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)