### PR TITLE
Fix session prefill not working in auto-detect flow (#751)

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -865,8 +865,12 @@
           try {
             const next = await getNextWorkout();
             if (next && next.plan && next.day && !next.is_complete) {
-              // Navigate to the correct plan+day URL so startFromPlan runs properly
+              // Update the URL bar so back-navigation works correctly.
+              // NOTE: goto() with replaceState does NOT re-run onMount (same-route
+              // navigation reuses the component), so we must call startFromPlan
+              // directly here rather than relying on the URL change to trigger it.
               goto(`/workout/active?plan=${next.plan.id}&day=${next.day.day_number}`, { replaceState: true });
+              await startFromPlan(next.plan.id, next.day.day_number);
               return;
             }
           } catch { /* fall through to picker if next-workout lookup fails */ }


### PR DESCRIPTION
## Summary
- When `/workout/active` is opened without `?plan=X&day=Y` URL params (e.g. from the home screen "Start Workout" link), the page auto-detects the next scheduled workout via `getNextWorkout()`
- It then called `goto()` to update the URL and `return`ed — but `goto()` with `replaceState` on the **same route** reuses the existing Svelte component instance and does **not** re-run `onMount`
- `startFromPlan` was therefore never called: user landed on an infinite loading spinner with no exercises and no prefilled weights
- Fix: call `startFromPlan()` directly after `goto()` so the workout starts with progressive overload suggestions

## Test plan
- [ ] Navigate to `/workout/active` (no URL params) after having completed a plan session — workout should auto-start with prefilled weights/reps
- [ ] Navigate via the Plans page (`/plans` → Start Workout button) — still works correctly with params in URL
- [ ] Navigate from home screen "Start Next Workout" button — now correctly prefills weights
- [ ] All 52 prefill/session tests passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)