### PR TITLE
Persist workout reordering and supersets when syncing plans (#743)

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -20,6 +20,7 @@ from app.schemas.requests import (
     SetCreate,
     SetResponse,
     SetUpdate,
+    SyncSessionToPlanRequest,
     WorkoutSessionAuditResponse,
     WorkoutSessionCreate,
     WorkoutSessionResponse,
@@ -418,6 +419,7 @@ async def sync_session_to_plan(
     session_id: int,
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    sync_data: Annotated[SyncSessionToPlanRequest | None, Body()] = None,
 ) -> dict:
     """Sync a completed session back to its plan — weights/reps AND structural changes.
 
@@ -451,7 +453,7 @@ async def sync_session_to_plan(
     all_sets_result = await db.execute(
         select(ExerciseSet)
         .where(ExerciseSet.workout_session_id == session_id)
-        .order_by(ExerciseSet.exercise_id, ExerciseSet.set_number)
+        .order_by(ExerciseSet.id, ExerciseSet.set_number)
     )
     all_sets = all_sets_result.scalars().all()
 
@@ -511,6 +513,20 @@ async def sync_session_to_plan(
     plan_exercise_ids = set(plan_exercise_map.keys())
     session_exercise_ids = set(seen_order)
 
+    structure_by_exercise_id: dict[int, dict] = {}
+    requested_order: list[int] = []
+    if sync_data and sync_data.exercises:
+        for item in sync_data.exercises:
+            if item.exercise_id not in structure_by_exercise_id:
+                requested_order.append(item.exercise_id)
+            structure_by_exercise_id[item.exercise_id] = item.model_dump()
+        ordered_from_client = [
+            eid for eid in requested_order
+            if eid in session_exercise_ids
+        ]
+        seen_set = set(ordered_from_client)
+        seen_order = ordered_from_client + [eid for eid in seen_order if eid not in seen_set]
+
     # Rebuild the day's exercise list in session order
     new_exercises = []
     updated_count = 0
@@ -538,9 +554,20 @@ async def sync_session_to_plan(
             if ex.get("set_type", "standard") != sdata["set_type"]:
                 ex["set_type"] = sdata["set_type"]
                 structural_changes += 1
+            structure = structure_by_exercise_id.get(eid)
+            if structure:
+                next_group_id = structure.get("group_id")
+                next_group_type = structure.get("group_type")
+                if ex.get("group_id") != next_group_id:
+                    ex["group_id"] = next_group_id
+                    structural_changes += 1
+                if ex.get("group_type") != next_group_type:
+                    ex["group_type"] = next_group_type
+                    structural_changes += 1
             new_exercises.append(ex)
         else:
             # New exercise added during session
+            structure = structure_by_exercise_id.get(eid, {})
             new_exercises.append({
                 "exercise_id": eid,
                 "sets": sdata["set_count"],
@@ -550,6 +577,8 @@ async def sync_session_to_plan(
                 "set_type": sdata["set_type"],
                 "rest_seconds": 90,
                 "notes": None,
+                "group_id": structure.get("group_id"),
+                "group_type": structure.get("group_type"),
             })
             structural_changes += 1
 

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -2,6 +2,7 @@
 
 from datetime import date, datetime
 from enum import Enum
+from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -230,6 +231,8 @@ class PlannedExercise(BaseModel):
     drops: int | None = None  # number of drops for drop sets
     rest_seconds: int | None = 90
     notes: str | None = None
+    group_id: str | None = None
+    group_type: Literal["superset", "circuit"] | None = None
 
 
 class PlanRirOverrides(BaseModel):
@@ -265,6 +268,16 @@ class WorkoutPlanCreate(BaseModel):
     auto_progression: bool = True
     is_draft: bool = False
     rir_overrides: PlanRirOverrides = Field(default_factory=PlanRirOverrides)
+
+
+class SyncPlanExercise(BaseModel):
+    exercise_id: int
+    group_id: str | None = None
+    group_type: Literal["superset", "circuit"] | None = None
+
+
+class SyncSessionToPlanRequest(BaseModel):
+    exercises: list[SyncPlanExercise] = Field(default_factory=list)
 
 
 class WorkoutPlanResponse(BaseModel):

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -389,9 +389,16 @@ export async function patchSession(sessionId: number, data: { notes?: string; na
 }
 
 export async function syncSessionToPlan(
-  sessionId: number
+  sessionId: number,
+  data?: {
+    exercises: Array<{
+      exercise_id: number;
+      group_id?: string | null;
+      group_type?: 'superset' | 'circuit' | null;
+    }>;
+  }
 ): Promise<{ updated: number; structural_changes?: number }> {
-  const response = await api.post(`/sessions/${sessionId}/sync-to-plan`);
+  const response = await api.post(`/sessions/${sessionId}/sync-to-plan`, data ?? null);
   return response.data;
 }
 

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -2189,7 +2189,13 @@
       }
       if (syncToPlan) {
         try {
-          const data = await syncSessionToPlan(sessionId);
+          const data = await syncSessionToPlan(sessionId, {
+            exercises: uiExercises.map((exercise) => ({
+              exercise_id: exercise.exerciseId,
+              group_id: exercise.groupId,
+              group_type: exercise.groupType,
+            })),
+          });
           syncCount = data.updated;
           syncStructural = data.structural_changes ?? 0;
         } catch (e) {

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -42,6 +42,53 @@ class TestPlansCRUD:
         assert data["duration_weeks"] == 8
         assert "id" in data
 
+    async def test_create_plan_preserves_superset_grouping(self, client: AsyncClient):
+        """POST /plans/ keeps group metadata for supersets/circuits."""
+        ex1 = await create_exercise(client, name="bench_press", display_name="Bench Press")
+        ex2 = await create_exercise(client, name="barbell_row", display_name="Barbell Row", primary_muscles=["back"])
+
+        r = await client.post(
+            "/api/plans/",
+            json={
+                "name": "Superset Plan",
+                "block_type": "hypertrophy",
+                "duration_weeks": 8,
+                "number_of_days": 1,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Day 1",
+                        "exercises": [
+                            {
+                                "exercise_id": ex1["id"],
+                                "sets": 3,
+                                "reps": 8,
+                                "starting_weight_kg": 0,
+                                "progression_type": "linear",
+                                "group_id": "g-1",
+                                "group_type": "superset",
+                            },
+                            {
+                                "exercise_id": ex2["id"],
+                                "sets": 3,
+                                "reps": 10,
+                                "starting_weight_kg": 0,
+                                "progression_type": "linear",
+                                "group_id": "g-1",
+                                "group_type": "superset",
+                            },
+                        ],
+                    }
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+        exercises = r.json()["days"][0]["exercises"]
+        assert exercises[0]["group_id"] == "g-1"
+        assert exercises[0]["group_type"] == "superset"
+        assert exercises[1]["group_id"] == "g-1"
+        assert exercises[1]["group_type"] == "superset"
+
     async def test_create_plan_invalid_exercise_id(self, client: AsyncClient):
         """exercise_id that doesn't exist returns 422."""
         r = await client.post(
@@ -358,6 +405,51 @@ class TestPlansCRUD:
         assert data["number_of_days"] == 1
         assert data["days"][0]["day_name"] == "Push"
         assert data["days"][0]["exercises"][0]["sets"] == 4
+
+    async def test_update_plan_days_preserves_grouping_and_order(self, client: AsyncClient):
+        """PUT /plans/{id} keeps explicit exercise order and superset metadata."""
+        ex1 = await create_exercise(client, name="bench_press", display_name="Bench Press")
+        ex2 = await create_exercise(client, name="barbell_row", display_name="Barbell Row", primary_muscles=["back"])
+        plan = await create_plan(client, ex1["id"], sets=3, reps=8)
+
+        new_days = [
+            {
+                "day_number": 1,
+                "day_name": "Upper",
+                "exercises": [
+                    {
+                        "exercise_id": ex2["id"],
+                        "sets": 4,
+                        "reps": 10,
+                        "starting_weight_kg": 0,
+                        "progression_type": "linear",
+                        "group_id": "g-upper",
+                        "group_type": "superset",
+                    },
+                    {
+                        "exercise_id": ex1["id"],
+                        "sets": 4,
+                        "reps": 8,
+                        "starting_weight_kg": 0,
+                        "progression_type": "linear",
+                        "group_id": "g-upper",
+                        "group_type": "superset",
+                    },
+                ],
+            }
+        ]
+        r = await client.put(
+            f"/api/plans/{plan['id']}",
+            json={"number_of_days": 1, "days": new_days},
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        exercises = data["days"][0]["exercises"]
+        assert [ex["exercise_id"] for ex in exercises] == [ex2["id"], ex1["id"]]
+        assert exercises[0]["group_id"] == "g-upper"
+        assert exercises[0]["group_type"] == "superset"
+        assert exercises[1]["group_id"] == "g-upper"
+        assert exercises[1]["group_type"] == "superset"
 
     async def test_update_plan_not_found(self, client: AsyncClient):
         """PUT /plans/99999 returns 404."""

--- a/tests/test_sync_to_plan.py
+++ b/tests/test_sync_to_plan.py
@@ -186,3 +186,47 @@ class TestSyncStructural:
         assert exercises[0]["rest_seconds"] == 120
         assert exercises[0]["notes"] == "Pause at bottom"
         assert exercises[0]["starting_weight_kg"] == 55.0
+
+    async def test_sync_uses_client_order_and_superset_grouping(self, client: AsyncClient):
+        """Sync respects the workout UI's final order and grouping metadata."""
+        ex1 = await create_exercise(client, name="bench_press", display_name="Bench Press")
+        ex2 = await create_exercise(client, name="barbell_row", display_name="Barbell Row", primary_muscles=["back"])
+        plan = await _create_plan_with_exercises(client, [
+            {"exercise_id": ex1["id"], "sets": 2, "reps": 8, "starting_weight_kg": 0, "progression_type": "linear"},
+            {"exercise_id": ex2["id"], "sets": 2, "reps": 10, "starting_weight_kg": 0, "progression_type": "linear"},
+        ])
+        sess = await start_session_from_plan(client, plan["id"])
+
+        for s in sess["sets"]:
+            await client.patch(f"/api/sessions/{sess['id']}/sets/{s['id']}", json={
+                "actual_weight_kg": 60.0,
+                "actual_reps": 8 if s["exercise_id"] == ex1["id"] else 10,
+            })
+
+        await _complete_session(client, sess["id"])
+        r = await client.post(
+            f"/api/sessions/{sess['id']}/sync-to-plan",
+            json={
+                "exercises": [
+                    {
+                        "exercise_id": ex2["id"],
+                        "group_id": "g-sync",
+                        "group_type": "superset",
+                    },
+                    {
+                        "exercise_id": ex1["id"],
+                        "group_id": "g-sync",
+                        "group_type": "superset",
+                    },
+                ]
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["structural_changes"] >= 1
+
+        exercises = await _get_plan_exercises(client, plan["id"])
+        assert [ex["exercise_id"] for ex in exercises] == [ex2["id"], ex1["id"]]
+        assert exercises[0]["group_id"] == "g-sync"
+        assert exercises[0]["group_type"] == "superset"
+        assert exercises[1]["group_id"] == "g-sync"
+        assert exercises[1]["group_type"] == "superset"


### PR DESCRIPTION
## Summary
- preserve superset/circuit grouping in planned exercise schemas instead of dropping that metadata on plan save
- send the active workout UI order and grouping back during sync-to-plan so reordered movements and linked supersets persist reliably
- keep the legacy no-body sync path working and stop fallback sync from sorting sets by exercise id

## Testing
- python3 -m py_compile app/api/sessions.py app/schemas/requests.py
- python3.11 end-to-end ASGI verification script covering create-plan grouping, update-plan reorder/group retention, sync-to-plan reorder/group persistence, and legacy no-body sync weight/rep updates
- Attempted: PYTHONPATH=. pytest tests/test_plans.py tests/test_sync_to_plan.py *(blocked by existing shared test DB user-fixture contamination in this environment, unrelated to this change)*

Closes #743