### PR TITLE
fix: rest timer hidden behind mobile bottom nav

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -234,8 +234,8 @@
     </div>
   {/if}
 
-  <!-- ── Bottom nav (mobile only) ──────────────────────────────────────── -->
-  <nav aria-label="Mobile navigation" class="bottom-nav md:hidden" class:hidden={keyboardOpen}>
+  <!-- ── Bottom nav (mobile only) — hidden during active workout so it doesn't cover the rest timer ── -->
+  <nav aria-label="Mobile navigation" class="bottom-nav md:hidden" class:hidden={keyboardOpen || $page.url.pathname.startsWith('/workout/active')}>
     {#each mobileNavItems as item}
       <a href={item.path} class="bottom-nav-item {isActive(item.path) ? 'active' : ''}">
         <span class="text-xl leading-none">{item.icon}</span>

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -3335,7 +3335,8 @@
     </div><!-- /scrollable -->
 
     <!-- ─── Rest timer banner (always visible) ──────────────────────────────── -->
-    <div class="sticky bottom-0 z-30 flex items-center px-4 {restActive ? 'py-2.5' : 'py-2'} border-t transition-colors {restActive ? 'bg-zinc-900/95 backdrop-blur border-primary-500/30' : 'bg-zinc-900/80 backdrop-blur border-zinc-800'}">
+    <div class="sticky bottom-0 z-30 flex items-center px-4 {restActive ? 'py-2.5' : 'py-2'} border-t transition-colors {restActive ? 'bg-zinc-900/95 backdrop-blur border-primary-500/30' : 'bg-zinc-900/80 backdrop-blur border-zinc-800'}"
+         style="padding-bottom: max({restActive ? '0.625rem' : '0.5rem'}, env(safe-area-inset-bottom, 0px))">
       {#if restActive}
         <div class="flex items-center gap-3 flex-1">
           <div class="w-7 h-7 rounded-full bg-primary-500/20 flex items-center justify-center shrink-0">


### PR DESCRIPTION
## Problem

The rest timer banner at the bottom of the active workout page was completely invisible on mobile. The layout's bottom navigation bar is `fixed bottom-0 z-40`; the timer was `sticky bottom-0 z-30` — the nav sat directly on top of it.

## Fix

- Hide the bottom nav while on `/workout/active` — the workout page is a full-screen immersive experience and doesn't need the nav visible (you can't navigate away mid-workout anyway)
- Add `safe-area-inset-bottom` padding to the timer banner for iPhone notch/home indicator

## Test plan
- [ ] Start a workout on mobile, complete a set — rest timer countdown should be visible at the bottom
- [ ] −15s / +15s / Skip buttons should be tappable (not covered)
- [ ] On iPhone, timer should respect the home indicator safe area
- [ ] Navigating away from `/workout/active` should restore the bottom nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)