### PR TITLE
fix: parse fl oz/mL serving sizes; show mL unit for liquid foods (#664)

### DIFF
--- a/app/api/food_search.py
+++ b/app/api/food_search.py
@@ -147,12 +147,23 @@ def _normalize_calorieninjas(item: dict) -> dict | None:
 
 
 def _parse_serving(s: str | None) -> float:
-    """Try to extract grams from a serving string like '100 g' or '1 cup (240ml)'."""
+    """Extract serving size in grams/mL from strings like '100 g', '16 fl oz', '473 mL'."""
     if not s:
         return 100.0
     import re
-    m = re.search(r"(\d+\.?\d*)\s*g", s, re.IGNORECASE)
-    return float(m.group(1)) if m else 100.0
+    # Grams: "100g", "100 g" — but not "gal"
+    m = re.search(r"(\d+\.?\d*)\s*g(?!al)", s, re.IGNORECASE)
+    if m:
+        return float(m.group(1))
+    # Milliliters: "473 ml", "473mL"
+    m = re.search(r"(\d+\.?\d*)\s*ml", s, re.IGNORECASE)
+    if m:
+        return float(m.group(1))
+    # Fluid ounces: "16 fl oz", "16fl oz", "16 fl. oz"
+    m = re.search(r"(\d+\.?\d*)\s*fl\.?\s*oz", s, re.IGNORECASE)
+    if m:
+        return round(float(m.group(1)) * 29.5735, 1)
+    return 100.0
 
 
 def _completeness(item: dict) -> int:

--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionView.swift
@@ -1065,6 +1065,13 @@ struct ServingSizeSheet: View {
     private var carb: Double { (food.carbs_per_100g ?? 0) * scale }
     private var fat: Double { (food.fat_per_100g ?? 0) * scale }
 
+    // Liquids (fl oz / mL in label) should display mL, not g
+    private var isLiquid: Bool {
+        let label = (food.serving_label ?? "").lowercased()
+        return label.contains("ml") || label.contains("fl oz") || label.contains("fl. oz")
+    }
+    private var quantityUnit: String { isLiquid ? "mL" : "g" }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
@@ -1108,7 +1115,7 @@ struct ServingSizeSheet: View {
                                 Image(systemName: "plus.circle.fill").font(.title2).foregroundStyle(.blue)
                             }
                         }
-                        Text(String(format: "%.0fg total", quantity))
+                        Text(String(format: "%.0f", quantity) + "\(quantityUnit) total")
                             .font(.caption).foregroundStyle(.tertiary)
                     }
                 } else {
@@ -1122,7 +1129,7 @@ struct ServingSizeSheet: View {
                             .font(.title3).foregroundStyle(.secondary)
                     }
                     if unitMode != .grams {
-                        Text(String(format: "= %.0fg", quantity))
+                        Text(String(format: "= %.0f", quantity) + "\(quantityUnit)")
                             .font(.caption).foregroundStyle(.tertiary)
                     }
                 }


### PR DESCRIPTION
## Summary
- `_parse_serving` now handles `mL` (1:1) and `fl oz` (×29.5735) in addition to grams — a serving label like `"1 can (16 fl oz)"` now correctly resolves to ~473 instead of the 100.0 fallback
- Fixes calorie calculation: C4 shows ~10 kcal instead of 2 kcal
- `ServingSizeSheet` detects liquid foods (fl oz/mL in `serving_label`) and renders `"473mL total"` instead of `"100g total"`

## Root causes fixed
1. **`app/api/food_search.py` `_parse_serving`**: regex only matched `g`, ignored `ml` and `fl oz`
2. **`NutritionView.swift` `ServingSizeSheet`**: `"%.0fg total"` label was hardcoded — now uses `quantityUnit` (mL vs g) based on serving_label content

## Test plan
- [ ] Scan C4 Performance Energy Drink (or any 16 fl oz product) — should show ~473mL total and correct calories
- [ ] Non-liquid food (e.g. chicken breast) — should still show grams
- [ ] Custom amount entry in Oz mode for a liquid — conversion label shows mL
- [ ] All 116 backend unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)