### PR TITLE
Add light mode setting across web and iOS (#668)

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -14,6 +14,15 @@
   --text-muted: #71717a;
 }
 
+html[data-theme='light'] {
+  color-scheme: light;
+  --surface-1: #fafafa;
+  --surface-2: #f4f4f5;
+  --surface-3: #e4e4e7;
+  --border: rgba(24,24,27,0.10);
+  --text-muted: #71717a;
+}
+
 /* ── Base ──────────────────────────────────────────────────────────────── */
 body {
   @apply bg-zinc-950 text-zinc-100;
@@ -25,6 +34,11 @@ body {
 /* Prevent over-scroll bounce on iOS causing layout shifts */
 html, body {
   overscroll-behavior: none;
+}
+
+html[data-theme='light'] body {
+  background-color: #fafafa;
+  color: #18181b;
 }
 
 /* ── Components ────────────────────────────────────────────────────────── */
@@ -220,4 +234,135 @@ body.large-targets .card {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
+}
+
+/* ── Light theme overrides ─────────────────────────────────────────────── */
+html[data-theme='light'] .btn-secondary {
+  background-color: #ffffff;
+  color: #27272a;
+  border-color: #d4d4d8;
+}
+
+html[data-theme='light'] .btn-secondary:hover {
+  background-color: #f4f4f5;
+}
+
+html[data-theme='light'] .btn-ghost {
+  color: #52525b;
+}
+
+html[data-theme='light'] .btn-ghost:hover {
+  color: #18181b;
+  background-color: #f4f4f5;
+}
+
+html[data-theme='light'] .card,
+html[data-theme='light'] .exercise-card,
+html[data-theme='light'] .rest-bar,
+html[data-theme='light'] .bottom-nav {
+  background-color: #ffffff;
+  border-color: #e4e4e7;
+}
+
+html[data-theme='light'] .card-elevated {
+  background-color: #f4f4f5;
+  border-color: #d4d4d8;
+  box-shadow: 0 10px 30px rgba(24, 24, 27, 0.08);
+}
+
+html[data-theme='light'] .input,
+html[data-theme='light'] .set-input,
+html[data-theme='light'] .set-type-select {
+  background-color: #ffffff;
+  color: #18181b;
+  border-color: #d4d4d8;
+}
+
+html[data-theme='light'] .input::placeholder,
+html[data-theme='light'] .set-input::placeholder {
+  color: #a1a1aa;
+}
+
+html[data-theme='light'] .set-input:focus {
+  background-color: #fafafa;
+}
+
+html[data-theme='light'] .set-row-done .set-input {
+  background-color: #f4f4f5;
+  border-color: #e4e4e7;
+  color: #a1a1aa;
+}
+
+html[data-theme='light'] .bottom-nav-item {
+  color: #71717a;
+}
+
+html[data-theme='light'] .bottom-nav-item.active {
+  color: #2563eb;
+}
+
+html[data-theme='light'] ::-webkit-scrollbar-thumb {
+  background: #d4d4d8;
+}
+
+html[data-theme='light'] .bg-zinc-950,
+html[data-theme='light'] .min-h-screen.bg-zinc-950,
+html[data-theme='light'] .bg-zinc-950\/90,
+html[data-theme='light'] .bg-zinc-950\/95 {
+  background-color: #fafafa !important;
+}
+
+html[data-theme='light'] .bg-zinc-900,
+html[data-theme='light'] .bg-zinc-900\/95,
+html[data-theme='light'] .bg-zinc-900\/40,
+html[data-theme='light'] .bg-zinc-900\/20 {
+  background-color: #ffffff !important;
+}
+
+html[data-theme='light'] .bg-zinc-800,
+html[data-theme='light'] .bg-zinc-800\/60,
+html[data-theme='light'] .bg-zinc-800\/40 {
+  background-color: #f4f4f5 !important;
+}
+
+html[data-theme='light'] .bg-zinc-700 {
+  background-color: #e4e4e7 !important;
+}
+
+html[data-theme='light'] .text-zinc-100,
+html[data-theme='light'] .text-zinc-200,
+html[data-theme='light'] .text-zinc-300,
+html[data-theme='light'] .text-white,
+html[data-theme='light'] .text-gray-300 {
+  color: #18181b !important;
+}
+
+html[data-theme='light'] .text-zinc-400,
+html[data-theme='light'] .text-zinc-500,
+html[data-theme='light'] .text-gray-400,
+html[data-theme='light'] .text-gray-500 {
+  color: #71717a !important;
+}
+
+html[data-theme='light'] .text-zinc-600 {
+  color: #a1a1aa !important;
+}
+
+html[data-theme='light'] .border-zinc-800,
+html[data-theme='light'] .border-zinc-700,
+html[data-theme='light'] .border-zinc-600,
+html[data-theme='light'] .border-white\/5,
+html[data-theme='light'] .border-white\/10 {
+  border-color: #e4e4e7 !important;
+}
+
+html[data-theme='light'] .hover\:bg-zinc-900:hover,
+html[data-theme='light'] .hover\:bg-zinc-800:hover,
+html[data-theme='light'] .hover\:bg-zinc-700:hover,
+html[data-theme='light'] .hover\:bg-gray-600:hover {
+  background-color: #e4e4e7 !important;
+}
+
+html[data-theme='light'] .hover\:text-zinc-200:hover {
+  color: #18181b !important;
 }

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -57,6 +57,7 @@ export interface DeloadSettings {
 }
 
 export interface AppSettings {
+  themePreference: 'dark' | 'light';
   restDurations: RestDurations;
   weightUnit: 'lbs' | 'kg';
   heightUnit: 'in' | 'ft' | 'cm';
@@ -77,6 +78,7 @@ export interface AppSettings {
 const SETTINGS_KEY = 'hgt_settings';
 
 const defaultSettings: AppSettings = {
+  themePreference: 'dark',
   restDurations: {
     upperCompound:  180,
     upperIsolation:  90,

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -78,6 +78,19 @@
     }
   });
 
+  // ── Theme preference ─────────────────────────────────────────────────
+  $effect(() => {
+    if (typeof document === 'undefined') return;
+    const theme = $settings.themePreference ?? 'dark';
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+    document.body.dataset.theme = theme;
+
+    const themeColor = theme === 'light' ? '#f4f4f5' : '#09090b';
+    const meta = document.querySelector('meta[name="theme-color"]');
+    meta?.setAttribute('content', themeColor);
+  });
+
   // ── Offline detection + sync ──────────────────────────────────────────
   $effect(() => {
     if (typeof window === 'undefined') return;

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -486,6 +486,26 @@
     </div>
   </div>
 
+  <!-- ── Theme ───────────────────────────────────────────────────────── -->
+  <div class="card space-y-4">
+    <div>
+      <h3 class="text-lg font-semibold">Appearance</h3>
+      <p class="text-sm text-zinc-400 mt-1">Choose the app theme for the web app and sync it to your account.</p>
+    </div>
+    <div class="flex gap-3">
+      {#each [['dark', 'Dark'], ['light', 'Light']] as [val, label]}
+        <button
+          onclick={() => settings.update(s => ({ ...s, themePreference: val as 'dark' | 'light' }))}
+          class="flex-1 py-2.5 rounded-lg text-sm font-medium transition-colors {
+            $settings.themePreference === val
+              ? 'bg-primary-600 text-white'
+              : 'bg-zinc-800 hover:bg-gray-600 text-gray-300'
+          }"
+        >{label}</button>
+      {/each}
+    </div>
+  </div>
+
   <!-- ── Body Weight / Weigh-in Log ──────────────────────────────────── -->
   <div class="card space-y-4">
     <div>

--- a/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
+++ b/ios/GymTracker/Gym Tracker/App/GymTrackerApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct GymTrackerApp: App {
     @Environment(\.scenePhase) private var scenePhase
+    @AppStorage(SettingsKey.themePreference) private var themePreference: String = "dark"
     @State private var auth = AuthService.shared
 
     var body: some Scene {
@@ -25,7 +26,7 @@ struct GymTrackerApp: App {
                 }
             }
             .environment(auth)
-            .preferredColorScheme(.dark)
+            .preferredColorScheme(themePreference == "light" ? .light : .dark)
         }
     }
 }

--- a/ios/GymTracker/Gym Tracker/Models/UIModels.swift
+++ b/ios/GymTracker/Gym Tracker/Models/UIModels.swift
@@ -24,16 +24,49 @@ enum AppConstants {
 // MARK: - Design System (matching web Tailwind zinc palette)
 
 enum AppColors {
+    private static func dynamic(light: UIColor, dark: UIColor) -> Color {
+        Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark ? dark : light
+        })
+    }
+
     // Zinc palette — matches Tailwind zinc scale
-    static let zinc950 = Color(red: 0.055, green: 0.055, blue: 0.063)  // bg
-    static let zinc900 = Color(red: 0.094, green: 0.094, blue: 0.106)  // card
-    static let zinc800 = Color(red: 0.153, green: 0.153, blue: 0.169)  // card-elevated, inputs
-    static let zinc700 = Color(red: 0.247, green: 0.247, blue: 0.267)  // borders
-    static let zinc600 = Color(red: 0.329, green: 0.329, blue: 0.353)  // input borders
-    static let zinc500 = Color(red: 0.443, green: 0.443, blue: 0.471)  // muted text
-    static let zinc400 = Color(red: 0.631, green: 0.631, blue: 0.659)  // secondary text
-    static let zinc300 = Color(red: 0.831, green: 0.831, blue: 0.847)  // primary text
-    static let zinc100 = Color(red: 0.953, green: 0.953, blue: 0.961)  // bright text
+    static let zinc950 = dynamic(
+        light: UIColor(red: 0.980, green: 0.980, blue: 0.985, alpha: 1),
+        dark: UIColor(red: 0.055, green: 0.055, blue: 0.063, alpha: 1)
+    )
+    static let zinc900 = dynamic(
+        light: UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1),
+        dark: UIColor(red: 0.094, green: 0.094, blue: 0.106, alpha: 1)
+    )
+    static let zinc800 = dynamic(
+        light: UIColor(red: 0.957, green: 0.957, blue: 0.965, alpha: 1),
+        dark: UIColor(red: 0.153, green: 0.153, blue: 0.169, alpha: 1)
+    )
+    static let zinc700 = dynamic(
+        light: UIColor(red: 0.894, green: 0.894, blue: 0.910, alpha: 1),
+        dark: UIColor(red: 0.247, green: 0.247, blue: 0.267, alpha: 1)
+    )
+    static let zinc600 = dynamic(
+        light: UIColor(red: 0.831, green: 0.831, blue: 0.847, alpha: 1),
+        dark: UIColor(red: 0.329, green: 0.329, blue: 0.353, alpha: 1)
+    )
+    static let zinc500 = dynamic(
+        light: UIColor(red: 0.443, green: 0.443, blue: 0.471, alpha: 1),
+        dark: UIColor(red: 0.443, green: 0.443, blue: 0.471, alpha: 1)
+    )
+    static let zinc400 = dynamic(
+        light: UIColor(red: 0.325, green: 0.325, blue: 0.353, alpha: 1),
+        dark: UIColor(red: 0.631, green: 0.631, blue: 0.659, alpha: 1)
+    )
+    static let zinc300 = dynamic(
+        light: UIColor(red: 0.149, green: 0.149, blue: 0.165, alpha: 1),
+        dark: UIColor(red: 0.831, green: 0.831, blue: 0.847, alpha: 1)
+    )
+    static let zinc100 = dynamic(
+        light: UIColor(red: 0.071, green: 0.071, blue: 0.090, alpha: 1),
+        dark: UIColor(red: 0.953, green: 0.953, blue: 0.961, alpha: 1)
+    )
 
     // Accent colors
     static let primary = Color(red: 0.231, green: 0.510, blue: 0.965)  // #3b82f6

--- a/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
+++ b/ios/GymTracker/Gym Tracker/Views/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ import HealthKit
 
 enum SettingsKey {
     static let branchPreference    = "branchPreference"
+    static let themePreference     = "themePreference"
     static let weightUnit          = "weightUnit"
     static let heightUnit          = "heightUnit"
     static let heightInches        = "heightInches"
@@ -77,6 +78,7 @@ private func normalizedActivityLevel(_ value: Double) -> Double {
 /// JSON structure matching the web app's settings format for cross-platform sync.
 struct SettingsJSON: Codable {
     var branchPreference: String?
+    var themePreference: String?
     var weightUnit: String?
     var heightUnit: String?
     var progressionStyle: String?
@@ -118,6 +120,7 @@ enum SettingsSync {
             let ud = UserDefaults.standard
 
             if let v = remote.branchPreference { ud.set(v, forKey: SettingsKey.branchPreference) }
+            if let v = remote.themePreference { ud.set(v, forKey: SettingsKey.themePreference) }
             if let v = remote.weightUnit { ud.set(v, forKey: SettingsKey.weightUnit) }
             if let v = remote.heightUnit { ud.set(v, forKey: SettingsKey.heightUnit) }
             if let v = remote.progressionStyle { ud.set(v, forKey: SettingsKey.progressionStyle) }
@@ -217,6 +220,7 @@ enum SettingsSync {
 
         let settings = SettingsJSON(
             branchPreference: ud.string(forKey: SettingsKey.branchPreference) ?? "main",
+            themePreference: ud.string(forKey: SettingsKey.themePreference) ?? "dark",
             weightUnit: ud.string(forKey: SettingsKey.weightUnit) ?? "lbs",
             heightUnit: normalizedHeightUnit(ud.string(forKey: SettingsKey.heightUnit)),
             progressionStyle: ud.string(forKey: SettingsKey.progressionStyle) ?? "rep",
@@ -274,6 +278,7 @@ struct SettingsView: View {
     // MARK: @AppStorage — all settings
 
     @AppStorage(SettingsKey.weightUnit) private var weightUnit: String = "lbs"
+    @AppStorage(SettingsKey.themePreference) private var themePreference: String = "dark"
     @AppStorage(SettingsKey.heightUnit) private var heightUnit: String = "imperial_split"
     @AppStorage(SettingsKey.heightInches) private var heightInches: Double = 67
     @AppStorage(SettingsKey.sex) private var sex: String = "male"
@@ -460,6 +465,12 @@ struct SettingsView: View {
 
     private var unitsSection: some View {
         Section("Units") {
+            Picker("Appearance", selection: $themePreference) {
+                Text("Dark").tag("dark")
+                Text("Light").tag("light")
+            }
+            .pickerStyle(.segmented)
+
             Picker("Weight Unit", selection: $weightUnit) {
                 Text("lbs").tag("lbs")
                 Text("kg").tag("kg")


### PR DESCRIPTION
## Summary\n- add a shared theme preference setting and expose it in web and iOS Settings\n- apply the selected theme to the web shell and add light-theme overrides for the shared zinc-based UI\n- stop forcing iOS into dark mode and make the shared iOS palette respond to the selected theme\n\n## Testing\n- npm --prefix frontend run check *(fails locally: svelte-check: command not found)*\n- Not run locally: full Xcode build is not available on this machine\n\nCloses #668