### PR TITLE
fix: skip volume recommendations when exercise has no primary muscle (#737)

### DIFF
--- a/app/api/plans.py
+++ b/app/api/plans.py
@@ -334,9 +334,12 @@ async def get_plan_recommendations(
         if feedback.rir is None:
             continue
 
-        primary_muscle = (exercise.primary_muscles or [None])[0]
-        muscle_landmarks = VOLUME_LANDMARKS.get(primary_muscle or "", {"mev": 4, "mav": 10, "mrv": 16})
-        weekly_sets = muscle_planned_sets.get(primary_muscle or "", 0)
+        primary_muscle = exercise.primary_muscles[0] if exercise.primary_muscles else None
+        if primary_muscle is None:
+            # No muscle data — can't make meaningful volume recommendations
+            continue
+        muscle_landmarks = VOLUME_LANDMARKS.get(primary_muscle, {"mev": 4, "mav": 10, "mrv": 16})
+        weekly_sets = muscle_planned_sets.get(primary_muscle, 0)
 
         if feedback.rir <= 1 and feedback.recovery_rating in {"poor", "ok"}:
             add_set = weekly_sets < muscle_landmarks["mav"]


### PR DESCRIPTION
## Summary

When an exercise had no `primary_muscles` data, the old code used `""` as the lookup key for both `VOLUME_LANDMARKS` and `muscle_planned_sets`. The sets lookup always returned `0` — as if no sets were planned — potentially triggering false "add a set" recommendations even when the muscle was already at or above MAV.

**Fix:** Explicitly check for `None` after extracting the first primary muscle and `continue` (skip) rather than proceeding with bad defaults. No muscle data = no volume recommendation.

Works correctly once PR #731 (seed syncing muscles for existing exercises) is merged — the `continue` path will only be hit for genuinely unmapped custom exercises.

Closes #737

## Test plan
- [ ] All 155 tests pass
- [ ] Exercise with no `primary_muscles` does not appear in volume recommendations
- [ ] Exercise with valid `primary_muscles` still generates recommendations normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)