### PR TITLE
Finish workout history edit follow-up after PR #686

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -651,6 +651,21 @@ async def update_set(
         )
 
     update_data = set_data.model_dump(exclude_unset=True)
+    if "exercise_id" in update_data:
+        exercise_id = update_data["exercise_id"]
+        if exercise_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="exercise_id cannot be null",
+            )
+        exercise_result = await db.execute(
+            select(Exercise).where(Exercise.id == exercise_id).where(_exercise_scope(user.id))
+        )
+        if exercise_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Exercise {exercise_id} not found",
+            )
     for field, value in update_data.items():
         # Strip timezone info — DB uses naive timestamps
         if isinstance(value, datetime) and value.tzinfo is not None:
@@ -715,8 +730,13 @@ async def update_set(
             )
 
     await db.flush()
-    await db.refresh(exercise_set)
-    return serialize_set(exercise_set)
+    refreshed_set_result = await db.execute(
+        select(ExerciseSet)
+        .options(selectinload(ExerciseSet.exercise))
+        .where(ExerciseSet.id == set_id, ExerciseSet.workout_session_id == session_id)
+    )
+    refreshed_set = refreshed_set_result.scalar_one()
+    return serialize_set(refreshed_set)
 
 
 @router.get("/{session_id}/audit", response_model=list[WorkoutSessionAuditResponse])

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -127,13 +127,14 @@ class SetCreate(BaseModel):
 
 
 class SetUpdate(BaseModel):
+    exercise_id: int | None = None
     actual_reps: int | None = None
     actual_weight_kg: float | None = None
     reps_left: int | None = None
     reps_right: int | None = None
     set_type: str | None = None
     sub_sets: list | str | None = None
-    peg_weights: str | None = None  # JSON: {"peg1":kg,"peg2":kg,"peg3":kg} per side
+    peg_weights: dict | list | str | None = None  # JSON: {"peg1":kg,"peg2":kg,"peg3":kg} per side
     notes: str | None = None
     completed_at: datetime | None = None
     started_at: datetime | None = None
@@ -147,6 +148,10 @@ class SetUpdate(BaseModel):
 class SetResponse(BaseModel):
     id: int
     exercise_id: int
+    exercise_name: str | None = None
+    movement_type: str | None = None
+    body_region: str | None = None
+    equipment_type: str | None = None
     set_number: int
     planned_reps: int | None = None
     planned_reps_left: int | None = None

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -184,6 +184,9 @@ export interface Set {
   id: number;
   exercise_id: number;
   exercise_name: string | null;
+  movement_type?: string | null;
+  body_region?: string | null;
+  equipment_type?: string | null;
   set_number: number;
   planned_reps: number | null;
   planned_reps_left: number | null;
@@ -199,6 +202,7 @@ export interface Set {
   skipped_at: string | null;
   set_type: string | null;
   sub_sets: { weight_kg: number; reps: number; type?: string }[] | null;
+  peg_weights?: { peg1?: number; peg2?: number; peg3?: number } | null;
   // Draft fields populated by the server for in-progress sets
   draft_weight_kg: number | null;
   draft_reps: number | null;

--- a/frontend/src/routes/calendar/workout/[name]/+page.svelte
+++ b/frontend/src/routes/calendar/workout/[name]/+page.svelte
@@ -1,21 +1,40 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { getSession, getSessions, updateSet } from '$lib/api';
+  import { getExercises, getSession, getSessions, updateSet } from '$lib/api';
   import { settings } from '$lib/stores';
-  import type { Set as WorkoutSet, WorkoutSession } from '$lib/api';
+  import type { Exercise, Set as WorkoutSet, WorkoutSession } from '$lib/api';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
 
   const KG_TO_LBS = 2.20462;
 
+  type PegDraft = { peg1: string; peg2: string; peg3: string };
+  type EditDraft = {
+    exerciseId: number;
+    weight: string;
+    reps: string;
+    notes: string;
+    pegWeights: PegDraft;
+  };
+  type SetGroup = {
+    key: string;
+    exerciseId: number;
+    exerciseName: string;
+    exercise: Exercise | undefined;
+    sets: WorkoutSet[];
+  };
+
   let loading = $state(true);
   let matchedSessions = $state<WorkoutSession[]>([]);
-  let expandedSessionIds = $state<Set<number>>(new Set());
   let detailedSessions = $state<Record<number, WorkoutSession>>({});
+  let allExercises = $state<Exercise[]>([]);
+  let expandedSessionIds = $state<Set<number>>(new Set());
+  let expandedGroupKeys = $state<Set<string>>(new Set());
+  let editingGroupKeys = $state<Set<string>>(new Set());
   let loadingSessionIds = $state<Set<number>>(new Set());
   let savingSetIds = $state<Set<number>>(new Set());
-  let editDrafts = $state<Record<number, { weight: string; reps: string; notes: string }>>({});
+  let editDrafts = $state<Record<number, EditDraft>>({});
 
   const workoutName = data.name;
 
@@ -56,6 +75,77 @@
       : weight;
   }
 
+  function emptyPegDraft(pegs?: WorkoutSet['peg_weights']): PegDraft {
+    return {
+      peg1: pegs?.peg1 != null ? String(pegs.peg1) : '',
+      peg2: pegs?.peg2 != null ? String(pegs.peg2) : '',
+      peg3: pegs?.peg3 != null ? String(pegs.peg3) : '',
+    };
+  }
+
+  function groupKey(sessionId: number, exerciseId: number): string {
+    return `${sessionId}:${exerciseId}`;
+  }
+
+  function getExerciseById(exerciseId: number | null | undefined): Exercise | undefined {
+    return allExercises.find((exercise) => exercise.id === exerciseId);
+  }
+
+  function displayExerciseName(set: WorkoutSet): string {
+    return set.exercise_name
+      ?? getExerciseById(set.exercise_id)?.display_name
+      ?? `Exercise #${set.exercise_id}`;
+  }
+
+  function isPrimePlateLoaded(exercise: Exercise | undefined): boolean {
+    return !!exercise && exercise.is_prime && exercise.equipment_type === 'plate_loaded';
+  }
+
+  function parseNumber(value: string): number | null {
+    const trimmed = value.trim();
+    if (trimmed === '') return null;
+    const parsed = Number(trimmed);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function sessionGroups(sessionId: number): SetGroup[] {
+    const session = detailedSessions[sessionId];
+    if (!session) return [];
+
+    const grouped = new Map<number, WorkoutSet[]>();
+    for (const set of session.sets) {
+      const existing = grouped.get(set.exercise_id) ?? [];
+      existing.push(set);
+      grouped.set(set.exercise_id, existing);
+    }
+
+    return [...grouped.entries()].map(([exerciseId, sets]) => ({
+      key: groupKey(sessionId, exerciseId),
+      exerciseId,
+      exerciseName: displayExerciseName(sets[0]),
+      exercise: getExerciseById(exerciseId),
+      sets,
+    }));
+  }
+
+  function buildDraft(set: WorkoutSet): EditDraft {
+    return {
+      exerciseId: set.exercise_id,
+      weight: displayWeight(set.actual_weight_kg),
+      reps: set.actual_reps != null ? String(set.actual_reps) : '',
+      notes: set.notes ?? '',
+      pegWeights: emptyPegDraft(set.peg_weights),
+    };
+  }
+
+  function resetDraftsFromSession(session: WorkoutSession) {
+    const drafts = { ...editDrafts };
+    for (const set of session.sets) {
+      drafts[set.id] = buildDraft(set);
+    }
+    editDrafts = drafts;
+  }
+
   async function loadSessionDetail(sessionId: number) {
     if (loadingSessionIds.has(sessionId)) return;
     loadingSessionIds.add(sessionId);
@@ -63,19 +153,8 @@
     try {
       const detail = await getSession(sessionId);
       detailedSessions = { ...detailedSessions, [sessionId]: detail };
-      matchedSessions = matchedSessions.map((session) =>
-        session.id === sessionId ? detail : session
-      );
-
-      const drafts = { ...editDrafts };
-      for (const set of detail.sets) {
-        drafts[set.id] = {
-          weight: displayWeight(set.actual_weight_kg),
-          reps: set.actual_reps != null ? String(set.actual_reps) : '',
-          notes: set.notes ?? '',
-        };
-      }
-      editDrafts = drafts;
+      matchedSessions = matchedSessions.map((session) => session.id === sessionId ? detail : session);
+      resetDraftsFromSession(detail);
     } catch (e) {
       console.error('Failed to load workout detail:', e);
     } finally {
@@ -93,8 +172,33 @@
 
     expandedSessionIds.add(sessionId);
     expandedSessionIds = new Set(expandedSessionIds);
-
     if (!detailedSessions[sessionId]) {
+      await loadSessionDetail(sessionId);
+    }
+  }
+
+  function toggleGroup(key: string) {
+    if (expandedGroupKeys.has(key)) expandedGroupKeys.delete(key);
+    else expandedGroupKeys.add(key);
+    expandedGroupKeys = new Set(expandedGroupKeys);
+  }
+
+  async function startEditingGroup(sessionId: number, key: string) {
+    if (!detailedSessions[sessionId]) {
+      await loadSessionDetail(sessionId);
+    }
+    expandedGroupKeys.add(key);
+    expandedGroupKeys = new Set(expandedGroupKeys);
+    editingGroupKeys.add(key);
+    editingGroupKeys = new Set(editingGroupKeys);
+  }
+
+  async function stopEditingGroup(sessionId: number, key: string) {
+    editingGroupKeys.delete(key);
+    editingGroupKeys = new Set(editingGroupKeys);
+    if (detailedSessions[sessionId]) {
+      resetDraftsFromSession(detailedSessions[sessionId]);
+    } else {
       await loadSessionDetail(sessionId);
     }
   }
@@ -103,17 +207,30 @@
     const draft = editDrafts[set.id];
     if (!draft) return;
 
-    const reps = draft.reps.trim() === '' ? null : Number(draft.reps);
-    const weight = draft.weight.trim() === '' ? null : Number(draft.weight);
-    if ((reps != null && Number.isNaN(reps)) || (weight != null && Number.isNaN(weight))) return;
+    const exerciseId = Number(draft.exerciseId);
+    const reps = parseNumber(draft.reps);
+    const weight = parseNumber(draft.weight);
+    const exercise = getExerciseById(exerciseId);
+    const peg1 = parseNumber(draft.pegWeights.peg1);
+    const peg2 = parseNumber(draft.pegWeights.peg2);
+    const peg3 = parseNumber(draft.pegWeights.peg3);
+    const hasPegValues = peg1 != null || peg2 != null || peg3 != null;
 
     savingSetIds.add(set.id);
     savingSetIds = new Set(savingSetIds);
     try {
       await updateSet(sessionId, set.id, {
+        exercise_id: exerciseId,
         actual_reps: reps,
         actual_weight_kg: weight != null ? toKg(weight) : null,
         notes: draft.notes.trim() || null,
+        peg_weights: isPrimePlateLoaded(exercise) && hasPegValues
+          ? {
+              peg1: peg1 ?? 0,
+              peg2: peg2 ?? 0,
+              peg3: peg3 ?? 0,
+            }
+          : null,
       });
       await loadSessionDetail(sessionId);
     } catch (e) {
@@ -125,19 +242,17 @@
     }
   }
 
-  let totalVolume = $derived(
-    matchedSessions.reduce((sum, session) => sum + (session.total_volume_kg ?? 0), 0)
-  );
-  let totalSets = $derived(
-    matchedSessions.reduce((sum, session) => sum + (session.total_sets ?? 0), 0)
-  );
-  let totalReps = $derived(
-    matchedSessions.reduce((sum, session) => sum + (session.total_reps ?? 0), 0)
-  );
+  let totalVolume = $derived(matchedSessions.reduce((sum, session) => sum + (session.total_volume_kg ?? 0), 0));
+  let totalSets = $derived(matchedSessions.reduce((sum, session) => sum + (session.total_sets ?? 0), 0));
+  let totalReps = $derived(matchedSessions.reduce((sum, session) => sum + (session.total_reps ?? 0), 0));
 
   onMount(async () => {
     try {
-      const sessions = await getSessions({ limit: 500 });
+      const [sessions, exercises] = await Promise.all([
+        getSessions({ limit: 500 }),
+        getExercises(),
+      ]);
+      allExercises = exercises;
       const target = normalizeName(workoutName);
       matchedSessions = sessions.filter((session) =>
         session.status === 'completed' && normalizeName(session.name) === target
@@ -150,12 +265,12 @@
   });
 </script>
 
-<div class="space-y-4 max-w-3xl mx-auto">
+<div class="space-y-4 max-w-4xl mx-auto">
   <div class="flex items-center justify-between gap-3">
     <div>
       <a href="/" class="text-xs text-primary-400 hover:text-primary-300 transition-colors">← Back to Dashboard</a>
       <h2 class="text-2xl font-bold mt-1">{workoutName}</h2>
-      <p class="text-sm text-zinc-500">Review past sessions and correct any logged set details.</p>
+      <p class="text-sm text-zinc-500">Review past sessions, open each exercise group, and edit only when you need to correct a log.</p>
     </div>
     <a href="/calendar" class="text-xs text-zinc-400 hover:text-zinc-200 transition-colors">Full Calendar</a>
   </div>
@@ -196,9 +311,7 @@
               >
                 <div>
                   <p class="text-sm font-medium text-zinc-100">{fmtDate(session.date)}</p>
-                  <p class="text-xs text-zinc-500 mt-1">
-                    {session.total_sets} sets · {session.total_reps} reps
-                  </p>
+                  <p class="text-xs text-zinc-500 mt-1">{session.total_sets} sets · {session.total_reps} reps</p>
                   {#if session.notes}
                     <p class="text-xs text-zinc-400 mt-2 line-clamp-2">{session.notes}</p>
                   {/if}
@@ -209,14 +322,11 @@
                   </p>
                   {#if session.completed_at}
                     <p class="text-xs text-zinc-500 mt-1">
-                      {new Date(session.completed_at).toLocaleTimeString('en-US', {
-                        hour: 'numeric',
-                        minute: '2-digit',
-                      })}
+                      {new Date(session.completed_at).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
                     </p>
                   {/if}
                   <p class="text-xs text-zinc-500 mt-2">
-                    {expandedSessionIds.has(session.id) ? 'Hide set details' : 'View and edit sets'}
+                    {expandedSessionIds.has(session.id) ? 'Hide history' : 'View exercise history'}
                   </p>
                 </div>
               </button>
@@ -229,59 +339,118 @@
                     <p class="text-sm text-zinc-500">No set details found for this session.</p>
                   {:else}
                     <div class="space-y-3">
-                      {#each detailedSessions[session.id].sets as set}
-                        {@const draft = editDrafts[set.id]}
-                        <div class="rounded-lg bg-zinc-950/70 border border-zinc-800 p-3 space-y-3">
-                          <div class="flex items-start justify-between gap-4">
-                            <div>
-                              <p class="text-sm font-medium text-zinc-100">
-                                {set.exercise_name ?? `Exercise #${set.exercise_id}`} · Set {set.set_number}
-                              </p>
-                              <p class="text-xs text-zinc-500 mt-1">
-                                Current log: {displayWeight(set.actual_weight_kg) || '0'} {volUnit()} × {set.actual_reps ?? 0} reps
-                              </p>
-                            </div>
+                      {#each sessionGroups(session.id) as group}
+                        <div class="rounded-lg border border-zinc-800 bg-zinc-950/60">
+                          <div class="flex items-center gap-3 px-4 py-3">
                             <button
-                              onclick={() => saveSet(session.id, set)}
-                              disabled={!draft || savingSetIds.has(set.id)}
-                              class="px-3 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-medium disabled:opacity-50"
+                              class="flex-1 text-left"
+                              onclick={() => toggleGroup(group.key)}
                             >
-                              {savingSetIds.has(set.id) ? 'Saving…' : 'Save'}
+                              <p class="text-sm font-medium text-zinc-100">{group.exerciseName}</p>
+                              <p class="text-xs text-zinc-500 mt-1">
+                                {group.sets.length} {group.sets.length === 1 ? 'set' : 'sets'}
+                                {#if group.exercise?.equipment_type}
+                                  · {group.exercise.equipment_type.replace('_', ' ')}
+                                {/if}
+                              </p>
                             </button>
+                            {#if editingGroupKeys.has(group.key)}
+                              <button
+                                class="px-3 py-1.5 rounded-lg border border-zinc-700 text-zinc-200 text-xs font-medium hover:border-zinc-500"
+                                onclick={() => stopEditingGroup(session.id, group.key)}
+                              >
+                                Done Editing
+                              </button>
+                            {:else}
+                              <button
+                                class="px-3 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-medium"
+                                onclick={() => startEditingGroup(session.id, group.key)}
+                              >
+                                Edit
+                              </button>
+                            {/if}
                           </div>
 
-                          {#if draft}
-                            <div class="grid grid-cols-2 gap-3">
-                              <div>
-                                <label class="text-xs text-zinc-500 block mb-1">Weight ({volUnit()})</label>
-                                <input
-                                  type="number"
-                                  bind:value={draft.weight}
-                                  class="input"
-                                  min="0"
-                                  step="0.5"
-                                />
-                              </div>
-                              <div>
-                                <label class="text-xs text-zinc-500 block mb-1">Reps</label>
-                                <input
-                                  type="number"
-                                  bind:value={draft.reps}
-                                  class="input"
-                                  min="0"
-                                  step="1"
-                                />
-                              </div>
-                            </div>
+                          {#if expandedGroupKeys.has(group.key)}
+                            <div class="border-t border-zinc-800 px-4 py-3 space-y-3">
+                              {#each group.sets as set}
+                                {@const draft = editDrafts[set.id]}
+                                {@const selectedExercise = draft ? getExerciseById(draft.exerciseId) : group.exercise}
+                                <div class="rounded-lg border border-zinc-800 bg-zinc-900/60 p-3 space-y-3">
+                                  <div class="flex items-start justify-between gap-4">
+                                    <div>
+                                      <p class="text-sm font-medium text-zinc-100">Set {set.set_number}</p>
+                                      <p class="text-xs text-zinc-500 mt-1">
+                                        Logged: {displayExerciseName(set)} · {displayWeight(set.actual_weight_kg) || '0'} {volUnit()} × {set.actual_reps ?? 0} reps
+                                      </p>
+                                      {#if set.notes}
+                                        <p class="text-xs text-zinc-400 mt-2">{set.notes}</p>
+                                      {/if}
+                                    </div>
+                                    {#if editingGroupKeys.has(group.key) && draft}
+                                      <button
+                                        onclick={() => saveSet(session.id, set)}
+                                        disabled={savingSetIds.has(set.id)}
+                                        class="px-3 py-1.5 rounded-lg bg-primary-600 text-white text-xs font-medium disabled:opacity-50"
+                                      >
+                                        {savingSetIds.has(set.id) ? 'Saving…' : 'Save'}
+                                      </button>
+                                    {/if}
+                                  </div>
 
-                            <div>
-                              <label class="text-xs text-zinc-500 block mb-1">Notes / machine</label>
-                              <input
-                                type="text"
-                                bind:value={draft.notes}
-                                class="input"
-                                placeholder="Machine, setup, or correction note"
-                              />
+                                  {#if editingGroupKeys.has(group.key) && draft}
+                                    <div>
+                                      <label class="text-xs text-zinc-500 block mb-1">Exercise</label>
+                                      <select bind:value={draft.exerciseId} class="input">
+                                        {#each allExercises as exercise}
+                                          <option value={exercise.id}>{exercise.display_name}</option>
+                                        {/each}
+                                      </select>
+                                    </div>
+
+                                    <div class="grid grid-cols-2 gap-3">
+                                      <div>
+                                        <label class="text-xs text-zinc-500 block mb-1">Weight ({volUnit()})</label>
+                                        <input type="number" bind:value={draft.weight} class="input" min="0" step="0.5" />
+                                      </div>
+                                      <div>
+                                        <label class="text-xs text-zinc-500 block mb-1">Reps</label>
+                                        <input type="number" bind:value={draft.reps} class="input" min="0" step="1" />
+                                      </div>
+                                    </div>
+
+                                    {#if isPrimePlateLoaded(selectedExercise)}
+                                      <div class="rounded-lg border border-zinc-800 bg-zinc-950/80 p-3">
+                                        <p class="text-xs font-medium text-zinc-300 mb-2">Prime peg weights per side</p>
+                                        <div class="grid grid-cols-3 gap-3">
+                                          {#each ['peg1', 'peg2', 'peg3'] as pegKey}
+                                            <div>
+                                              <label class="text-xs text-zinc-500 block mb-1">{pegKey.toUpperCase()}</label>
+                                              <input
+                                                type="number"
+                                                bind:value={draft.pegWeights[pegKey as keyof PegDraft]}
+                                                class="input"
+                                                min="0"
+                                                step="0.5"
+                                              />
+                                            </div>
+                                          {/each}
+                                        </div>
+                                      </div>
+                                    {/if}
+
+                                    <div>
+                                      <label class="text-xs text-zinc-500 block mb-1">Notes / machine</label>
+                                      <input
+                                        type="text"
+                                        bind:value={draft.notes}
+                                        class="input"
+                                        placeholder="Machine, setup, or correction note"
+                                      />
+                                    </div>
+                                  {/if}
+                                </div>
+                              {/each}
                             </div>
                           {/if}
                         </div>

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -132,6 +132,28 @@ class TestSessionLifecycle:
         assert data["actual_weight_kg"] == 80.0
         assert data["actual_reps"] == 10
 
+    async def test_log_set_allows_changing_exercise(self, client: AsyncClient):
+        """PATCH /sessions/{id}/sets/{set_id} can move a logged set to another visible exercise."""
+        ex = await create_exercise(client, name="incline_press", display_name="Incline Press")
+        replacement = await create_exercise(client, name="prime_press", display_name="Prime Press")
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+        sess = await start_session_from_plan(client, plan["id"])
+
+        set_id = sess["sets"][0]["id"]
+        r = await client.patch(
+            f"/api/sessions/{sess['id']}/sets/{set_id}",
+            json={
+                "exercise_id": replacement["id"],
+                "actual_weight_kg": 70.0,
+                "actual_reps": 9,
+                "completed_at": "2024-01-01T10:00:00",
+            },
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["exercise_id"] == replacement["id"]
+        assert data["exercise_name"] == replacement["display_name"]
+
     async def test_log_set_with_partials(self, client: AsyncClient):
         """PATCH /sessions/{id}/sets/{set_id} accepts partial-rep sub_sets payloads."""
         ex = await create_exercise(client)


### PR DESCRIPTION
## Summary
- finish the missed workout-history follow-up on its own issue and PR after merged PR #686
- group session history by exercise with explicit edit mode and readable exercise names
- allow changing a logged set's exercise and safely saving Prime peg weights through the session API

## Testing
- PYTHONPATH=. pytest tests/test_sessions.py tests/test_prime_machines.py
- python3 -m py_compile app/api/sessions.py app/schemas/requests.py
- npm --prefix frontend run check *(fails in this environment because `svelte-check` is not installed)*

Closes #700