### PR TITLE
Make custom food calories match macros (#711)

### DIFF
--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -339,6 +339,17 @@ class FoodItemCreate(BaseModel):
     serving_label: str | None = None
     micronutrients: dict | None = None
 
+    @model_validator(mode="after")
+    def align_calories_with_macros(self) -> "FoodItemCreate":
+        macro_calories = round(
+            self.protein_per_100g * 4
+            + self.carbs_per_100g * 4
+            + self.fat_per_100g * 9,
+            1,
+        )
+        self.calories_per_100g = macro_calories
+        return self
+
 
 class FoodItemUpdate(FoodItemCreate):
     pass

--- a/frontend/src/routes/nutrition/+page.svelte
+++ b/frontend/src/routes/nutrition/+page.svelte
@@ -52,6 +52,9 @@
   let saveAsCustom = $state(false);
   let showFullMacros = $state(false);
   let editingFood = $state<FoodItem | null>(null);
+  let customFoodMacroCalories = $derived(
+    Math.round(((manualProtein ?? 0) * 4 + (manualCarbs ?? 0) * 4 + (manualFat ?? 0) * 9) * 10) / 10
+  );
 
   // Inline entry editing
   let editingEntry = $state<NutritionEntry | null>(null);
@@ -470,7 +473,7 @@
       await createCustomFood({
         name: manualName.trim(),
         brand: manualBrand.trim() || undefined,
-        calories_per_100g: (manualCal ?? 0) * scale,
+        calories_per_100g: customFoodMacroCalories * scale,
         protein_per_100g: (manualProtein ?? 0) * scale,
         carbs_per_100g: (manualCarbs ?? 0) * scale,
         fat_per_100g: (manualFat ?? 0) * scale,
@@ -509,7 +512,7 @@
       name: manualName.trim(),
       brand: manualBrand.trim() || undefined,
       barcode: editingFood.barcode ?? undefined,
-      calories_per_100g: (manualCal ?? 0) * scale,
+      calories_per_100g: customFoodMacroCalories * scale,
       protein_per_100g: (manualProtein ?? 0) * scale,
       carbs_per_100g: (manualCarbs ?? 0) * scale,
       fat_per_100g: (manualFat ?? 0) * scale,
@@ -1564,6 +1567,11 @@
                 <input type="checkbox" bind:checked={saveAsCustom} class="rounded bg-zinc-800 border-zinc-700" />
                 Save as custom food
               </label>
+              {/if}
+              {#if editingFood || saveAsCustom}
+                <p class="text-xs text-zinc-500">
+                  Saved custom food calories will use macros: {customFoodMacroCalories} kcal for this serving.
+                </p>
               {/if}
               <button onclick={editingFood ? saveEditedFood : logManualEntry} disabled={!manualName.trim()}
                       class="btn-primary w-full disabled:opacity-40 disabled:cursor-not-allowed">

--- a/tests/test_community_food.py
+++ b/tests/test_community_food.py
@@ -78,7 +78,7 @@ async def test_multi_user_promotion(client: AsyncClient):
             assert r2.status_code == 201
             data = r2.json()
             assert data["source"] == "community"
-            assert data["calories_per_100g"] == 410.0
+            assert data["calories_per_100g"] == 419.0
             assert data["protein_per_100g"] == 31.0
         finally:
             await client2.aclose()

--- a/tests/test_nutrition.py
+++ b/tests/test_nutrition.py
@@ -76,9 +76,57 @@ async def test_update_custom_food(client, db):
     payload = response.json()
     assert payload["name"] == "Chicken Breast, Cooked"
     assert payload["barcode"] == "123456789012"
-    assert payload["calories_per_100g"] == 180
+    assert payload["calories_per_100g"] == 168
     assert payload["serving_size_g"] == 112
     assert payload["serving_label"] == "4 oz"
+
+
+async def test_create_custom_food_aligns_calories_to_macros(client):
+    response = await client.post("/api/nutrition/foods", json={
+        "name": "Macro Match Bar",
+        "calories_per_100g": 999,
+        "protein_per_100g": 20,
+        "carbs_per_100g": 30,
+        "fat_per_100g": 10,
+        "serving_size_g": 50,
+        "serving_label": "1 bar",
+    })
+    assert response.status_code == 201, response.text
+
+    payload = response.json()
+    assert payload["calories_per_100g"] == 290
+
+
+async def test_update_custom_food_recomputes_calories_from_macros(client, db):
+    food = FoodItem(
+        user_id=1,
+        name="Protein Oats",
+        source="custom",
+        is_custom=True,
+        calories_per_100g=999,
+        protein_per_100g=10,
+        carbs_per_100g=10,
+        fat_per_100g=10,
+        serving_size_g=100,
+        serving_label="100g",
+    )
+    db.add(food)
+    await db.commit()
+    await db.refresh(food)
+
+    response = await client.put(f"/api/nutrition/foods/{food.id}", json={
+        "name": "Protein Oats",
+        "brand": None,
+        "barcode": None,
+        "calories_per_100g": 10,
+        "protein_per_100g": 25,
+        "carbs_per_100g": 40,
+        "fat_per_100g": 5,
+        "serving_size_g": 100,
+        "serving_label": "100g",
+    })
+    assert response.status_code == 200, response.text
+    assert response.json()["calories_per_100g"] == 305
 
 
 async def test_search_prioritizes_matching_recipes(client, db, monkeypatch):


### PR DESCRIPTION
## Summary\n- normalize custom and community food calories from protein, carbs, and fat in the shared nutrition schema\n- add regression coverage for create/update behavior and the promoted community-food average\n- show the saved custom-food calorie total in the web manual entry flow so the save behavior is clear\n\n## Testing\n- PYTHONPATH=. pytest tests/test_nutrition.py tests/test_community_food.py\n- python3 -m py_compile app/schemas/requests.py\n- npm --prefix frontend run check *(fails locally: svelte-check: command not found)*\n\nCloses #711