### PR TITLE
fix(#750): fix progress card and recommendations layout on mobile

### DIFF
--- a/frontend/src/routes/progress/+page.svelte
+++ b/frontend/src/routes/progress/+page.svelte
@@ -532,22 +532,22 @@
 
   <!-- Drill-down: individual exercise cards -->
   {#if selectedGroup && drilldownExercises.length > 0 && !loading}
-    <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
       {#each drilldownExercises as name, idx}
         {@const vals = [...exercisePctSeries.get(name)!.values()]}
         {@const pct = vals.length > 0 ? Math.round(vals[vals.length - 1] * 10) / 10 : 0}
         {@const assisted = exerciseNameToIsAssisted.get(name) === true}
-        <div class="card">
-          <div class="flex items-center gap-2 mb-1">
-            <div class="w-2.5 h-2.5 rounded-full flex-shrink-0" style="background:{COLORS[idx % COLORS.length]}"></div>
-            <p class="text-xs text-zinc-400 truncate" title={name}>{name}</p>
+        <div class="card flex items-center gap-3">
+          <div class="w-2.5 h-2.5 rounded-full flex-shrink-0" style="background:{COLORS[idx % COLORS.length]}"></div>
+          <div class="min-w-0 flex-1">
+            <p class="text-sm text-zinc-300 truncate" title={name}>{name}</p>
+            <p class="text-lg font-bold {pct > 0 ? 'text-green-400' : pct < 0 ? 'text-red-400' : 'text-zinc-400'}">
+              {pct > 0 ? '+' : ''}{pct}%
+            </p>
+            {#if assisted}
+              <p class="text-xs text-zinc-600">assistance ↓ = progress</p>
+            {/if}
           </div>
-          <p class="text-xl font-bold {pct > 0 ? 'text-green-400' : pct < 0 ? 'text-red-400' : 'text-zinc-400'}">
-            {pct > 0 ? '+' : ''}{pct}%
-          </p>
-          {#if assisted}
-            <p class="text-xs text-zinc-600 mt-0.5">assistance ↓ = progress</p>
-          {/if}
         </div>
       {/each}
     </div>
@@ -565,33 +565,25 @@
         {/each}
       </div>
     {:else if filteredRecs.length > 0}
-      <div class="overflow-x-auto">
-        <table class="w-full text-left text-sm">
-          <thead>
-            <tr class="border-b border-zinc-800 text-zinc-400">
-              <th class="py-2 px-3">Exercise</th>
-              <th class="py-2 px-3">Current best</th>
-              <th class="py-2 px-3">Recommended</th>
-              <th class="py-2 px-3">Reason</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each filteredRecs as rec}
-              {@const delta = rec.recommended_weight - rec.current_weight}
-              <tr class="border-b border-zinc-800/50 hover:bg-zinc-900">
-                <td class="py-2 px-3 font-medium">{rec.exercise_name}</td>
-                <td class="py-2 px-3 font-mono">{displayWeight(rec.current_weight).toFixed(1)} {unit}</td>
-                <td class="py-2 px-3 font-mono {delta > 0 ? 'text-green-400' : delta < 0 ? 'text-red-400' : 'text-yellow-400'}">
-                  {displayWeight(rec.recommended_weight).toFixed(1)} {unit}
-                  {#if delta > 0}<span class="text-xs ml-1">↑</span>
-                  {:else if delta < 0}<span class="text-xs ml-1">↓</span>
-                  {:else}<span class="text-xs ml-1">→</span>{/if}
-                </td>
-                <td class="py-2 px-3 text-zinc-400">{rec.reason}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
+      <div class="space-y-2">
+        {#each filteredRecs as rec}
+          {@const delta = rec.recommended_weight - rec.current_weight}
+          <div class="flex items-center gap-3 py-3 border-b border-zinc-800/50 last:border-0">
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-medium truncate" title={rec.exercise_name}>{rec.exercise_name}</p>
+              <p class="text-xs text-zinc-500 mt-0.5 line-clamp-2">{rec.reason}</p>
+            </div>
+            <div class="flex-shrink-0 text-right">
+              <p class="text-xs text-zinc-400">{displayWeight(rec.current_weight).toFixed(1)} {unit}</p>
+              <p class="text-sm font-mono font-bold {delta > 0 ? 'text-green-400' : delta < 0 ? 'text-red-400' : 'text-yellow-400'}">
+                {displayWeight(rec.recommended_weight).toFixed(1)} {unit}
+                {#if delta > 0}<span class="text-xs">↑</span>
+                {:else if delta < 0}<span class="text-xs">↓</span>
+                {:else}<span class="text-xs">→</span>{/if}
+              </p>
+            </div>
+          </div>
+        {/each}
       </div>
     {:else}
       <p class="text-zinc-400 text-center py-6">


### PR DESCRIPTION
## Summary
- Exercise drill-down cards: switched from `grid-cols-2` to `grid-cols-1` on mobile with horizontal flex layout and `min-w-0` for proper text truncation
- Recommendations section: replaced 4-column table (which overflowed on narrow screens, cutting off the Reason column) with a flex card/list layout — exercise name + reason on left, current/recommended weights on right

## Test plan
- [ ] Progress page exercise cards display in single column on mobile (375px wide)
- [ ] Long exercise names truncate properly with ellipsis
- [ ] Recommendations section shows all columns without horizontal overflow
- [ ] Layout expands to 2/3 columns on tablet/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)