### PR TITLE
fix #778: fatigue-adjusted prefill when exercise order changes

### DIFF
--- a/alembic/versions/f1a2b3c4d5e6_add_is_extrapolated_to_exercise_sets.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_is_extrapolated_to_exercise_sets.py
@@ -1,0 +1,28 @@
+"""add is_extrapolated to exercise_sets
+
+Revision ID: f1a2b3c4d5e6
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-02
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, Sequence[str], None] = 'e5f6a7b8c9d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    cols = [c[1] for c in conn.execute(sa.text("PRAGMA table_info(exercise_sets)")).fetchall()]
+    if 'is_extrapolated' not in cols:
+        with op.batch_alter_table('exercise_sets', schema=None) as batch_op:
+            batch_op.add_column(sa.Column('is_extrapolated', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('exercise_sets', schema=None) as batch_op:
+        batch_op.drop_column('is_extrapolated')

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -93,6 +93,7 @@ def serialize_set(exercise_set: ExerciseSet) -> dict:
         "draft_reps_left": exercise_set.draft_reps_left,
         "draft_reps_right": exercise_set.draft_reps_right,
         "skipped_at": exercise_set.skipped_at.isoformat() if exercise_set.skipped_at else None,
+        "is_extrapolated": bool(exercise_set.is_extrapolated) if exercise_set.is_extrapolated else False,
     }
 
 
@@ -1003,10 +1004,15 @@ async def create_session_from_plan(
     # Build per-exercise PER-SET lookup from prior session so each set can
     # be progressively overloaded from its own corresponding prior-session set.
     # Structure: prior_set_data[exercise_id][set_number] = {weight, reps, planned_reps}
+    # Also track prior_exercise_order (exercise_ids in set-creation order) so we
+    # can detect reordering and apply a fatigue-freshness adjustment.
     prior_set_data: dict[int, dict[int, dict]] = {}
+    prior_exercise_order: list[int] = []  # exercise_ids in order they were worked
     if prior_session:
         prior_sets_result = await db.execute(
-            select(ExerciseSet).where(ExerciseSet.workout_session_id == prior_session.id)
+            select(ExerciseSet)
+            .where(ExerciseSet.workout_session_id == prior_session.id)
+            .order_by(ExerciseSet.id)
         )
         for s in prior_sets_result.scalars().all():
             if s.skipped_at is not None:
@@ -1015,6 +1021,7 @@ async def create_session_from_plan(
                 continue
             ex_id = s.exercise_id
             if ex_id not in prior_set_data:
+                prior_exercise_order.append(ex_id)  # first appearance = exercise order
                 prior_set_data[ex_id] = {}
 
             weight = s.actual_weight_kg
@@ -1068,6 +1075,57 @@ async def create_session_from_plan(
                 if ex_m and ex_m.is_assisted and body_weight_kg > 0 and w > body_weight_kg * 0.5:
                     w = max(0.0, body_weight_kg - w)
                 cross_meso_data[ex_id] = {"weight": w, "reps": row.actual_reps}
+
+    # ── Fatigue-freshness reorder detection ───────────────────────────────────
+    # When the exercise order changes between sessions each exercise is performed
+    # with a different level of accumulated fatigue from similar-muscle work.
+    # We model this as ~2 % e1RM reduction per additional preceding set whose
+    # primary muscles overlap with the current exercise.
+    #
+    # "Similar" = any primary-muscle overlap (e.g. flies and presses both work
+    # pecs). Only movements that share at least one primary muscle group are
+    # considered fatiguing to one another.
+    FATIGUE_PER_SIMILAR_SET = 0.02  # 2 % e1RM per similar set
+
+    # Build a map of exercise_id → primary muscle set for the day's exercises.
+    exercise_primary_muscles: dict[int, set[str]] = {
+        ex_id: set(exercise_model_map[ex_id].primary_muscles or [])
+        for ex_id in day_exercise_ids
+        if ex_id in exercise_model_map
+    }
+
+    # New plan exercise order (current day array index order).
+    new_exercise_order: list[int] = [
+        ex.get("exercise_id")
+        for ex in day_exercises
+        if ex.get("exercise_id")
+    ]
+
+    # Sets-per-exercise lookups (used to accumulate fatigue load).
+    prior_sets_count: dict[int, int] = {
+        ex_id: len(sets) for ex_id, sets in prior_set_data.items()
+    }
+    new_sets_count: dict[int, int] = {
+        ex.get("exercise_id"): ex.get("sets", 3)
+        for ex in day_exercises
+        if ex.get("exercise_id")
+    }
+
+    def _similar_sets_before(target_ex_id: int, order: list[int],
+                              sets_count: dict[int, int]) -> int:
+        """Count sets of exercises whose primary muscles overlap with target_ex_id
+        that appear BEFORE target_ex_id in the given exercise order."""
+        muscles_target = exercise_primary_muscles.get(target_ex_id, set())
+        if not muscles_target:
+            return 0
+        total = 0
+        for ex_id in order:
+            if ex_id == target_ex_id:
+                break
+            muscles_other = exercise_primary_muscles.get(ex_id, set())
+            if muscles_target & muscles_other:
+                total += sets_count.get(ex_id, 3)
+        return total
 
     def _overload_for_side(
         prior_weight: float | None,
@@ -1291,6 +1349,30 @@ async def create_session_from_plan(
                 if overload_style == "double" and rep_range_top > 0 and suggested_reps and suggested_reps > rep_range_top:
                     suggested_reps = rep_range_top
 
+            # ── Fatigue-freshness adjustment when exercise order changed ──────
+            # Only applies when we have prior session data AND the exercise has
+            # a valid weight suggestion AND primary muscles are known.
+            is_extrapolated = False
+            if (
+                weight_kg is not None
+                and prior_exercise_order
+                and exercise_id in exercise_primary_muscles
+                and exercise_primary_muscles[exercise_id]
+            ):
+                prior_similar = _similar_sets_before(
+                    exercise_id, prior_exercise_order, prior_sets_count
+                )
+                new_similar = _similar_sets_before(
+                    exercise_id, new_exercise_order, new_sets_count
+                )
+                delta = new_similar - prior_similar
+                if delta != 0:
+                    # Positive delta → more pre-fatigue → lower e1RM estimate.
+                    # Clamp factor to [0.70, 1.30] to avoid absurd extrapolations.
+                    factor = max(0.70, min(1.30, 1.0 - delta * FATIGUE_PER_SIMILAR_SET))
+                    weight_kg = round(weight_kg * factor / 2.5) * 2.5
+                    is_extrapolated = True
+
             # Save set 1's values for myo_rep_match copying
             if set_num == 1:
                 set1_weight_kg = weight_kg
@@ -1307,6 +1389,7 @@ async def create_session_from_plan(
                 planned_reps_right=planned_right,
                 planned_weight_kg=weight_kg,
                 set_type=effective_set_type,
+                is_extrapolated=is_extrapolated or None,  # None = falsy, saves space
             )
             db.add(exercise_set)
 

--- a/app/models/workout.py
+++ b/app/models/workout.py
@@ -69,6 +69,11 @@ class ExerciseSet(Base):
     draft_reps_left: Mapped[int | None] = mapped_column(Integer, nullable=True)
     draft_reps_right: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Fatigue-adjusted prefill flag: True when the planned weight was adjusted
+    # because the exercise moved to a more/less fatigued position vs last session.
+    # Shown as a visual indicator so the user knows it's an estimate.
+    is_extrapolated: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+
     # Notes and timestamps
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -173,6 +173,7 @@ class SetResponse(BaseModel):
     draft_reps_left: int | None = None
     draft_reps_right: int | None = None
     skipped_at: str | None = None
+    is_extrapolated: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -93,6 +93,7 @@
     // Original suggestions for deviation warning
     initWeight: number | null;
     initReps: number | null;
+    isExtrapolated: boolean;  // weight adjusted for fatigue/freshness due to reorder
     setType: string;  // 'standard' | 'standard_partials' | 'myo_rep' | 'myo_rep_match' | 'drop_set'
     partialReps: number | null;  // for standard_partials — partial ROM reps after full ROM
     drops: { weightLbs: number | null; reps: number | null }[];  // for drop sets only
@@ -1064,6 +1065,7 @@
               oneRM,
               initWeight: suggestedWeight,
               initReps:   suggestedReps,
+              isExtrapolated: bset?.is_extrapolated ?? false,
               setType: bset?.set_type || 'standard',
               partialReps: bset?.sub_sets?.find((d: any) => d.type === 'partial')?.reps ?? null,
               drops: bset?.sub_sets ? bset.sub_sets.filter((d: any) => d.type !== 'partial').map((d: any) => ({
@@ -1228,6 +1230,7 @@
             oneRM,
             initWeight: sugW,
             initReps: sugR,
+            isExtrapolated: bset.is_extrapolated ?? false,
             setType: bset.set_type || 'standard',
             partialReps: bset.sub_sets?.find((d: any) => d.type === 'partial')?.reps ?? null,
             drops: bset.sub_sets ? bset.sub_sets.filter((d: any) => d.type !== 'partial').map((d: any) => ({
@@ -3085,6 +3088,9 @@
                             {#if isAssistedEx && set.weightLbs !== null}
                               <span class="text-xs text-amber-400 text-center">{netDisplay(set.weightLbs)}</span>
                             {/if}
+                            {#if set.isExtrapolated && !set.done}
+                              <span class="text-[9px] text-violet-400 text-center leading-tight" title="Adjusted for exercise reorder — estimate only">≈ reorder adj.</span>
+                            {/if}
                             {#if focusedWeightSetId === set.localId && !isAssistedEx && set.oneRM && set.weightLbs != null && set.weightLbs > 0 && !set.done}
                               {@const estReps = epleyReps(set.oneRM, set.weightLbs)}
                               {#if estReps < 5}
@@ -3269,6 +3275,9 @@
                       />
                       {#if isAssistedEx && set.weightLbs !== null}
                         <span class="text-xs text-amber-400 text-center">{netDisplay(set.weightLbs)}</span>
+                      {/if}
+                      {#if set.isExtrapolated && !set.done}
+                        <span class="text-[9px] text-violet-400 text-center leading-tight" title="Adjusted for exercise reorder — estimate only">≈ reorder adj.</span>
                       {/if}
                       {#if focusedWeightSetId === set.localId && !isAssistedEx && set.oneRM && set.weightLbs != null && set.weightLbs > 0 && !set.done}
                         {@const estReps = epleyReps(set.oneRM, set.weightLbs)}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,17 +36,11 @@ app.dependency_overrides[get_db] = override_get_db
 
 @pytest_asyncio.fixture(autouse=True)
 async def setup_db():
-    """Create all tables before each test, truncate after."""
+    """Drop and recreate all tables before each test for clean schema + isolation."""
     async with test_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
     yield
-    # Truncate all tables and reset sequences for clean isolation
-    async with test_engine.begin() as conn:
-        tables = ", ".join(
-            f'"{t.name}"' for t in reversed(Base.metadata.sorted_tables)
-        )
-        if tables:
-            await conn.exec_driver_sql(f"TRUNCATE {tables} RESTART IDENTITY CASCADE")
 
 
 @pytest_asyncio.fixture

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -829,3 +829,156 @@ class TestDoubleProgression:
         for s in w4["sets"]:
             assert s["planned_weight_kg"] == 42.5, f"Expected 42.5, got {s['planned_weight_kg']}"
             assert s["planned_reps"] == 8, f"Expected reset to 8, got {s['planned_reps']}"
+
+
+# ── Reorder fatigue adjustment ────────────────────────────────────────────────
+
+class TestReorderFatigueAdjustment:
+    """When exercise order changes between sessions the prefill adjusts for fatigue.
+
+    Flies and presses both work the chest (same primary muscle).  If presses
+    previously came AFTER 4 sets of flies (pre-fatigued), but now come FIRST
+    (fresh), the suggestion should be slightly heavier.  Conversely, flies
+    moving to AFTER presses should suggest slightly lighter.
+
+    The is_extrapolated flag must be True for any adjusted set.
+    """
+
+    async def _create_two_exercise_plan(self, client, ex1_id: int, ex2_id: int,
+                                         ex1_sets: int = 4, ex2_sets: int = 2,
+                                         reps: int = 10) -> dict:
+        body = {
+            "name": "Chest Day",
+            "block_type": "hypertrophy",
+            "duration_weeks": 4,
+            "number_of_days": 1,
+            "days": [{
+                "day_number": 1,
+                "day_name": "Day 1",
+                "exercises": [
+                    {"exercise_id": ex1_id, "sets": ex1_sets, "reps": reps,
+                     "starting_weight_kg": 0, "progression_type": "linear"},
+                    {"exercise_id": ex2_id, "sets": ex2_sets, "reps": reps,
+                     "starting_weight_kg": 0, "progression_type": "linear"},
+                ],
+            }],
+        }
+        r = await client.post("/api/plans/", json=body)
+        assert r.status_code == 201, r.text
+        return r.json()
+
+    async def test_no_reorder_no_extrapolation(self, client: AsyncClient):
+        """When order is unchanged, is_extrapolated must be False for all sets."""
+        flies = await create_exercise(client, name="flies", display_name="Flies",
+                                       primary_muscles=["chest"])
+        press = await create_exercise(client, name="press", display_name="Press",
+                                       primary_muscles=["chest"])
+        plan = await self._create_two_exercise_plan(client, flies["id"], press["id"])
+
+        # Week 1: flies first, then press
+        w1 = await start_session_from_plan(client, plan["id"])
+        for s in w1["sets"]:
+            await log_set(client, w1["id"], s["id"], 60.0, 10)
+
+        # Week 2: same order — no reorder adjustment
+        w2 = await start_session_from_plan(client, plan["id"])
+        assert all(not s["is_extrapolated"] for s in w2["sets"]), \
+            "No reorder → is_extrapolated must be False for all sets"
+
+    async def test_moving_exercise_earlier_increases_suggestion(self, client: AsyncClient):
+        """User reorders exercises within the same plan between sessions.
+
+        Week 1: flies (4 sets) → press (2 sets)  [plan order at that time]
+        User drags press to the top.
+        Week 2: press (2 sets) → flies (4 sets)  [new plan order after reorder]
+
+        Press is now fresher (fewer pre-fatiguing sets before it) → is_extrapolated True.
+        Flies is now more fatigued (more pre-fatiguing sets before it) → is_extrapolated True.
+        """
+        flies = await create_exercise(client, name="flies2", display_name="Flies",
+                                       primary_muscles=["chest"])
+        press = await create_exercise(client, name="press2", display_name="Press",
+                                       primary_muscles=["chest"])
+
+        # Create plan: flies (4 sets) → press (2 sets)
+        plan = await self._create_two_exercise_plan(
+            client, flies["id"], press["id"], ex1_sets=4, ex2_sets=2, reps=10
+        )
+
+        # Week 1 in original order: flies → press
+        w1 = await start_session_from_plan(client, plan["id"])
+        for s in w1["sets"]:
+            await log_set(client, w1["id"], s["id"], 80.0, 10)
+
+        # User reorders the plan: press → flies (swap within same plan)
+        reordered_days = [{
+            "day_number": 1,
+            "day_name": "Day 1",
+            "exercises": [
+                {"exercise_id": press["id"], "sets": 2, "reps": 10,
+                 "starting_weight_kg": 0, "progression_type": "linear"},
+                {"exercise_id": flies["id"], "sets": 4, "reps": 10,
+                 "starting_weight_kg": 0, "progression_type": "linear"},
+            ],
+        }]
+        r_update = await client.put(f"/api/plans/{plan['id']}", json={"days": reordered_days})
+        assert r_update.status_code == 200, r_update.text
+
+        # Week 2: press is now FIRST (was second after 4 sets of flies → fresher)
+        #         flies is now SECOND (was first with 0 pre-fatigue → more fatigued)
+        w2 = await start_session_from_plan(client, plan["id"])
+        press_sets = [s for s in w2["sets"] if s["exercise_id"] == press["id"]]
+        flies_sets = [s for s in w2["sets"] if s["exercise_id"] == flies["id"]]
+
+        assert all(s["is_extrapolated"] for s in press_sets), \
+            f"Press moved earlier (fresher) → is_extrapolated True: {press_sets}"
+        assert all(s["is_extrapolated"] for s in flies_sets), \
+            f"Flies moved later (more fatigued) → is_extrapolated True: {flies_sets}"
+
+        # Press moved to fresher position: weight should be >= unmodified overload
+        # (2% per 4 sets = 8% more e1RM → higher weight suggestion)
+        press_w = press_sets[0]["planned_weight_kg"]
+        # Baseline would be 80kg at 10 reps overloaded to 11 reps at same weight
+        # After freshness adjustment it should equal or exceed that (or same weight with more reps)
+        assert press_w is not None, "Press should have a weight suggestion"
+
+    async def test_unrelated_muscles_no_adjustment(self, client: AsyncClient):
+        """Reordering exercises with non-overlapping muscles does NOT adjust weight."""
+        chest_ex = await create_exercise(client, name="chest_ex", display_name="Chest",
+                                          primary_muscles=["chest"])
+        leg_ex   = await create_exercise(client, name="leg_ex", display_name="Legs",
+                                          primary_muscles=["quads"])
+
+        # Plan: chest → legs
+        body = {
+            "name": "Full Body",
+            "block_type": "hypertrophy",
+            "duration_weeks": 4,
+            "number_of_days": 1,
+            "days": [{"day_number": 1, "day_name": "Day 1", "exercises": [
+                {"exercise_id": chest_ex["id"], "sets": 3, "reps": 10,
+                 "starting_weight_kg": 0, "progression_type": "linear"},
+                {"exercise_id": leg_ex["id"], "sets": 3, "reps": 10,
+                 "starting_weight_kg": 0, "progression_type": "linear"},
+            ]}],
+        }
+        r = await client.post("/api/plans/", json=body)
+        plan = r.json()
+        w1 = await start_session_from_plan(client, plan["id"])
+        for s in w1["sets"]:
+            await log_set(client, w1["id"], s["id"], 100.0, 10)
+
+        # Reordered plan: legs → chest (order changed but no muscle overlap)
+        body2 = dict(body)
+        body2["name"] = "Full Body v2"
+        body2["days"][0]["exercises"] = list(reversed(body["days"][0]["exercises"]))
+        r2 = await client.post("/api/plans/", json=body2)
+        plan2 = r2.json()
+        w1_p2 = await start_session_from_plan(client, plan2["id"])
+        for s in w1_p2["sets"]:
+            await log_set(client, w1_p2["id"], s["id"], 100.0, 10)
+
+        w2_p2 = await start_session_from_plan(client, plan2["id"])
+        # No muscle overlap → no adjustment → is_extrapolated must be False
+        assert all(not s["is_extrapolated"] for s in w2_p2["sets"]), \
+            "Non-overlapping muscles: no fatigue adjustment, is_extrapolated must be False"


### PR DESCRIPTION
## Summary
- When exercises are reordered within a plan between sessions, prefill weights are now adjusted for the change in accumulated fatigue
- ~2% e1RM reduction per additional preceding set with overlapping primary muscles (e.g. flies before presses both work chest)
- Adjusted sets are flagged `is_extrapolated=True` and shown with a violet "≈ reorder adj." hint under the weight input
- No adjustment fires when primary muscles don't overlap (legs → chest reorder has no effect)

## Technical details
- New `is_extrapolated` boolean column on `exercise_sets` with Alembic migration
- Prior session's exercise order tracked via set creation order (`.order_by(ExerciseSet.id)`)
- `_similar_sets_before()` computes cumulative pre-fatigue load for each position
- Fatigue factor clamped to [0.70, 1.30] to prevent absurd extrapolations
- `SetResponse` Pydantic schema updated to expose `is_extrapolated`
- `conftest.py` updated to `drop_all` + `create_all` so schema changes always take effect in tests

## Test plan
- [ ] All 162 tests pass (`python3.11 -m pytest tests/ -x -q`)
- [ ] `TestReorderFatigueAdjustment::test_no_reorder_no_extrapolation` — no flag when order unchanged
- [ ] `TestReorderFatigueAdjustment::test_moving_exercise_earlier_increases_suggestion` — flag fires on reorder
- [ ] `TestReorderFatigueAdjustment::test_unrelated_muscles_no_adjustment` — no flag for non-overlapping muscles
- [ ] Preview: reorder exercises in a plan mid-cycle, verify "≈ reorder adj." appears on affected sets

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)