### PR TITLE
fix: offline banner stuck after server restart

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,9 +63,12 @@ api.interceptors.response.use(
     } else if (error.response) {
       console.error('API Error:', error.response.status, error.response.data);
     } else if (error.request) {
-      // Network error — queue write requests for offline sync
+      // Network error — only queue if the browser is truly offline.
+      // Transient server errors (container restart) shouldn't trigger
+      // the offline banner or queue stale requests.
       const method = error.config?.method?.toUpperCase();
-      if (method && ['PATCH', 'POST', 'PUT', 'DELETE'].includes(method) && error.config?.url) {
+      const browserOffline = typeof navigator !== 'undefined' && !navigator.onLine;
+      if (browserOffline && method && ['PATCH', 'POST', 'PUT', 'DELETE'].includes(method) && error.config?.url) {
         try {
           const { queueRequest, getPendingCount } = await import('$lib/offline');
           const { isOnline, pendingSyncCount } = await import('$lib/stores');

--- a/frontend/src/lib/offline.ts
+++ b/frontend/src/lib/offline.ts
@@ -121,7 +121,13 @@ export async function syncPendingRequests(
         // Token expired — stop syncing, user needs to re-auth
         failed++;
         break;
+      } else if (response.status >= 400 && response.status < 500) {
+        // Client error (404 deleted resource, 422 validation, etc.) —
+        // this request will never succeed, discard it.
+        await removeRequest(req.id);
+        failed++;
       } else {
+        // Server error (5xx) — keep for retry
         failed++;
       }
     } catch {


### PR DESCRIPTION
## Summary
- Only trigger offline mode when `navigator.onLine` is false (not on transient server errors during container restarts)
- Discard queued requests that get 4xx responses (deleted resources, validation errors) since they'll never succeed — previously they stayed in IndexedDB forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)