### PR TITLE
Use unilateral rep evidence in cross-plan prefill

### DIFF
--- a/app/api/sessions.py
+++ b/app/api/sessions.py
@@ -142,6 +142,18 @@ def _set_total_volume_kg(exercise_set: ExerciseSet) -> float:
     return _set_total_reps(exercise_set) * (exercise_set.actual_weight_kg or 0)
 
 
+def _set_rep_evidence(exercise_set: ExerciseSet) -> int | None:
+    """Return the strongest usable rep signal for progression logic."""
+    if exercise_set.actual_reps is not None and exercise_set.actual_reps > 0:
+        return exercise_set.actual_reps
+
+    left = exercise_set.reps_left if exercise_set.reps_left is not None and exercise_set.reps_left > 0 else None
+    right = exercise_set.reps_right if exercise_set.reps_right is not None and exercise_set.reps_right > 0 else None
+    if left is not None and right is not None:
+        return min(left, right)
+    return left if left is not None else right
+
+
 def _find_plan_day_for_session(session: WorkoutSession, days: list[dict]) -> dict | None:
     """Prefer structured day identity; fall back to legacy name parsing."""
     if session.plan_day_number is not None:
@@ -1083,7 +1095,11 @@ async def create_session_from_plan(
             .join(WorkoutSession, ExerciseSet.workout_session_id == WorkoutSession.id)
             .where(
                 ExerciseSet.exercise_id.in_(day_exercise_ids),
-                ExerciseSet.actual_reps.is_not(None),
+                or_(
+                    ExerciseSet.actual_reps.is_not(None),
+                    ExerciseSet.reps_left.is_not(None),
+                    ExerciseSet.reps_right.is_not(None),
+                ),
                 ExerciseSet.actual_weight_kg.is_not(None),
                 ExerciseSet.actual_weight_kg > 0,
                 ExerciseSet.set_type.in_(["standard", None]),
@@ -1096,12 +1112,15 @@ async def create_session_from_plan(
         for row, _date in recent_sets_q.all():
             ex_id = row.exercise_id
             if ex_id not in cross_meso_data:  # keep first = most recent
+                rep_evidence = _set_rep_evidence(row)
+                if rep_evidence is None:
+                    continue
                 w = row.actual_weight_kg
                 ex_m = exercise_model_map.get(ex_id)
                 # Correct legacy assisted data (see prior_set_data block above)
                 if ex_m and ex_m.is_assisted and body_weight_kg > 0 and w > body_weight_kg * 0.5:
                     w = max(0.0, body_weight_kg - w)
-                cross_meso_data[ex_id] = {"weight": w, "reps": row.actual_reps}
+                cross_meso_data[ex_id] = {"weight": w, "reps": rep_evidence}
 
     # ── Fatigue-freshness reorder detection ───────────────────────────────────
     # When the exercise order changes between sessions each exercise is performed

--- a/tests/test_prefill.py
+++ b/tests/test_prefill.py
@@ -13,7 +13,10 @@ Key invariants:
 """
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.workout import ExerciseSet
 from tests.conftest import (
     create_exercise, create_plan, start_session_from_plan, log_set
 )
@@ -309,6 +312,45 @@ class TestPlanIsolation:
         # Overload from Plan B's own week-1: should suggest same or slight increase
         assert all(w is not None for w in b2_weights), \
             f"Plan B week 2 should be pre-filled from its own week-1: {b2_weights}"
+
+    async def test_new_plan_cross_meso_uses_unilateral_rep_evidence(
+        self, client: AsyncClient, db: AsyncSession
+    ):
+        """Cross-meso prefill should accept legacy unilateral rows with only side reps."""
+        ex = await create_exercise(
+            client,
+            name="split_squat_cross",
+            display_name="Split Squat Cross",
+            is_unilateral=True,
+        )
+        plan_a = await create_plan(client, ex["id"], sets=1, reps=8, name="Cross A")
+        plan_b = await create_plan(client, ex["id"], sets=1, reps=8, name="Cross B")
+
+        sess_a = await start_session_from_plan(client, plan_a["id"])
+        set_id = sess_a["sets"][0]["id"]
+        logged = await client.patch(
+            f"/api/sessions/{sess_a['id']}/sets/{set_id}",
+            json={
+                "actual_weight_kg": 30.0,
+                "actual_reps": 8,
+                "reps_left": 8,
+                "reps_right": 10,
+                "completed_at": "2024-01-01T10:00:00",
+            },
+        )
+        assert logged.status_code == 200, logged.text
+        complete = await client.post(f"/api/sessions/{sess_a['id']}/complete")
+        assert complete.status_code == 200, complete.text
+
+        row = await db.execute(select(ExerciseSet).where(ExerciseSet.id == set_id))
+        exercise_set = row.scalar_one()
+        exercise_set.actual_reps = None
+        await db.commit()
+
+        sess_b = await start_session_from_plan(client, plan_b["id"])
+        next_set = sess_b["sets"][0]
+        assert next_set["planned_weight_kg"] is not None, next_set
+        assert next_set["planned_reps"] is not None, next_set
 
 
 # ── Assisted exercises ────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #786

## Summary
- accept unilateral left/right rep data in the cross-plan prefill query
- reuse the same rep-evidence logic when building cross-meso suggestions
- add regression coverage for starting a new plan from legacy unilateral history

## Verification
- python3 -m py_compile app/api/sessions.py tests/test_prefill.py
- DB=/tmp/fitness_prefill_786_focus_$RANDOM.sqlite; PYTHONPATH=. TEST_DATABASE_URL=sqlite+aiosqlite:///$DB pytest -q tests/test_prefill.py -k "cross_meso or unilateral_rep_evidence"
- DB=/tmp/fitness_prefill_786_full_$RANDOM.sqlite; PYTHONPATH=. TEST_DATABASE_URL=sqlite+aiosqlite:///$DB pytest -q tests/test_prefill.py