### PR TITLE
feat: Sentry + PostHog observability

### DIFF
--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -12,6 +12,15 @@ from app.api.auth import get_optional_user
 from app.database import Base, get_db
 from app.models.user import User
 
+# Import is_sentry_active once at module scope so we don't pay the cost
+# on every request.  Safe no-op if sentry-sdk isn't installed.
+try:
+    import sentry_sdk  # type: ignore
+    _SENTRY_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    sentry_sdk = None  # type: ignore
+    _SENTRY_AVAILABLE = False
+
 
 class ClientError(Base):
     """Stores client-side errors reported by the frontend."""
@@ -52,6 +61,23 @@ async def report_error(
     )
     db.add(error)
     await db.flush()
+
+    # Mirror to Sentry for alerting + grouping.  No-op if Sentry isn't
+    # configured.  Tagged as `frontend` so we can filter server vs client.
+    if _SENTRY_AVAILABLE and sentry_sdk is not None and sentry_sdk.Hub.current.client is not None:
+        with sentry_sdk.push_scope() as scope:
+            scope.set_tag("source", "frontend")
+            if user:
+                scope.set_user({"id": str(user.id), "username": user.username})
+            if body.url:
+                scope.set_context("page", {"url": body.url})
+            if body.stack:
+                scope.set_context("stack", {"trace": body.stack[:5000]})
+            sentry_sdk.capture_message(
+                body.message[:2000],
+                level="error",
+            )
+
     return {"id": error.id}
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://homegym:homegym_secret@localhost:5432/homegym"
     database_sync_url: str = "postgresql://homegym:homegym_secret@localhost:5432/homegym"
 
+    # Observability — optional in dev, set in prod env
+    sentry_dsn: str = ""
+    sentry_traces_sample_rate: float = 0.1
+    sentry_environment: str = ""  # falls back to `environment` if empty
+
 
 
 @lru_cache

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,27 @@ from app.database import init_db
 
 settings = get_settings()
 
+# ── Sentry ──────────────────────────────────────────────────────────────────
+# Initialize at import time so startup errors are captured too.  Only
+# active when SENTRY_DSN is set — a silent no-op in dev/CI.
+if settings.sentry_dsn:
+    import sentry_sdk
+    from sentry_sdk.integrations.fastapi import FastApiIntegration
+    from sentry_sdk.integrations.starlette import StarletteIntegration
+
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment or settings.environment,
+        release=settings.app_version,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+        profiles_sample_rate=0.0,
+        send_default_pii=False,
+        integrations=[
+            StarletteIntegration(transaction_style="endpoint"),
+            FastApiIntegration(transaction_style="endpoint"),
+        ],
+    )
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
+    "@sentry/sveltekit": "^9.0.0",
     "@sveltejs/adapter-static": "^3.0.10",
     "@tanstack/svelte-query": "^5.17.0",
     "axios": "^1.6.0",
@@ -30,6 +31,7 @@
     "date-fns": "^3.0.0",
     "html2canvas": "^1.4.1",
     "html5-qrcode": "^2.3.8",
+    "posthog-js": "^1.160.0",
     "svelte-chartjs": "^4.0.1",
     "tesseract.js": "^7.0.0"
   }

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,0 +1,104 @@
+/**
+ * Telemetry — Sentry + PostHog wrappers.
+ *
+ * Both are optional: if the corresponding PUBLIC_* env var isn't set at
+ * build time, the init is a no-op and all track/capture calls become
+ * silent. Safe to call from any component.
+ */
+import { browser } from '$app/environment';
+import { PUBLIC_SENTRY_DSN, PUBLIC_POSTHOG_KEY, PUBLIC_POSTHOG_HOST } from '$env/static/public';
+
+let _posthog: any = null;
+let _sentryReady = false;
+
+// ── Sentry ────────────────────────────────────────────────────────────
+export async function initSentry() {
+  if (!browser || !PUBLIC_SENTRY_DSN || _sentryReady) return;
+  try {
+    const Sentry = await import('@sentry/sveltekit');
+    Sentry.init({
+      dsn: PUBLIC_SENTRY_DSN,
+      tracesSampleRate: 0.1,
+      replaysSessionSampleRate: 0,
+      replaysOnErrorSampleRate: 1.0,
+    });
+    _sentryReady = true;
+  } catch (err) {
+    console.warn('Sentry init failed:', err);
+  }
+}
+
+// ── PostHog ───────────────────────────────────────────────────────────
+export async function initPostHog() {
+  if (!browser || !PUBLIC_POSTHOG_KEY || _posthog) return;
+  try {
+    const { default: posthog } = await import('posthog-js');
+    posthog.init(PUBLIC_POSTHOG_KEY, {
+      api_host: PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com',
+      capture_pageview: true,
+      capture_pageleave: true,
+      persistence: 'localStorage+cookie',
+      // Respect DNT / privacy opt-out — users can toggle in Settings later
+      opt_out_capturing_by_default: hasOptedOut(),
+    });
+    _posthog = posthog;
+  } catch (err) {
+    console.warn('PostHog init failed:', err);
+  }
+}
+
+function hasOptedOut(): boolean {
+  if (!browser) return true;
+  // Honor Do Not Track
+  // @ts-ignore
+  if (navigator.doNotTrack === '1' || window.doNotTrack === '1') return true;
+  // User-set preference
+  try {
+    return localStorage.getItem('onyx_analytics_opt_out') === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function setAnalyticsOptOut(optedOut: boolean) {
+  if (!browser) return;
+  try {
+    if (optedOut) {
+      localStorage.setItem('onyx_analytics_opt_out', '1');
+      _posthog?.opt_out_capturing();
+    } else {
+      localStorage.removeItem('onyx_analytics_opt_out');
+      _posthog?.opt_in_capturing();
+    }
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+// ── Events ────────────────────────────────────────────────────────────
+export function track(event: string, properties?: Record<string, unknown>) {
+  if (!_posthog) return;
+  try {
+    _posthog.capture(event, properties);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function identify(userId: number | string, properties?: Record<string, unknown>) {
+  if (!_posthog) return;
+  try {
+    _posthog.identify(String(userId), properties);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function resetAnalyticsIdentity() {
+  if (!_posthog) return;
+  try {
+    _posthog.reset();
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
   import { getExercises, getLatestBodyWeight, getPlans, getActivePhase, isAuthenticated, getStoredUser, clearAuthTokens } from '$lib/api';
   import type { AuthUser } from '$lib/api';
   import { initLocale } from '$lib/i18n';
+  import { initSentry, initPostHog, identify, resetAnalyticsIdentity } from '$lib/telemetry';
 
   // Desktop shows all tabs including nutrition; mobile hides nutrition
   const desktopNavItems = [
@@ -28,6 +29,9 @@
 
   onMount(async () => {
     initLocale(); // load saved language preference
+    // Kick off analytics early (no-op if env vars aren't set)
+    void initSentry();
+    void initPostHog();
     // Auth check
     const path = window.location.pathname;
     if (PUBLIC_PATHS.some(p => path.startsWith(p))) {
@@ -40,6 +44,7 @@
     }
     authUser = getStoredUser();
     authChecked = true;
+    if (authUser) identify(authUser.id, { username: authUser.username });
 
     try {
       // Load settings from DB first (syncs across devices)
@@ -170,6 +175,7 @@
   });
 
   function logout() {
+    resetAnalyticsIdentity();
     clearAuthTokens();
     window.location.href = '/login';
   }

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { authLogin, saveAuthTokens, isAuthenticated } from '$lib/api';
   import { onMount } from 'svelte';
+  import { track, identify } from '$lib/telemetry';
 
   let username = $state('');
   let password = $state('');
@@ -17,6 +18,8 @@
     try {
       const auth = await authLogin({ username, password });
       saveAuthTokens(auth);
+      if (auth?.user?.id) identify(auth.user.id, { username: auth.user.username });
+      track('login');
       window.location.href = '/';
     } catch (e: any) {
       error = e.response?.data?.detail || 'Login failed. Please try again.';

--- a/frontend/src/routes/signup/+page.svelte
+++ b/frontend/src/routes/signup/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { authRegister, saveAuthTokens, isAuthenticated } from '$lib/api';
   import { onMount } from 'svelte';
+  import { track, identify } from '$lib/telemetry';
 
   let username = $state('');
   let password = $state('');
@@ -26,6 +27,8 @@
     try {
       const auth = await authRegister({ username, password });
       saveAuthTokens(auth);
+      if (auth?.user?.id) identify(auth.user.id, { username: auth.user.username });
+      track('signup');
       window.location.href = '/';
     } catch (e: any) {
       error = e.response?.data?.detail || 'Registration failed. Please try again.';

--- a/frontend/src/routes/workout/active/+page.svelte
+++ b/frontend/src/routes/workout/active/+page.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { beforeNavigate } from '$app/navigation';
   import { currentSession, exercises as exerciseStore, latestBodyWeight, settings } from '$lib/stores';
+  import { track } from '$lib/telemetry';
   import {
     getExercises, getPlan, getPlans, getNextWorkout, getRecentExercises, getSession, getSessions,
     createSessionFromPlan, createSession,
@@ -1208,6 +1209,9 @@
   function startClockIfNeeded() {
     if (startedAt !== null) return;
     startedAt = Date.now();
+    try {
+      track('workout_started', { session_id: sessionId, linked_plan: hasLinkedPlan });
+    } catch { /* telemetry optional */ }
   }
 
   async function startFreeSession() {
@@ -2404,6 +2408,15 @@
     finishing = true;
     try {
       await completeSession(sessionId);
+      const doneSetCount = uiExercises.reduce((n, ex) => n + ex.sets.filter(s => s.done).length, 0);
+      try {
+        track('workout_completed', {
+          session_id: finishedSessionId,
+          linked_plan: hasLinkedPlan,
+          set_count: doneSetCount,
+          duration_sec: startedAt ? Math.round((Date.now() - startedAt) / 1000) : null,
+        });
+      } catch { /* telemetry optional */ }
       // Clean up any saved exercise order for this session
       const orderKey = exerciseOrderKey(sessionId);
       if (orderKey && typeof localStorage !== 'undefined') localStorage.removeItem(orderKey);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "bcrypt>=4.0.0",
     "PyJWT>=2.8.0",
     "email-validator>=2.0.0",
+    "sentry-sdk[fastapi]>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ email-validator>=2.0.0
 asyncpg>=0.29.0
 psycopg2-binary>=2.9.9
 ijson>=3.2.0
+sentry-sdk[fastapi]>=2.0.0


### PR DESCRIPTION
Closes #865.

## Summary
Instrumentation for error tracking (Sentry) and product analytics (PostHog). No behavior change without env vars set — integrations are opt-in.

## Backend
- \`sentry-sdk[fastapi]\` added to requirements + pyproject
- Initialized at import time in \`app/main.py\`; silent no-op without \`SENTRY_DSN\`
- \`/api/errors\` now mirrors client reports to Sentry with user + URL + stack context

## Frontend
- \`@sentry/sveltekit\` and \`posthog-js\` as deps
- New \`frontend/src/lib/telemetry.ts\` — \`initSentry\`, \`initPostHog\`, \`track\`, \`identify\`, \`resetAnalyticsIdentity\`
- Respects Do Not Track + future opt-out toggle (\`onyx_analytics_opt_out\` localStorage flag)
- Events: \`signup\`, \`login\`, \`workout_started\`, \`workout_completed\` (with set count + duration)

## Deploy notes
- Requires setting \`SENTRY_DSN\`, \`PUBLIC_SENTRY_DSN\`, \`PUBLIC_POSTHOG_KEY\`, \`PUBLIC_POSTHOG_HOST\` on prod
- SvelteKit exposes \`PUBLIC_*\` vars to the browser bundle; the non-prefixed ones stay server-only
- Free tiers on both cover our scale (5k errors/mo, 1M events/mo)

## Test plan
- [x] All 48 existing backend tests pass with sentry-sdk installed
- [ ] After deploy + setting DSN: throw a deliberate error, confirm it lands in Sentry
- [ ] After deploy + setting PostHog key: complete a workout, confirm \`workout_completed\` event appears