### PR TITLE
Prevent duplicate Apple Health workout syncs (#690)

### DIFF
--- a/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
+++ b/ios/GymTracker/Gym Tracker/Services/HealthKitManager.swift
@@ -5,6 +5,8 @@ import HealthKit
 /// Handles body weight sync, workout logging, and authorization.
 final class HealthKitManager: @unchecked Sendable {
     static let shared = HealthKitManager()
+    private let workoutBrandNames = ["GymTracker", "Onyx Intake", "Onyx Expenditure"]
+    private let backendSessionIdMetadataKey = "BackendSessionID"
 
     private let store = HKHealthStore()
 
@@ -253,6 +255,16 @@ final class HealthKitManager: @unchecked Sendable {
             return false
         }
 
+        if let existingWorkout = await findExistingWorkout(
+            sessionId: sessionId,
+            name: name,
+            startDate: startDate,
+            endDate: endDate
+        ) {
+            print("[HealthKit] Skipping duplicate workout sync for session \(sessionId.map(String.init) ?? "?") because matching workout \(existingWorkout.uuid) already exists")
+            return true
+        }
+
         let calorieQuantity = HKQuantity(unit: .kilocalorie(), doubleValue: totalCalories)
 
         let config = HKWorkoutConfiguration()
@@ -278,12 +290,16 @@ final class HealthKitManager: @unchecked Sendable {
             try await builder.endCollection(at: endDate)
 
             // Add metadata before finishing
-            try await builder.addMetadata([
+            var metadata: [String: Any] = [
                 HKMetadataKeyWorkoutBrandName: "Onyx Expenditure",
                 "WorkoutName": name,
                 "TotalSets": totalSets,
                 "TotalVolumeKg": totalVolume,
-            ])
+            ]
+            if let sessionId {
+                metadata[backendSessionIdMetadataKey] = sessionId
+            }
+            try await builder.addMetadata(metadata)
 
             try await builder.finishWorkout()
 
@@ -305,7 +321,7 @@ final class HealthKitManager: @unchecked Sendable {
         let workoutType = HKObjectType.workoutType()
         let predicate = HKQuery.predicateForObjects(
             withMetadataKey: HKMetadataKeyWorkoutBrandName,
-            allowedValues: ["GymTracker", "Onyx Intake", "Onyx Expenditure"]
+            allowedValues: workoutBrandNames
         )
 
         return await withCheckedContinuation { continuation in
@@ -371,5 +387,65 @@ final class HealthKitManager: @unchecked Sendable {
             }
             self.store.execute(query)
         }
+    }
+
+    private func findExistingWorkout(
+        sessionId: Int?,
+        name: String,
+        startDate: Date,
+        endDate: Date
+    ) async -> HKWorkout? {
+        let workoutType = HKObjectType.workoutType()
+        let predicate = HKQuery.predicateForSamples(
+            withStart: startDate.addingTimeInterval(-60),
+            end: endDate.addingTimeInterval(60),
+            options: []
+        )
+
+        let workouts: [HKWorkout] = await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: workoutType,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: nil
+            ) { _, samples, error in
+                if let error {
+                    print("[HealthKit] Existing workout lookup error: \(error.localizedDescription)")
+                    continuation.resume(returning: [])
+                    return
+                }
+                continuation.resume(returning: samples as? [HKWorkout] ?? [])
+            }
+            store.execute(query)
+        }
+
+        for workout in workouts {
+            guard workout.workoutActivityType == .traditionalStrengthTraining else { continue }
+            let metadata = workout.metadata ?? [:]
+            let brand = metadata[HKMetadataKeyWorkoutBrandName] as? String
+            guard brand.map({ workoutBrandNames.contains($0) }) ?? false else { continue }
+
+            if let sessionId,
+               let storedSessionId = metadata[backendSessionIdMetadataKey] as? NSNumber,
+               storedSessionId.intValue == sessionId {
+                return workout
+            }
+
+            if let sessionId,
+               let storedSessionId = metadata[backendSessionIdMetadataKey] as? String,
+               Int(storedSessionId) == sessionId {
+                return workout
+            }
+
+            let storedName = metadata["WorkoutName"] as? String
+            let sameName = storedName == name
+            let sameStart = abs(workout.startDate.timeIntervalSince(startDate)) < 1
+            let sameEnd = abs(workout.endDate.timeIntervalSince(endDate)) < 1
+            if sameName && sameStart && sameEnd {
+                return workout
+            }
+        }
+
+        return nil
     }
 }


### PR DESCRIPTION
## Summary\n- check HealthKit for an existing branded strength workout before saving a synced session\n- stamp the backend session id into workout metadata for durable duplicate detection across reinstalls and resyncs\n- keep the fallback duplicate match compatible with older branded workouts that were saved before session ids were included\n\n## Testing\n- Not run locally: full Xcode build is not available on this machine\n\nCloses #690