### PR TITLE
fix: pre-start weight edits lost after RIR adjustment

### DIFF
--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -998,8 +998,14 @@
     window.addEventListener('beforeunload', () => {
       if (sessionId) {
         const anyDone = uiExercises.some(ex => ex.sets.some(s => s.done));
-        if (!anyDone) {
-          // No sets completed — silently delete the empty planned session
+        const anyEdited = uiExercises.some(ex => ex.sets.some(s =>
+          !s.done && (
+            (s.weightLbs != null && s.weightLbs !== s.initWeight) ||
+            (s.reps != null && s.reps !== s.initReps)
+          )
+        ));
+        if (!anyDone && !anyEdited) {
+          // No sets completed or edited — silently delete the empty planned session
           const token = localStorage.getItem('hgt_access_token');
           fetch(`/api/sessions/${sessionId}`, {
             method: 'DELETE',


### PR DESCRIPTION
## Summary
When the user adjusts RIR, opens the workout, manually tweaks weights, then navigates away — the `beforeunload` handler deleted the session because no sets were completed. The user's weight edits were lost and the session was regenerated with the original RIR-calculated weights.

Now the session is preserved if the user has edited any weights or reps from their initial suggested values (compared against `initWeight`/`initReps`).

## Test plan
- [ ] Adjust RIR, open workout, change a weight, navigate away, come back — weight should be preserved
- [ ] Open workout without editing anything, navigate away — session should still be deleted (clean slate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)