### PR TITLE
Fix database-backed personal records and PR detection (#694)

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -448,10 +448,11 @@ async def get_personal_records(
 ) -> list[dict]:
     """Get personal records per exercise — heaviest weight, most reps, best estimated 1RM."""
     result = await db.execute(
-        select(ExerciseSet, Exercise.display_name, Exercise.name)
+        select(ExerciseSet, Exercise.display_name, Exercise.name, WorkoutSession.date)
         .join(WorkoutSession, ExerciseSet.workout_session_id == WorkoutSession.id)
         .join(Exercise, ExerciseSet.exercise_id == Exercise.id)
         .where(WorkoutSession.user_id == user.id)
+        .where(WorkoutSession.status == WorkoutStatus.COMPLETED)
         .where(ExerciseSet.actual_reps.isnot(None))
         .where(ExerciseSet.actual_weight_kg.isnot(None))
         .where(ExerciseSet.actual_weight_kg > 0)
@@ -461,11 +462,12 @@ async def get_personal_records(
 
     # Group by exercise
     exercise_data: dict[int, dict] = {}
-    for exercise_set, display_name, name in rows:
+    for exercise_set, display_name, name, session_date in rows:
         eid = exercise_set.exercise_id
         w = exercise_set.actual_weight_kg or 0
         r = exercise_set.actual_reps or 0
         est_1rm = w * (1 + r / 30) if r > 0 and w > 0 else 0
+        achieved_on = session_date.isoformat()
 
         if eid not in exercise_data:
             exercise_data[eid] = {
@@ -473,8 +475,11 @@ async def get_personal_records(
                 "display_name": display_name,
                 "name": name,
                 "max_weight_kg": 0,
+                "max_weight_date": None,
                 "max_reps": 0,
+                "max_reps_date": None,
                 "best_1rm_kg": 0,
+                "best_1rm_date": None,
                 "best_set_weight_kg": 0,
                 "best_set_reps": 0,
             }
@@ -482,10 +487,13 @@ async def get_personal_records(
         d = exercise_data[eid]
         if w > d["max_weight_kg"]:
             d["max_weight_kg"] = w
+            d["max_weight_date"] = achieved_on
         if r > d["max_reps"]:
             d["max_reps"] = r
+            d["max_reps_date"] = achieved_on
         if est_1rm > d["best_1rm_kg"]:
             d["best_1rm_kg"] = round(est_1rm, 1)
+            d["best_1rm_date"] = achieved_on
             d["best_set_weight_kg"] = w
             d["best_set_reps"] = r
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -512,7 +512,21 @@ export async function recalculateWeights(pattern: string, oldBaseKg: number, new
 }
 
 // Personal records
-export async function getPersonalRecords(): Promise<any[]> {
+export interface PersonalRecord {
+  exercise_id: number;
+  display_name: string;
+  name: string;
+  max_weight_kg: number;
+  max_weight_date: string | null;
+  max_reps: number;
+  max_reps_date: string | null;
+  best_1rm_kg: number;
+  best_1rm_date: string | null;
+  best_set_weight_kg: number;
+  best_set_reps: number;
+}
+
+export async function getPersonalRecords(): Promise<PersonalRecord[]> {
   const response = await api.get('/progress/records');
   return response.data;
 }

--- a/frontend/src/routes/records/+page.svelte
+++ b/frontend/src/routes/records/+page.svelte
@@ -2,26 +2,26 @@
   import { onMount } from 'svelte';
   import { settings } from '$lib/stores';
   import { getPersonalRecords } from '$lib/api';
+  import type { PersonalRecord } from '$lib/api';
 
   const KG_TO_LBS = 2.20462;
 
-  interface PR {
-    exercise_id: number;
-    display_name: string;
-    max_weight_kg: number;
-    max_reps: number;
-    best_1rm_kg: number;
-    best_set_weight_kg: number;
-    best_set_reps: number;
-  }
-
-  let records = $state<PR[]>([]);
+  let records = $state<PersonalRecord[]>([]);
   let loading = $state(true);
   let filter = $state('');
 
   function w(kg: number): string {
     const val = $settings.weightUnit === 'lbs' ? kg * KG_TO_LBS : kg;
     return Math.round(val).toLocaleString();
+  }
+
+  function formatDate(dateStr: string | null): string {
+    if (!dateStr) return '—';
+    return new Date(`${dateStr}T12:00:00`).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
   }
 
   let unit = $derived($settings.weightUnit);
@@ -65,14 +65,17 @@
                 <div>
                   <p class="text-xs text-zinc-500">Best Weight</p>
                   <p class="text-sm font-mono text-primary-400">{w(pr.max_weight_kg)} {unit}</p>
+                  <p class="text-[10px] text-zinc-600">{formatDate(pr.max_weight_date)}</p>
                 </div>
                 <div>
                   <p class="text-xs text-zinc-500">Most Reps</p>
                   <p class="text-sm font-mono text-green-400">{pr.max_reps}</p>
+                  <p class="text-[10px] text-zinc-600">{formatDate(pr.max_reps_date)}</p>
                 </div>
                 <div>
                   <p class="text-xs text-zinc-500">Est. 1RM</p>
                   <p class="text-sm font-mono text-amber-400">{w(pr.best_1rm_kg)} {unit}</p>
+                  <p class="text-[10px] text-zinc-600">{formatDate(pr.best_1rm_date)}</p>
                 </div>
               </div>
               <p class="text-[10px] text-zinc-600 mt-1">Best set: {w(pr.best_set_weight_kg)} × {pr.best_set_reps}</p>

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -7,10 +7,10 @@
     getExercises, getPlan, getPlans, getRecentExercises, getSession, getSessions,
     createSessionFromPlan, createSession, startSession,
     addSet, updateSet, deleteSet, completeSession, deleteSession,
-    getExerciseHistory, getAllExerciseNotes, setExerciseNote,
+    getExerciseHistory, getAllExerciseNotes, setExerciseNote, getPersonalRecords,
     saveExerciseFeedback, getExerciseFeedback, syncSessionToPlan, patchSession, createExercise,
   } from '$lib/api';
-  import type { Exercise, WorkoutPlan, PlannedDay, ExerciseHistorySession, WorkoutSession } from '$lib/api';
+  import type { Exercise, WorkoutPlan, PlannedDay, ExerciseHistorySession, WorkoutSession, PersonalRecord } from '$lib/api';
   import { swipeable } from '$lib/actions/swipeable';
   import PlateVisual from '$lib/components/PlateVisual.svelte';
   import PrimePegVisual from '$lib/components/PrimePegVisual.svelte';
@@ -141,6 +141,8 @@
   let sessionId = $state<number | null>(null);
   let workoutName = $state('Workout');
   let allExercises = $state<Exercise[]>([]);
+  let personalRecordsByExercise = $state<Record<number, PersonalRecord>>({});
+  let startingPersonalRecordsByExercise = $state<Record<number, PersonalRecord>>({});
   let uiExercises = $state<UIExercise[]>([]);
 
   let exerciseGroups = $derived(computeGroups(uiExercises));
@@ -194,25 +196,115 @@
   let prCelebration = $state<{ exercise: string; type: string; value: string } | null>(null);
   let prTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  function checkForPR(ex: UIExercise, set: UISet) {
+  function indexPersonalRecords(records: PersonalRecord[]): Record<number, PersonalRecord> {
+    return Object.fromEntries(records.map((record) => [record.exercise_id, record]));
+  }
+
+  function emptyPersonalRecord(exercise: Exercise): PersonalRecord {
+    return {
+      exercise_id: exercise.id,
+      display_name: exercise.display_name,
+      name: exercise.name,
+      max_weight_kg: 0,
+      max_weight_date: null,
+      max_reps: 0,
+      max_reps_date: null,
+      best_1rm_kg: 0,
+      best_1rm_date: null,
+      best_set_weight_kg: 0,
+      best_set_reps: 0,
+    };
+  }
+
+  function getSetRepCount(ex: UIExercise, set: UISet): number {
+    return ex.isUnilateral
+      ? Math.min(set.repsLeft ?? 0, set.repsRight ?? 0)
+      : (set.reps ?? 0);
+  }
+
+  function getSetWeightKg(set: UISet): number {
+    return set.weightLbs != null ? toKg(set.weightLbs) : 0;
+  }
+
+  function getEstimatedOneRmKg(weightKg: number, reps: number): number {
+    return weightKg > 0 && reps > 0 ? weightKg * (1 + reps / 30) : 0;
+  }
+
+  function formatDisplayWeight(kg: number): string {
+    return `${fromKg(kg)} ${unit}`;
+  }
+
+  type PRHit = {
+    type: 'weight' | 'reps' | '1rm';
+    value: string;
+    rawValue: number;
+  };
+
+  function getPrHits(
+    ex: UIExercise,
+    set: UISet,
+    recordMap: Record<number, PersonalRecord>,
+  ): PRHit[] {
     const exercise = allExercises.find(e => e.id === ex.exerciseId);
-    if (!exercise || !set.initWeight || !set.initReps) return;
-    const w = set.weightLbs ?? 0;
-    const r = ex.isUnilateral ? Math.min(set.repsLeft ?? 0, set.repsRight ?? 0) : (set.reps ?? 0);
+    if (!exercise) return [];
+
+    const baseline = recordMap[ex.exerciseId] ?? emptyPersonalRecord(exercise);
+    const reps = getSetRepCount(ex, set);
+    const weightKg = getSetWeightKg(set);
+    const estOneRmKg = getEstimatedOneRmKg(weightKg, reps);
     const isAsst = exercise.is_assisted ?? false;
 
-    let prType = '';
-    let prValue = '';
-    if (!isAsst && w > (set.initWeight ?? 0)) {
-      prType = 'Weight PR';
-      prValue = `${w} ${unit}`;
-    } else if (r > (set.initReps ?? 0)) {
-      prType = 'Rep PR';
-      prValue = `${r} reps`;
+    const hits: PRHit[] = [];
+    if (!isAsst && weightKg > baseline.max_weight_kg) {
+      hits.push({ type: 'weight', value: formatDisplayWeight(weightKg), rawValue: weightKg });
+    }
+    if (reps > baseline.max_reps) {
+      hits.push({ type: 'reps', value: `${reps} reps`, rawValue: reps });
+    }
+    if (!isAsst && estOneRmKg > baseline.best_1rm_kg) {
+      hits.push({ type: '1rm', value: formatDisplayWeight(estOneRmKg), rawValue: estOneRmKg });
+    }
+    return hits;
+  }
+
+  function updateLivePersonalRecords(ex: UIExercise, set: UISet) {
+    const exercise = allExercises.find(e => e.id === ex.exerciseId);
+    if (!exercise) return;
+
+    const current = personalRecordsByExercise[ex.exerciseId] ?? emptyPersonalRecord(exercise);
+    const reps = getSetRepCount(ex, set);
+    const weightKg = getSetWeightKg(set);
+    const estOneRmKg = getEstimatedOneRmKg(weightKg, reps);
+    const updated: PersonalRecord = { ...current };
+
+    if (weightKg > updated.max_weight_kg) {
+      updated.max_weight_kg = weightKg;
+    }
+    if (reps > updated.max_reps) {
+      updated.max_reps = reps;
+    }
+    if (estOneRmKg > updated.best_1rm_kg) {
+      updated.best_1rm_kg = estOneRmKg;
+      updated.best_set_weight_kg = weightKg;
+      updated.best_set_reps = reps;
     }
 
-    if (prType) {
-      prCelebration = { exercise: exercise.display_name, type: prType, value: prValue };
+    personalRecordsByExercise = {
+      ...personalRecordsByExercise,
+      [ex.exerciseId]: updated,
+    };
+  }
+
+  function checkForPR(ex: UIExercise, set: UISet) {
+    const exercise = allExercises.find(e => e.id === ex.exerciseId);
+    if (!exercise) return;
+
+    const hits = getPrHits(ex, set, personalRecordsByExercise);
+    if (hits.length > 0) {
+      updateLivePersonalRecords(ex, set);
+      const hit = hits[0];
+      const label = hit.type === 'weight' ? 'Weight PR' : hit.type === 'reps' ? 'Rep PR' : '1RM PR';
+      prCelebration = { exercise: exercise.display_name, type: label, value: hit.value };
       if (navigator.vibrate) navigator.vibrate([100, 50, 100]);
       fireConfetti();
       if (prTimeout) clearTimeout(prTimeout);
@@ -719,9 +811,15 @@
       const dayNumber = parseInt(params.get('day') || '1');
       const isDeload = params.get('deload') === 'true';
 
-      const [exData, notesData] = await Promise.all([getExercises(), getAllExerciseNotes()]);
+      const [exData, notesData, recordData] = await Promise.all([
+        getExercises(),
+        getAllExerciseNotes(),
+        getPersonalRecords().catch(() => []),
+      ]);
       allExercises = exData;
       exerciseStore.set(allExercises);
+      personalRecordsByExercise = indexPersonalRecords(recordData);
+      startingPersonalRecordsByExercise = indexPersonalRecords(recordData);
       // Convert string keys to numbers
       for (const [k, v] of Object.entries(notesData)) {
         exerciseNotes[Number(k)] = v.note;
@@ -2099,26 +2197,25 @@
     for (const ex of uiExercises) {
       const exercise = getEx(ex.exerciseId);
       if (!exercise) continue;
-      const isAsst = exercise.is_assisted ?? false;
       const doneSetsEx = ex.sets.filter(s => s.done);
       if (doneSetsEx.length === 0) continue;
-      let foundWeight = false;
-      let foundReps = false;
+      let bestWeight: PRHit | null = null;
+      let bestReps: PRHit | null = null;
+      let bestOneRm: PRHit | null = null;
       for (const s of doneSetsEx) {
-        const w = s.weightLbs ?? 0;
-        const r = s.reps ?? (ex.isUnilateral ? Math.min(s.repsLeft ?? 0, s.repsRight ?? 0) : 0);
-        if (!s.initWeight || !s.initReps) continue;
-        // Weight PR: beat the suggested weight (not applicable for assisted)
-        if (!foundWeight && !isAsst && w > (s.initWeight ?? 0)) {
-          results.push({ exerciseName: exercise.display_name, type: 'weight', value: `${w} ${unit}` });
-          foundWeight = true;
-        }
-        // Rep PR: beat the suggested reps
-        if (!foundReps && r > (s.initReps ?? 0)) {
-          results.push({ exerciseName: exercise.display_name, type: 'reps', value: `${r} reps` });
-          foundReps = true;
+        for (const hit of getPrHits(ex, s, startingPersonalRecordsByExercise)) {
+          if (hit.type === 'weight' && (!bestWeight || hit.rawValue > bestWeight.rawValue)) {
+            bestWeight = hit;
+          } else if (hit.type === 'reps' && (!bestReps || hit.rawValue > bestReps.rawValue)) {
+            bestReps = hit;
+          } else if (hit.type === '1rm' && (!bestOneRm || hit.rawValue > bestOneRm.rawValue)) {
+            bestOneRm = hit;
+          }
         }
       }
+      if (bestWeight) results.push({ exerciseName: exercise.display_name, type: 'weight', value: bestWeight.value });
+      if (bestReps) results.push({ exerciseName: exercise.display_name, type: 'reps', value: bestReps.value });
+      if (bestOneRm) results.push({ exerciseName: exercise.display_name, type: '1rm', value: bestOneRm.value });
     }
     return results;
   }

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,7 +1,12 @@
 """Tests for the progress tracking API."""
+from datetime import date
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.workout import WorkoutSession
 from tests.conftest import create_exercise, create_plan, start_session_from_plan, log_set
 
 pytestmark = pytest.mark.asyncio(loop_scope="function")
@@ -102,3 +107,42 @@ class TestProgressAPI:
         })
         assert advanced_res.status_code == 200, advanced_res.text
         assert beginner_res.json()["next_weight"] > advanced_res.json()["next_weight"]
+
+    async def test_records_return_db_backed_prs_with_achieved_dates(
+        self, client: AsyncClient, db: AsyncSession
+    ):
+        """GET /progress/records should use persisted history and include achieved dates."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=1, reps=8)
+
+        sess1 = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess1["id"], sess1["sets"][0]["id"], 100.0, 8)
+        await client.post(f"/api/sessions/{sess1['id']}/complete")
+
+        sess2 = await start_session_from_plan(client, plan["id"])
+        await log_set(client, sess2["id"], sess2["sets"][0]["id"], 95.0, 12)
+        await client.post(f"/api/sessions/{sess2['id']}/complete")
+
+        sessions = (
+            await db.execute(select(WorkoutSession).order_by(WorkoutSession.id))
+        ).scalars().all()
+        assert len(sessions) == 2
+        sessions[0].date = date(2024, 1, 1)
+        sessions[1].date = date(2024, 2, 1)
+        await db.commit()
+
+        r = await client.get("/api/progress/records")
+        assert r.status_code == 200
+        records = r.json()
+        assert len(records) == 1
+
+        record = records[0]
+        assert record["exercise_id"] == ex["id"]
+        assert record["max_weight_kg"] == 100.0
+        assert record["max_weight_date"] == "2024-01-01"
+        assert record["max_reps"] == 12
+        assert record["max_reps_date"] == "2024-02-01"
+        assert record["best_1rm_kg"] == 133.0
+        assert record["best_1rm_date"] == "2024-02-01"
+        assert record["best_set_weight_kg"] == 95.0
+        assert record["best_set_reps"] == 12


### PR DESCRIPTION
## Summary\n- use completed workout history from the database for personal records and include achieved dates\n- update the records page to show when each PR was achieved\n- compare in-workout PR celebrations and summaries against all-time records instead of suggested starting values\n\n## Testing\n- PYTHONPATH=. pytest tests/test_progress.py\n- python3 -m py_compile app/api/progress.py\n- npm --prefix frontend run check *(fails locally: svelte-check: command not found)*\n\nCloses #694