### PR TITLE
Use structured plan day identity for session prefill

### DIFF
--- a/alembic/versions/2b4c6d8e0f1a_add_plan_day_number_to_workout_sessions.py
+++ b/alembic/versions/2b4c6d8e0f1a_add_plan_day_number_to_workout_sessions.py
@@ -1,0 +1,27 @@
+"""add plan_day_number to workout sessions
+
+Revision ID: 2b4c6d8e0f1a
+Revises: 1f2e3d4c5b6a
+Create Date: 2026-04-02
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "2b4c6d8e0f1a"
+down_revision: str | None = "1f2e3d4c5b6a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workout_sessions", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("plan_day_number", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workout_sessions", schema=None) as batch_op:
+        batch_op.drop_column("plan_day_number")

--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -106,6 +106,7 @@ def serialize_session(workout_session: WorkoutSession) -> dict:
         "date": workout_session.date,
         "status": workout_session.status,
         "workout_plan_id": workout_session.workout_plan_id,
+        "plan_day_number": workout_session.plan_day_number,
         "total_volume_kg": workout_session.total_volume_kg,
         "total_sets": workout_session.total_sets,
         "total_reps": workout_session.total_reps,
@@ -138,6 +139,25 @@ def _set_total_reps(exercise_set: ExerciseSet) -> int:
 
 def _set_total_volume_kg(exercise_set: ExerciseSet) -> float:
     return _set_total_reps(exercise_set) * (exercise_set.actual_weight_kg or 0)
+
+
+def _find_plan_day_for_session(session: WorkoutSession, days: list[dict]) -> dict | None:
+    """Prefer structured day identity; fall back to legacy name parsing."""
+    if session.plan_day_number is not None:
+        matched = next(
+            (day for day in days if day.get("day_number") == session.plan_day_number),
+            None,
+        )
+        if matched is not None:
+            return matched
+
+    if session.name and " - " in session.name:
+        session_day_name = session.name.split(" - ", 1)[1]
+        matched = next((day for day in days if day.get("day_name") == session_day_name), None)
+        if matched is not None:
+            return matched
+
+    return days[0] if days else None
 
 
 async def record_session_audit(
@@ -495,13 +515,8 @@ async def sync_session_to_plan(
     planned = json.loads(plan.planned_exercises) if isinstance(plan.planned_exercises, str) else plan.planned_exercises
     days = planned.get("days", [])
 
-    # Find the matching day by parsing day_name from session name ("Plan - DayName")
-    target_day = None
-    if session.name and " - " in session.name:
-        session_day_name = session.name.split(" - ", 1)[1]
-        target_day = next((d for d in days if d.get("day_name") == session_day_name), None)
-    if target_day is None and days:
-        target_day = days[0]
+    # Find the matching day using structured day identity first, then legacy name parsing.
+    target_day = _find_plan_day_for_session(session, days)
     if target_day is None:
         return {"updated": 0, "structural_changes": 0}
 
@@ -948,7 +963,13 @@ async def create_session_from_plan(
     planned_result = await db.execute(
         select(WorkoutSession).where(
             WorkoutSession.workout_plan_id == plan_id,
-            WorkoutSession.name == f"{plan.name} - {day_name}",
+            or_(
+                WorkoutSession.plan_day_number == day_number,
+                (
+                    WorkoutSession.plan_day_number.is_(None)
+                    & (WorkoutSession.name == f"{plan.name} - {day_name}")
+                ),
+            ),
             WorkoutSession.status == WorkoutStatus.PLANNED,
             WorkoutSession.started_at.is_(None),
             WorkoutSession.user_id == user.id,
@@ -991,9 +1012,15 @@ async def create_session_from_plan(
         select(WorkoutSession)
         .where(
             WorkoutSession.workout_plan_id == plan_id,
-            WorkoutSession.name == f"{plan.name} - {day_name}",
             WorkoutSession.id.in_(sessions_with_data),
             WorkoutSession.user_id == user.id,
+            or_(
+                WorkoutSession.plan_day_number == day_number,
+                (
+                    WorkoutSession.plan_day_number.is_(None)
+                    & (WorkoutSession.name == f"{plan.name} - {day_name}")
+                ),
+            ),
         )
         .order_by(desc(WorkoutSession.date), desc(WorkoutSession.id))
         .limit(1)
@@ -1159,6 +1186,7 @@ async def create_session_from_plan(
         date=date.today(),
         name=f"{plan.name} - {day_name}",
         workout_plan_id=plan_id,
+        plan_day_number=day_number,
         status=WorkoutStatus.PLANNED,
         user_id=user.id,
     )

--- a/app/models/workout.py
+++ b/app/models/workout.py
@@ -98,6 +98,7 @@ class WorkoutSession(Base):
     workout_plan_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("workout_plans.id"), nullable=True
     )
+    plan_day_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     name: Mapped[str | None] = mapped_column(String(100), nullable=True)
     date: Mapped[date] = mapped_column(Date, nullable=False)

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -194,6 +194,7 @@ class WorkoutSessionResponse(BaseModel):
     date: date
     status: WorkoutStatusSchema
     workout_plan_id: int | None = None
+    plan_day_number: int | None = None
     total_volume_kg: float
     total_sets: int
     total_reps: int

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -216,6 +216,7 @@ export interface WorkoutSession {
   date: string;
   status: 'planned' | 'in_progress' | 'completed' | 'skipped';
   workout_plan_id: number | null;
+  plan_day_number: number | null;
   total_volume_kg: number;
   total_sets: number;
   total_reps: number;

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -561,6 +561,42 @@ class TestStalePlannedSessionRegeneration:
             "Prefill weight should be unchanged on reuse"
 
 
+class TestStructuredPlanDayIdentity:
+    async def test_prefill_survives_plan_and_day_rename(self, client: AsyncClient):
+        """Prefill should continue after renaming the plan and the day label."""
+        ex = await create_exercise(client)
+        plan = await create_plan(client, ex["id"], sets=2, reps=8, name="Push Block")
+
+        w1 = await start_session_from_plan(client, plan["id"])
+        for s in w1["sets"]:
+            await log_set(client, w1["id"], s["id"], 80.0, 8)
+        complete = await client.post(f"/api/sessions/{w1['id']}/complete")
+        assert complete.status_code == 200, complete.text
+
+        renamed = await client.put(
+            f"/api/plans/{plan['id']}",
+            json={
+                "name": "Push Block v2",
+                "number_of_days": 1,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Press Day",
+                        "exercises": plan["days"][0]["exercises"],
+                    }
+                ],
+            },
+        )
+        assert renamed.status_code == 200, renamed.text
+
+        w2 = await start_session_from_plan(client, plan["id"])
+        assert w2["plan_day_number"] == 1
+        weights = [s["planned_weight_kg"] for s in w2["sets"]]
+        reps = [s["planned_reps"] for s in w2["sets"]]
+        assert all(w is not None for w in weights), f"Expected renamed week 2 to keep weight prefill, got {weights}"
+        assert all(r is not None for r in reps), f"Expected renamed week 2 to keep rep prefill, got {reps}"
+
+
 # ── Multi-week progression chain ──────────────────────────────────────────────
 
 class TestMultiWeekChain:

--- a/tests/test_sync_to_plan.py
+++ b/tests/test_sync_to_plan.py
@@ -230,3 +230,70 @@ class TestSyncStructural:
         assert exercises[0]["group_type"] == "superset"
         assert exercises[1]["group_id"] == "g-sync"
         assert exercises[1]["group_type"] == "superset"
+
+    async def test_sync_targets_same_day_after_day_rename(self, client: AsyncClient):
+        """Completed sessions should sync back to their original ordinal day even if labels changed."""
+        ex1 = await create_exercise(client, name="squat", display_name="Squat")
+        ex2 = await create_exercise(client, name="row", display_name="Row", primary_muscles=["back"])
+        plan = await _create_plan_with_exercises(client, [
+            {"exercise_id": ex1["id"], "sets": 2, "reps": 8, "starting_weight_kg": 0, "progression_type": "linear"},
+        ], day_name="Day 1")
+
+        # Expand to two days so day targeting matters.
+        expanded = await client.put(
+            f"/api/plans/{plan['id']}",
+            json={
+                "number_of_days": 2,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Day 1",
+                        "exercises": plan["days"][0]["exercises"],
+                    },
+                    {
+                        "day_number": 2,
+                        "day_name": "Day 2",
+                        "exercises": [
+                            {"exercise_id": ex2["id"], "sets": 2, "reps": 10, "starting_weight_kg": 0, "progression_type": "linear"},
+                        ],
+                    },
+                ],
+            },
+        )
+        assert expanded.status_code == 200, expanded.text
+
+        sess = await start_session_from_plan(client, plan["id"], day=2)
+        for s in sess["sets"]:
+            await client.patch(f"/api/sessions/{sess['id']}/sets/{s['id']}", json={
+                "actual_weight_kg": 55.0, "actual_reps": 10,
+            })
+        await _complete_session(client, sess["id"])
+
+        renamed = await client.put(
+            f"/api/plans/{plan['id']}",
+            json={
+                "number_of_days": 2,
+                "days": [
+                    {
+                        "day_number": 1,
+                        "day_name": "Lower A",
+                        "exercises": expanded.json()["days"][0]["exercises"],
+                    },
+                    {
+                        "day_number": 2,
+                        "day_name": "Upper Pull",
+                        "exercises": expanded.json()["days"][1]["exercises"],
+                    },
+                ],
+            },
+        )
+        assert renamed.status_code == 200, renamed.text
+
+        sync = await client.post(f"/api/sessions/{sess['id']}/sync-to-plan")
+        assert sync.status_code == 200, sync.text
+
+        plan_after = await client.get(f"/api/plans/{plan['id']}")
+        assert plan_after.status_code == 200, plan_after.text
+        days = plan_after.json()["days"]
+        assert days[0]["exercises"][0]["starting_weight_kg"] == 0
+        assert days[1]["exercises"][0]["starting_weight_kg"] == 55.0


### PR DESCRIPTION
Closes #780

## Summary
- add `plan_day_number` to workout sessions created from plans
- use plan id + day number for cached planned-session reuse and prior-session prefill lookup
- use the structured day number for sync-to-plan, with legacy name parsing fallback for older rows
- add regression coverage for plan/day renames

## Verification
- `python3 -m py_compile app/api/sessions.py app/models/workout.py app/schemas/requests.py`
- direct Python 3.11 ASGI verification script passed for rename-based prefill and sync-to-plan day targeting
- `PYTHONPATH=. pytest ...` is still flaky locally because the shared PostgreSQL test harness can reuse stale schema/users across interrupted runs