### PR TITLE
Guard food search against shortened response lists (#738)

### DIFF
--- a/app/api/food_search.py
+++ b/app/api/food_search.py
@@ -201,6 +201,7 @@ async def search_foods(query: str, page: int = 1, page_size: int = 15) -> list[d
     settings = get_settings()
 
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        task_names = ["openfoodfacts", "usda"]
         tasks = [
             client.get(
                 "https://world.openfoodfacts.org/cgi/search.pl",
@@ -214,6 +215,7 @@ async def search_foods(query: str, page: int = 1, page_size: int = 15) -> list[d
         # Add CalorieNinjas if API key is configured
         cn_key = settings.calorieninjas_api_key
         if cn_key:
+            task_names.append("calorieninjas")
             tasks.append(
                 client.get(
                     "https://api.calorieninjas.com/v1/nutrition",
@@ -221,11 +223,13 @@ async def search_foods(query: str, page: int = 1, page_size: int = 15) -> list[d
                     headers={"X-Api-Key": cn_key},
                 )
             )
-        responses = await asyncio.gather(*tasks, return_exceptions=True)
+        gathered = await asyncio.gather(*tasks, return_exceptions=True)
 
-    off_resp = responses[0] if len(responses) > 0 else None
-    usda_resp = responses[1] if len(responses) > 1 else None
-    cn_resp = responses[2] if len(responses) > 2 else None
+    responses = {name: response for name, response in zip(task_names, gathered)}
+
+    off_resp = responses.get("openfoodfacts")
+    usda_resp = responses.get("usda")
+    cn_resp = responses.get("calorieninjas")
 
     results: list[dict] = []
 

--- a/tests/test_nutrition.py
+++ b/tests/test_nutrition.py
@@ -1,6 +1,10 @@
 from datetime import datetime, timezone
+import json
+from types import SimpleNamespace
 
 import app.api.nutrition as nutrition_api
+import app.api.food_search as food_search
+import httpx
 from app.api.nutrition import _search_match_score
 from app.api.food_search import _relevance_score
 from app.models.nutrition import FoodItem
@@ -244,6 +248,36 @@ class TestExternalRelevanceScore:
         _, len_short = _relevance_score("Burger, Beef", "burger")
         _, len_long = _relevance_score("Burger, Beef, Extra Lean, Organic, Grass-Fed", "burger")
         assert len_short < len_long
+
+
+class TestExternalFoodSearch:
+    async def test_search_foods_handles_short_response_list(self, monkeypatch):
+        class FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def get(self, url, params=None, headers=None):
+                if "openfoodfacts" in url:
+                    payload = {"products": [{"product_name": "Bread", "nutriments": {}}]}
+                else:
+                    payload = {"foods": []}
+                return httpx.Response(200, content=json.dumps(payload).encode("utf-8"))
+
+        async def fake_gather(*tasks, return_exceptions=True):
+            first = await tasks[0]
+            for task in tasks[1:]:
+                task.close()
+            return [first]
+
+        monkeypatch.setattr(food_search.httpx, "AsyncClient", lambda timeout=None: FakeClient())
+        monkeypatch.setattr(food_search, "get_settings", lambda: SimpleNamespace(usda_api_key="test", calorieninjas_api_key=None))
+        monkeypatch.setattr(food_search.asyncio, "gather", fake_gather)
+
+        results = await food_search.search_foods("bread")
+        assert [item["name"] for item in results] == ["Bread"]
 
 
 class TestSearchRelevanceIntegration:


### PR DESCRIPTION
## Summary
- replace positional external food-search response access with name-based mapping
- make the food search merge logic resilient even if fewer responses come back than tasks were expected
- add a regression test covering a shortened gather result list

## Testing
- PYTHONPATH=. pytest tests/test_nutrition.py
- python3 -m py_compile app/api/food_search.py tests/test_nutrition.py

Closes #738