### PR TITLE
fix(#757): compute assisted exercise 1RM as bodyweight minus assistance

### DIFF
--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -106,6 +106,16 @@ async def get_progress(
     )
     exercise_map = {e.id: e for e in exercises_result.scalars().all()}
 
+    # ── Fetch user's most recent body weight (needed for assisted 1RM) ───────
+    bw_result = await db.execute(
+        select(BodyWeightEntry)
+        .where(BodyWeightEntry.user_id == user.id)
+        .order_by(desc(BodyWeightEntry.recorded_at))
+        .limit(1)
+    )
+    bw_entry = bw_result.scalar_one_or_none()
+    body_weight_kg: float = bw_entry.weight_kg if bw_entry else 0.0
+
     # ── Group sets by (session_id, exercise_id) ──────────────────────────────
     grouped: dict[tuple[int, int], list[ExerciseSet]] = {}
     for s in all_sets:
@@ -132,7 +142,15 @@ async def get_progress(
             r = s.actual_reps or 0
             max_weight = max(max_weight, w)
             if w > 0 and r > 0:
-                one_rm = w * (1 + r / 30)
+                # For assisted exercises (pull-up/dip machines) the stored weight
+                # is the assistance weight. Effective load = bodyweight - assistance.
+                # This makes 1RM naturally increase as the user gets stronger
+                # (less assistance → higher effective weight → higher 1RM).
+                if exercise.is_assisted and body_weight_kg > 0:
+                    eff_w = max(0.0, body_weight_kg - w)
+                else:
+                    eff_w = w
+                one_rm = eff_w * (1 + r / 30)
                 if estimated_1rm is None or one_rm > estimated_1rm:
                     estimated_1rm = one_rm
 
@@ -195,26 +213,40 @@ async def get_recommendations(
     exercise_map = {e.id: e for e in exercises_result.scalars().all()}
 
     # ── Collect best performance per exercise ─────────────────────────────────
+    # For assisted exercises: "best" means lowest assistance weight (= highest effective load).
+    # We initialise best_weight to infinity so the first real set always wins.
     exercise_performance: dict[int, dict] = {}
     for exercise_set in all_sets:
         ex_id = exercise_set.exercise_id
+        exercise = exercise_map.get(ex_id)
+        is_assisted = exercise.is_assisted if exercise else False
+
         if ex_id not in exercise_performance:
             exercise_performance[ex_id] = {
-                "best_weight": 0.0,
+                # For assisted start at inf so any real weight beats it
+                "best_weight": float("inf") if is_assisted else 0.0,
                 "best_reps": 0,
                 "total_volume": 0.0,
                 "set_count": 0,
+                "is_assisted": is_assisted,
             }
 
         weight = exercise_set.actual_weight_kg or 0.0
         reps = exercise_set.actual_reps or 0
 
-        if weight > exercise_performance[ex_id]["best_weight"]:
-            exercise_performance[ex_id]["best_weight"] = weight
-            exercise_performance[ex_id]["best_reps"] = reps
+        perf = exercise_performance[ex_id]
+        if is_assisted:
+            # Lower assistance = stronger; track the set with least assistance
+            if weight > 0 and weight < perf["best_weight"]:
+                perf["best_weight"] = weight
+                perf["best_reps"] = reps
+        else:
+            if weight > perf["best_weight"]:
+                perf["best_weight"] = weight
+                perf["best_reps"] = reps
 
-        exercise_performance[ex_id]["total_volume"] += weight * reps
-        exercise_performance[ex_id]["set_count"] += 1
+        perf["total_volume"] += weight * reps
+        perf["set_count"] += 1
 
     # ── Build recommendations ─────────────────────────────────────────────────
     recommendations = []
@@ -224,19 +256,39 @@ async def get_recommendations(
             continue
 
         current_weight = perf["best_weight"]
+        is_assisted = perf.get("is_assisted", False)
 
-        if perf["best_reps"] >= 10:
-            recommended_weight = current_weight * 1.05
-            reason = "Achieved 10+ reps — increase weight by 5%"
-        elif perf["best_reps"] >= 8:
-            recommended_weight = current_weight * 1.025
-            reason = "Achieved 8–9 reps — small weight increase"
-        elif perf["best_reps"] >= 5:
-            recommended_weight = current_weight
-            reason = "Focus on adding reps before increasing weight"
+        # Guard against inf (no valid sets found for assisted)
+        if current_weight == float("inf"):
+            continue
+
+        if is_assisted:
+            # Assisted: goal is to REDUCE assistance weight over time
+            if perf["best_reps"] >= 10:
+                recommended_weight = current_weight * 0.95
+                reason = "Achieved 10+ reps — reduce assistance by 5%"
+            elif perf["best_reps"] >= 8:
+                recommended_weight = current_weight * 0.975
+                reason = "Achieved 8–9 reps — small assistance reduction"
+            elif perf["best_reps"] >= 5:
+                recommended_weight = current_weight
+                reason = "Focus on adding reps before reducing assistance"
+            else:
+                recommended_weight = current_weight * 1.05
+                reason = "Below 5 reps — consider more assistance"
         else:
-            recommended_weight = current_weight * 0.95
-            reason = "Below 5 reps — consider deloading"
+            if perf["best_reps"] >= 10:
+                recommended_weight = current_weight * 1.05
+                reason = "Achieved 10+ reps — increase weight by 5%"
+            elif perf["best_reps"] >= 8:
+                recommended_weight = current_weight * 1.025
+                reason = "Achieved 8–9 reps — small weight increase"
+            elif perf["best_reps"] >= 5:
+                recommended_weight = current_weight
+                reason = "Focus on adding reps before increasing weight"
+            else:
+                recommended_weight = current_weight * 0.95
+                reason = "Below 5 reps — consider deloading"
 
         recommendations.append({
             "exercise_id": ex_id,

--- a/frontend/src/routes/progress/+page.svelte
+++ b/frontend/src/routes/progress/+page.svelte
@@ -131,19 +131,6 @@
     return map;
   });
 
-  // exercise display name → is_assisted flag
-  let exerciseNameToIsAssisted = $derived.by(() => {
-    const idToAssisted = new Map<number, boolean>();
-    for (const ex of allExercises) idToAssisted.set(ex.id, ex.is_assisted ?? false);
-    const map = new Map<string, boolean>();
-    for (const p of progressData) {
-      if (p.exercise_id != null) {
-        map.set(p.exercise_name, p.is_assisted === true);
-      }
-    }
-    return map;
-  });
-
   // exercise display name → primary muscles (for sub-group filtering)
   let exerciseNameToMuscles = $derived.by(() => {
     const idToMuscles = new Map<number, string[]>();
@@ -161,8 +148,9 @@
   // Per-exercise % change time series: Map<exerciseName, Map<date, pctChange>>
   // All series start at 0% on the first date.
   // Uses the highest estimated 1RM per date (best set, not first set).
-  // For assisted exercises (dip/pull-up machines), lower weight = more strength,
-  // so we invert the direction: decreasing assistance → positive % change.
+  // For assisted exercises the backend returns estimated_1rm computed from
+  // (bodyweight - assistance), so a decreasing assistance weight correctly
+  // produces an increasing 1RM — no direction inversion needed here.
   let exercisePctSeries = $derived.by(() => {
     const result = new Map<string, Map<string, number>>();
     const names = [...new Set(progressData.map(p => p.exercise_name))];
@@ -172,18 +160,11 @@
       );
       if (points.length === 0) continue;
 
-      const isAssisted = points[0].is_assisted === true;
-
       // Group by date — keep max estimated_1rm per date (best set wins)
-      // For assisted, keep min (lowest assistance weight = strongest set)
       const bestByDate = new Map<string, number>();
       for (const p of points) {
         const prev = bestByDate.get(p.date);
-        if (isAssisted) {
-          bestByDate.set(p.date, prev == null ? p.estimated_1rm! : Math.min(prev, p.estimated_1rm!));
-        } else {
-          bestByDate.set(p.date, prev == null ? p.estimated_1rm! : Math.max(prev, p.estimated_1rm!));
-        }
+        bestByDate.set(p.date, prev == null ? p.estimated_1rm! : Math.max(prev, p.estimated_1rm!));
       }
 
       const sortedDates = [...bestByDate.keys()].sort();
@@ -191,10 +172,7 @@
       const series = new Map<string, number>();
       for (const date of sortedDates) {
         const current = bestByDate.get(date)!;
-        // Invert for assisted: less assistance = more progress
-        const pct = isAssisted
-          ? ((baseline - current) / baseline) * 100
-          : ((current - baseline) / baseline) * 100;
+        const pct = ((current - baseline) / baseline) * 100;
         series.set(date, pct);
       }
       result.set(name, series);
@@ -536,7 +514,6 @@
       {#each drilldownExercises as name, idx}
         {@const vals = [...exercisePctSeries.get(name)!.values()]}
         {@const pct = vals.length > 0 ? Math.round(vals[vals.length - 1] * 10) / 10 : 0}
-        {@const assisted = exerciseNameToIsAssisted.get(name) === true}
         <div class="card flex items-center gap-3">
           <div class="w-2.5 h-2.5 rounded-full flex-shrink-0" style="background:{COLORS[idx % COLORS.length]}"></div>
           <div class="min-w-0 flex-1">
@@ -544,9 +521,6 @@
             <p class="text-lg font-bold {pct > 0 ? 'text-green-400' : pct < 0 ? 'text-red-400' : 'text-zinc-400'}">
               {pct > 0 ? '+' : ''}{pct}%
             </p>
-            {#if assisted}
-              <p class="text-xs text-zinc-600">assistance ↓ = progress</p>
-            {/if}
           </div>
         </div>
       {/each}


### PR DESCRIPTION
## Summary
- **Root cause**: For assisted machines (pull-up/dip), stored weight = assistance weight. As users get stronger, assistance decreases → raw 1RM went DOWN, showing false regression in the chart.
- **Backend fix (`get_progress`)**: Fetch the user's latest body weight and compute `effective_weight = BW - assistance` for `is_assisted` exercises. The 1RM now naturally increases as assistance drops.
- **Backend fix (`get_recommendations`)**: Track the set with the *lowest* assistance as best performance (not highest). Invert recommendation logic — suggest reducing assistance on success, not adding more weight.
- **Frontend fix**: Removed the direction inversion in `exercisePctSeries` that was compensating for the incorrect backend calculation. Dropped unused `exerciseNameToIsAssisted` derived and the "assistance ↓ = progress" hint from exercise cards.

> **Note**: This supersedes PR #748 (assisted exercise direction inversion) — the backend fix makes the frontend workaround unnecessary.

## Test plan
- [ ] All 159 backend tests pass
- [ ] TypeScript compiles clean
- [ ] Progress page loads and renders without errors
- [ ] Assisted pull-up/dip machine exercises show increasing 1RM trend as assistance weight decreases over sessions
- [ ] Recommendations for assisted exercises suggest *reducing* assistance when high reps are achieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)