### PR TITLE
Fix iOS recipe auth redirect on collection endpoints

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/RecipesView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/RecipesView.swift
@@ -102,7 +102,7 @@ struct RecipesView: View {
     private func loadRecipes() async {
         loading = true
         do {
-            recipes = try await APIClient.shared.get("/recipes")
+            recipes = try await APIClient.shared.get("/recipes/")
         } catch {
             print("[Recipes] Load error: \(error)")
         }
@@ -456,7 +456,7 @@ struct RecipeBuilderView: View {
             if let existing {
                 let _: RecipeModel = try await APIClient.shared.put("/recipes/\(existing.id)", body: body)
             } else {
-                let _: RecipeModel = try await APIClient.shared.post("/recipes", body: body)
+                let _: RecipeModel = try await APIClient.shared.post("/recipes/", body: body)
             }
             dismiss()
         } catch {


### PR DESCRIPTION
## Summary
- call the canonical recipe collection route directly from iOS
- avoid the redirect that can strip the Authorization header in URLSession
- restore authenticated recipe list and create requests on iOS

## Root cause
The iOS app called the recipe collection endpoint without the trailing slash while the backend route is mounted on the canonical trailing-slash path. The redirect could drop the auth header, which led to 401 Not authenticated errors.

## Testing
- not run in Xcode on this machine because full Xcode is not installed
- confirmed the diff is limited to the iOS recipe collection GET and POST paths

Closes #679