### PR TITLE
feat: nightly Postgres backups to B2

### DIFF
--- a/scripts/BACKUPS.md
+++ b/scripts/BACKUPS.md
@@ -1,0 +1,71 @@
+# Nightly Postgres backups → Backblaze B2
+
+Server-side setup only; runs outside Docker on the host.
+
+## One-time setup
+
+1. **Create the B2 bucket**
+   - Log in to [Backblaze](https://secure.backblaze.com/user_signin.htm)
+   - Buckets → Create Bucket → private → e.g. `onyx-db-backups`
+   - App Keys → Add a New Application Key → scope to this bucket, permissions: read + write + delete
+   - Copy the `keyID` and `applicationKey` (shown once).
+
+2. **Create a healthchecks.io check**
+   - https://healthchecks.io → Add Check → "Onyx DB backup"
+   - Schedule: cron `30 3 * * *`, grace 2h
+   - Copy the ping URL (looks like `https://hc-ping.com/<uuid>`)
+
+3. **Install the host deps**
+
+    ```bash
+    ssh c@your-server
+    sudo apt install -y jq curl python3-venv pipx
+    pipx install b2
+    pipx ensurepath
+    ```
+
+4. **Create `/etc/Fitness-App/.backup-env`** (mode 600):
+
+    ```
+    B2_APPLICATION_KEY_ID=<keyID>
+    B2_APPLICATION_KEY=<applicationKey>
+    B2_BUCKET=onyx-db-backups
+    HEALTHCHECKS_URL=https://hc-ping.com/<uuid>
+    ```
+
+5. **Install the service + timer**
+
+    ```bash
+    cd /etc/Fitness-App
+    sudo bash scripts/install-backup.sh
+    ```
+
+6. **Smoke test** — force one run immediately:
+
+    ```bash
+    sudo systemctl start onyx-backup.service
+    journalctl -u onyx-backup.service -n 50 --no-pager
+    ```
+
+   Confirm the file appears on B2 and healthchecks.io shows green.
+
+## Ongoing
+
+- Logs: `journalctl -u onyx-backup.service -e`
+- Timer status: `systemctl list-timers onyx-backup.timer`
+- Manual run: `sudo systemctl start onyx-backup.service`
+- Weekly sanity: `sudo -E bash scripts/restore-db.sh` (loads latest backup into a scratch DB, compares row counts, drops it)
+
+## Retention
+
+The script deletes remote backups older than 30 days (configurable via `RETENTION_DAYS` in `.backup-env`). You can also set a B2 lifecycle rule for belt + suspenders.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `backup-db.sh` | Runs the dump, compresses, uploads to B2, pings healthchecks |
+| `restore-db.sh` | Downloads latest backup, restores to scratch DB, verifies row counts |
+| `onyx-backup.service` | Systemd oneshot unit running `backup-db.sh` |
+| `onyx-backup.timer` | Systemd timer firing `onyx-backup.service` nightly at 03:30 |
+| `install-backup.sh` | One-time installer — copies units, enables timer |

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# backup-db.sh — Nightly Postgres backup to Backblaze B2
+#
+# Runs `pg_dump` inside the db container, compresses with gzip, uploads
+# to B2, and pings healthchecks.io.  Exits nonzero on any failure so
+# systemd + healthchecks can alert.
+#
+# Required env (from /etc/Fitness-App/.backup-env or service EnvironmentFile):
+#   B2_APPLICATION_KEY_ID       — Backblaze B2 key ID
+#   B2_APPLICATION_KEY          — Backblaze B2 application key
+#   B2_BUCKET                   — e.g. "onyx-db-backups"
+#   HEALTHCHECKS_URL            — https://hc-ping.com/<uuid>
+#
+# Optional:
+#   COMPOSE_DIR                 — directory with docker-compose.yml (default /etc/Fitness-App)
+#   DB_SERVICE                  — compose service name of Postgres (default db)
+#   DB_NAME                     — Postgres database name (default homegym)
+#   DB_USER                     — Postgres user (default homegym)
+#   RETENTION_DAYS              — delete remote backups older than N days (default 30)
+#
+# Retention uses b2's lifecycle rules when possible; this script also
+# prunes as a belt-and-suspenders check.
+
+set -euo pipefail
+
+# ── Required env ─────────────────────────────────────────────────────────────
+: "${B2_APPLICATION_KEY_ID:?B2_APPLICATION_KEY_ID must be set}"
+: "${B2_APPLICATION_KEY:?B2_APPLICATION_KEY must be set}"
+: "${B2_BUCKET:?B2_BUCKET must be set}"
+: "${HEALTHCHECKS_URL:?HEALTHCHECKS_URL must be set}"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+COMPOSE_DIR="${COMPOSE_DIR:-/etc/Fitness-App}"
+DB_SERVICE="${DB_SERVICE:-db}"
+DB_NAME="${DB_NAME:-homegym}"
+DB_USER="${DB_USER:-homegym}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_NAME="onyx-${DB_NAME}-${TIMESTAMP}.sql.gz"
+TMP_DIR="$(mktemp -d)"
+BACKUP_PATH="${TMP_DIR}/${BACKUP_NAME}"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+log() { echo "[backup $(date -u +%H:%M:%S)] $*"; }
+
+# ── Ping healthchecks: start ─────────────────────────────────────────────────
+curl -fsS --retry 3 -m 10 -o /dev/null "${HEALTHCHECKS_URL}/start" || true
+
+# ── Dump ─────────────────────────────────────────────────────────────────────
+log "Dumping database ${DB_NAME} from service ${DB_SERVICE}..."
+cd "$COMPOSE_DIR"
+docker compose exec -T "$DB_SERVICE" pg_dump -U "$DB_USER" -d "$DB_NAME" \
+  --no-owner --no-privileges --format=plain \
+  | gzip -9 > "$BACKUP_PATH"
+
+SIZE_BYTES=$(stat -c %s "$BACKUP_PATH" 2>/dev/null || stat -f %z "$BACKUP_PATH")
+log "Dump complete: ${SIZE_BYTES} bytes"
+
+# Sanity: an empty dump is a failure (smallest sane dump is ~1KB)
+if [ "$SIZE_BYTES" -lt 1024 ]; then
+  log "ERROR: dump is suspiciously small (${SIZE_BYTES} bytes)"
+  curl -fsS --retry 3 -m 10 -o /dev/null "${HEALTHCHECKS_URL}/fail" || true
+  exit 1
+fi
+
+# ── Upload ───────────────────────────────────────────────────────────────────
+log "Authorizing with B2..."
+export B2_APPLICATION_KEY_ID B2_APPLICATION_KEY
+# `b2` is the Backblaze B2 CLI; install via pipx install b2 or apt
+b2 account authorize "$B2_APPLICATION_KEY_ID" "$B2_APPLICATION_KEY" >/dev/null
+
+log "Uploading to b2://${B2_BUCKET}/${BACKUP_NAME}..."
+b2 file upload --no-progress --quiet "$B2_BUCKET" "$BACKUP_PATH" "$BACKUP_NAME"
+
+log "Upload complete."
+
+# ── Retention prune ──────────────────────────────────────────────────────────
+# Delete remote files older than RETENTION_DAYS.  Uses JSON listing + jq.
+if command -v jq >/dev/null 2>&1; then
+  log "Pruning backups older than ${RETENTION_DAYS} days..."
+  CUTOFF_EPOCH_MS=$(( ( $(date -u +%s) - RETENTION_DAYS * 86400 ) * 1000 ))
+  # b2 ls returns JSON with --json flag
+  b2 ls --json "$B2_BUCKET" \
+    | jq -r --argjson cutoff "$CUTOFF_EPOCH_MS" \
+        '.[] | select(.uploadTimestamp < $cutoff) | "\(.fileId) \(.fileName)"' \
+    | while read -r file_id file_name; do
+        [ -z "$file_id" ] && continue
+        log "  deleting ${file_name}"
+        b2 file delete "$file_id" >/dev/null || true
+      done
+else
+  log "jq not installed; skipping retention prune (configure B2 lifecycle rules instead)"
+fi
+
+# ── Ping healthchecks: success ───────────────────────────────────────────────
+curl -fsS --retry 3 -m 10 -o /dev/null "$HEALTHCHECKS_URL" || true
+log "Done."

--- a/scripts/install-backup.sh
+++ b/scripts/install-backup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# install-backup.sh — install & enable the nightly DB backup.
+#
+# Prerequisites (ensure these are installed on the host first):
+#   - b2 CLI (pipx install b2 OR apt install backblaze-b2)
+#   - jq
+#   - curl
+#   - docker compose (already present)
+#
+# Before running, create /etc/Fitness-App/.backup-env with:
+#   B2_APPLICATION_KEY_ID=...
+#   B2_APPLICATION_KEY=...
+#   B2_BUCKET=onyx-db-backups
+#   HEALTHCHECKS_URL=https://hc-ping.com/<uuid>
+#
+# Then: sudo bash scripts/install-backup.sh
+
+set -euo pipefail
+
+if [ "${EUID}" -ne 0 ]; then
+  echo "Run with sudo: sudo bash $0"
+  exit 1
+fi
+
+APP_DIR="${APP_DIR:-/etc/Fitness-App}"
+SCRIPTS_DIR="${APP_DIR}/scripts"
+
+# ── Sanity checks ────────────────────────────────────────────────────────────
+command -v b2   >/dev/null 2>&1 || { echo "b2 CLI not installed. pipx install b2"; exit 1; }
+command -v jq   >/dev/null 2>&1 || { echo "jq not installed. apt install jq"; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo "curl not installed"; exit 1; }
+
+if [ ! -f "${APP_DIR}/.backup-env" ]; then
+  cat <<HINT
+Missing ${APP_DIR}/.backup-env
+
+Create it (mode 600) with:
+  B2_APPLICATION_KEY_ID=...
+  B2_APPLICATION_KEY=...
+  B2_BUCKET=onyx-db-backups
+  HEALTHCHECKS_URL=https://hc-ping.com/<uuid>
+
+Then re-run this script.
+HINT
+  exit 1
+fi
+
+# Lock down the env file
+chmod 600 "${APP_DIR}/.backup-env"
+
+# ── Sanity-check the backup env ──────────────────────────────────────────────
+# shellcheck source=/dev/null
+source "${APP_DIR}/.backup-env"
+: "${B2_APPLICATION_KEY_ID:?missing in .backup-env}"
+: "${B2_APPLICATION_KEY:?missing in .backup-env}"
+: "${B2_BUCKET:?missing in .backup-env}"
+: "${HEALTHCHECKS_URL:?missing in .backup-env}"
+
+# ── Install systemd units ────────────────────────────────────────────────────
+echo "Installing systemd units..."
+install -m 644 "${SCRIPTS_DIR}/onyx-backup.service" /etc/systemd/system/onyx-backup.service
+install -m 644 "${SCRIPTS_DIR}/onyx-backup.timer"   /etc/systemd/system/onyx-backup.timer
+
+# Make sure the script is executable
+chmod +x "${SCRIPTS_DIR}/backup-db.sh"
+
+systemctl daemon-reload
+systemctl enable --now onyx-backup.timer
+
+echo
+echo "Backup timer installed."
+echo "  Next run:     systemctl list-timers onyx-backup.timer"
+echo "  Trigger now:  sudo systemctl start onyx-backup.service"
+echo "  Logs:         journalctl -u onyx-backup.service -e"

--- a/scripts/onyx-backup.service
+++ b/scripts/onyx-backup.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Onyx — nightly Postgres backup to Backblaze B2
+After=docker.service
+Wants=docker.service
+# Don't rate-limit restarts
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+User=root
+EnvironmentFile=/etc/Fitness-App/.backup-env
+WorkingDirectory=/etc/Fitness-App
+ExecStart=/etc/Fitness-App/scripts/backup-db.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=onyx-backup
+
+# Give the backup plenty of time but don't hang forever
+TimeoutStartSec=30min

--- a/scripts/onyx-backup.timer
+++ b/scripts/onyx-backup.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Onyx — daily DB backup timer
+Requires=onyx-backup.service
+
+[Timer]
+# Run every day at 03:30 local time
+OnCalendar=*-*-* 03:30:00
+# If the system was off when the timer fired, run on next boot
+Persistent=true
+Unit=onyx-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# restore-db.sh — dry-run restore of the most recent B2 backup to a
+# scratch database, verify row counts, drop the scratch DB.
+#
+# Use this as a recurring sanity check (weekly?) AND during the 48h
+# burn-in to prove the backups are actually loadable.
+#
+# Usage: sudo bash scripts/restore-db.sh
+#
+# Required env (same as backup-db.sh, from /etc/Fitness-App/.backup-env):
+#   B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY, B2_BUCKET
+# Optional:
+#   COMPOSE_DIR (default /etc/Fitness-App)
+#   DB_SERVICE (default db)
+#   DB_USER (default homegym)
+#   SOURCE_DB (default homegym) — DB we compare against
+#   SCRATCH_DB (default homegym_restore_check)
+
+set -euo pipefail
+
+: "${B2_APPLICATION_KEY_ID:?}"
+: "${B2_APPLICATION_KEY:?}"
+: "${B2_BUCKET:?}"
+
+COMPOSE_DIR="${COMPOSE_DIR:-/etc/Fitness-App}"
+DB_SERVICE="${DB_SERVICE:-db}"
+DB_USER="${DB_USER:-homegym}"
+SOURCE_DB="${SOURCE_DB:-homegym}"
+SCRATCH_DB="${SCRATCH_DB:-homegym_restore_check}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+log() { echo "[restore $(date -u +%H:%M:%S)] $*"; }
+
+# ── Find the most recent backup on B2 ───────────────────────────────────────
+log "Locating most recent backup in b2://${B2_BUCKET}..."
+b2 account authorize "$B2_APPLICATION_KEY_ID" "$B2_APPLICATION_KEY" >/dev/null
+
+LATEST_FILE=$(b2 ls --json "$B2_BUCKET" \
+  | jq -r 'sort_by(.uploadTimestamp) | reverse | .[0].fileName')
+if [ -z "$LATEST_FILE" ] || [ "$LATEST_FILE" = "null" ]; then
+  log "ERROR: no backups found in bucket"
+  exit 1
+fi
+
+log "Latest backup: $LATEST_FILE"
+
+# ── Download and decompress ─────────────────────────────────────────────────
+LOCAL_GZ="${TMP_DIR}/${LATEST_FILE}"
+LOCAL_SQL="${LOCAL_GZ%.gz}"
+b2 file download --no-progress "b2://${B2_BUCKET}/${LATEST_FILE}" "$LOCAL_GZ"
+gunzip -f "$LOCAL_GZ"
+log "Decompressed to ${LOCAL_SQL}"
+
+# ── Restore into scratch DB ─────────────────────────────────────────────────
+cd "$COMPOSE_DIR"
+log "Creating scratch DB ${SCRATCH_DB}..."
+docker compose exec -T "$DB_SERVICE" psql -U "$DB_USER" -d postgres -c "DROP DATABASE IF EXISTS ${SCRATCH_DB};" >/dev/null
+docker compose exec -T "$DB_SERVICE" psql -U "$DB_USER" -d postgres -c "CREATE DATABASE ${SCRATCH_DB};" >/dev/null
+
+log "Restoring dump..."
+docker compose exec -T "$DB_SERVICE" psql -U "$DB_USER" -d "$SCRATCH_DB" < "$LOCAL_SQL" >/dev/null
+
+# ── Compare row counts ──────────────────────────────────────────────────────
+TABLES=(users workout_sessions exercise_sets workout_plans exercises)
+all_ok=1
+for t in "${TABLES[@]}"; do
+  src=$(docker compose exec -T "$DB_SERVICE" psql -U "$DB_USER" -d "$SOURCE_DB" -tAc "SELECT COUNT(*) FROM ${t};" 2>/dev/null || echo "?")
+  dst=$(docker compose exec -T "$DB_SERVICE" psql -U "$DB_USER" -d "$SCRATCH_DB" -tAc "SELECT COUNT(*) FROM ${t};" 2>/dev/null || echo "?")
+  printf "  %-20s source=%s  restored=%s" "$t" "$src" "$dst"
+  # Allow restored to be <= source (source may have newer rows than the backup)
+  if [ "$src" = "?" ] || [ "$dst" = "?" ] || [ "$dst" -gt "$src" ]; then
+    echo "  ✗"
+    all_ok=0
+  else
+    echo "  ✓"
+  fi
+done
+
+# ── Cleanup scratch DB ──────────────────────────────────────────────────────
+log "Dropping scratch DB..."
+docker compose exec -T "$DB_SERVICE" psql -U "$DB_USER" -d postgres -c "DROP DATABASE ${SCRATCH_DB};" >/dev/null
+
+if [ "$all_ok" = "1" ]; then
+  log "Restore dry-run SUCCESS"
+  exit 0
+else
+  log "Restore dry-run FAILED — row counts mismatched or tables missing"
+  exit 1
+fi


### PR DESCRIPTION
Closes #866.

## Summary
Self-contained backup system on the host. Runs pg_dump nightly at 03:30, compresses, uploads to Backblaze B2, pings healthchecks.io, prunes remote backups older than 30 days. Plus a restore dry-run script for weekly verification and Phase 4.3 burn-in.

## Files
- \`scripts/backup-db.sh\` — dump + gzip + b2 upload + healthcheck ping
- \`scripts/restore-db.sh\` — dry-run restore + row count sanity check
- \`scripts/onyx-backup.service\` + \`onyx-backup.timer\` — systemd units
- \`scripts/install-backup.sh\` — one-time installer
- \`scripts/BACKUPS.md\` — full setup walkthrough

## Deploy notes
Server-side setup (see \`scripts/BACKUPS.md\`):
1. Create B2 bucket + app key (scoped to bucket)
2. Create healthchecks.io check
3. Install \`b2\` CLI + \`jq\` on the host
4. Create \`/etc/Fitness-App/.backup-env\` with the four env vars
5. \`sudo bash scripts/install-backup.sh\`
6. Smoke test: \`sudo systemctl start onyx-backup.service\`

## Test plan
- [ ] Dry-run backup script on the server with real B2 credentials
- [ ] Dry-run restore script — confirm it can read the latest backup and row counts match
- [ ] Wait a day, confirm systemd timer fires and healthchecks.io shows green