### PR TITLE
Use shared persistence helper for workout reorder buttons (#761)

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -2914,9 +2914,9 @@
               </div>
               <div class="flex items-center gap-1 ml-3 mt-0.5">
                 <!-- Reorder buttons -->
-                <button onclick={() => { const i = uiExercises.indexOf(ex); if (i > 0) { [uiExercises[i-1], uiExercises[i]] = [uiExercises[i], uiExercises[i-1]]; uiExercises = [...uiExercises]; } }}
+                <button onclick={() => { const i = uiExercises.indexOf(ex); if (i > 0) moveExercise(i, -1); }}
                         class="text-zinc-500 hover:text-white px-1 text-sm">▲</button>
-                <button onclick={() => { const i = uiExercises.indexOf(ex); if (i < uiExercises.length - 1) { [uiExercises[i], uiExercises[i+1]] = [uiExercises[i+1], uiExercises[i]]; uiExercises = [...uiExercises]; } }}
+                <button onclick={() => { const i = uiExercises.indexOf(ex); if (i < uiExercises.length - 1) moveExercise(i, 1); }}
                         class="text-zinc-500 hover:text-white px-1 text-sm">▼</button>
                 {#if exercise?.description}
                   <button


### PR DESCRIPTION
## Summary
- route the visible active-workout reorder buttons through the shared move helper
- make those button-triggered reorders persist through the same session-structure save path as other planning-stage edits
- avoid the previous inline array swap path that changed UI order without saving it for resume

## Testing
- npm --prefix frontend run check *(fails locally: svelte-check: command not found)*

Closes #761