### PR TITLE
Fix iOS barcode lookup against saved foods (#692)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Nutrition/NutritionSheets.swift
@@ -548,13 +548,8 @@ struct AddFoodView: View {
 
     private func lookupBarcode(_ barcode: String) async {
         do {
-            let results: [FoodSearchResult] = try await APIClient.shared.get("/nutrition/barcode/\(barcode)")
-            if let food = results.first {
-                await logFood(food)
-            } else {
-                pendingBarcode = barcode
-                showLabelScanner = true
-            }
+            let food: FoodSearchResult = try await APIClient.shared.get("/nutrition/barcode/\(barcode)")
+            await logFood(food)
         } catch {
             pendingBarcode = barcode
             showLabelScanner = true


### PR DESCRIPTION
## Summary\n- decode barcode lookup in the iOS add-food sheet as a single \n- stop falling back to the nutrition label scanner when the backend returns an existing saved food\n\n## Testing\n- Not run locally: full Xcode build is not available on this machine\n\nCloses #692