### PR TITLE
feat: email verification + password reset (Resend)

### DIFF
--- a/alembic/versions/h2i3j4k5l6m7_email_required_and_verified.py
+++ b/alembic/versions/h2i3j4k5l6m7_email_required_and_verified.py
@@ -1,0 +1,59 @@
+"""email required on users + email_verified_at column
+
+Revision ID: h2i3j4k5l6m7
+Revises: g1h2i3j4k5l6
+Create Date: 2026-04-16
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'h2i3j4k5l6m7'
+down_revision: Union[str, Sequence[str], None] = 'g1h2i3j4k5l6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    # ── 1. Add email_verified_at column ────────────────────────────────────
+    if dialect == 'sqlite':
+        cols = [c[1] for c in conn.execute(sa.text("PRAGMA table_info(users)")).fetchall()]
+        if 'email_verified_at' not in cols:
+            with op.batch_alter_table('users', schema=None) as batch_op:
+                batch_op.add_column(sa.Column('email_verified_at', sa.DateTime(), nullable=True))
+    else:
+        conn.execute(sa.text(
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMP NULL"
+        ))
+
+    # ── 2. Backfill missing emails with a deterministic placeholder ────────
+    # Existing users without an email get "{username}@local.invalid" — a
+    # non-deliverable placeholder they'll be prompted to replace in UI.
+    conn.execute(sa.text(
+        "UPDATE users SET email = username || '@local.invalid' WHERE email IS NULL OR email = ''"
+    ))
+
+    # ── 3. Make email NOT NULL ─────────────────────────────────────────────
+    if dialect == 'sqlite':
+        # SQLite requires a batch operation to alter column nullability
+        with op.batch_alter_table('users', schema=None) as batch_op:
+            batch_op.alter_column('email', existing_type=sa.String(255), nullable=False)
+    else:
+        conn.execute(sa.text("ALTER TABLE users ALTER COLUMN email SET NOT NULL"))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == 'sqlite':
+        with op.batch_alter_table('users', schema=None) as batch_op:
+            batch_op.alter_column('email', existing_type=sa.String(255), nullable=True)
+            batch_op.drop_column('email_verified_at')
+    else:
+        conn.execute(sa.text("ALTER TABLE users ALTER COLUMN email DROP NOT NULL"))
+        conn.execute(sa.text("ALTER TABLE users DROP COLUMN IF EXISTS email_verified_at"))

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,25 +1,36 @@
 """Authentication API — register, login, refresh, current user, and settings."""
 
 import json
+import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings as get_app_settings
 from app.database import get_db
 from app.models.user import User
 from app.services.auth import (
     create_access_token,
+    create_purpose_token,
     create_refresh_token,
+    decode_purpose_token,
     decode_token,
     hash_password,
     verify_password,
 )
+from app.services.email import (
+    password_reset_html,
+    send_email,
+    verification_email_html,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 security = HTTPBearer(auto_error=False)
@@ -29,7 +40,7 @@ security = HTTPBearer(auto_error=False)
 
 class RegisterRequest(BaseModel):
     username: str = Field(min_length=1)
-    email: str | None = None
+    email: EmailStr
     password: str = Field(min_length=6)
 
 
@@ -47,6 +58,19 @@ class TokenResponse(BaseModel):
 
 class RefreshRequest(BaseModel):
     refresh_token: str
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class RequestPasswordResetRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str = Field(min_length=6)
 
 
 # ── Current user dependency ───────────────────────────────────────────────────
@@ -96,8 +120,26 @@ def serialize_user(user: User) -> dict:
         "id": user.id,
         "username": user.username,
         "email": user.email,
+        "email_verified": user.email_verified_at is not None,
         "created_at": user.created_at.isoformat(),
     }
+
+
+async def _send_verification_email(user: User) -> None:
+    """Issue a fresh verification token and email the link to the user.
+    Safe to call without RESEND_API_KEY — logs a warning and returns.
+    """
+    settings = get_app_settings()
+    token = create_purpose_token(user.id, "email_verification", expires_hours=24)
+    verify_url = f"{settings.public_app_url.rstrip('/')}/verify-email?token={token}"
+    try:
+        await send_email(
+            to=user.email,
+            subject="Verify your Onyx email",
+            html=verification_email_html(user.username, verify_url),
+        )
+    except Exception:
+        logger.exception("Failed to send verification email to %s", user.email)
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -107,7 +149,7 @@ async def register(
     data: RegisterRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> dict:
-    """Create a new user account."""
+    """Create a new user account and send a verification email."""
     # Check for duplicate username
     existing = await db.execute(
         select(User).where(User.username == data.username)
@@ -118,6 +160,16 @@ async def register(
             detail="Username already taken",
         )
 
+    # Check for duplicate email (emails are now required)
+    existing_email = await db.execute(
+        select(User).where(User.email == data.email)
+    )
+    if existing_email.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Email already registered",
+        )
+
     user = User(
         username=data.username,
         email=data.email,
@@ -126,6 +178,9 @@ async def register(
     db.add(user)
     await db.flush()
     await db.refresh(user)
+
+    # Send verification email (no-op in dev/CI without RESEND_API_KEY)
+    await _send_verification_email(user)
 
     return {
         "access_token": create_access_token(user.id, user.username),
@@ -232,3 +287,91 @@ async def save_settings(
     user.settings_json = json.dumps(body)
     await db.flush()
     return body
+
+
+# ── Email verification ───────────────────────────────────────────────────────
+
+@router.post("/verify-email")
+async def verify_email(
+    data: VerifyEmailRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Consume a verification token and mark the user's email verified."""
+    try:
+        user_id = decode_purpose_token(data.token, "email_verification")
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Verification link expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid verification link")
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User not found")
+
+    if user.email_verified_at is None:
+        user.email_verified_at = datetime.utcnow()
+        await db.flush()
+
+    return {"verified": True, "email": user.email}
+
+
+@router.post("/resend-verification")
+async def resend_verification(
+    user: Annotated[User, Depends(get_current_user)],
+) -> dict:
+    """Resend the verification email to the current user."""
+    if user.email_verified_at is not None:
+        return {"status": "already_verified"}
+    await _send_verification_email(user)
+    return {"status": "sent"}
+
+
+# ── Password reset ───────────────────────────────────────────────────────────
+
+@router.post("/request-password-reset")
+async def request_password_reset(
+    data: RequestPasswordResetRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Issue a reset token and email it.  Always returns 200 even if the
+    email isn't registered, to avoid leaking which emails have accounts.
+    """
+    result = await db.execute(select(User).where(User.email == data.email))
+    user = result.scalar_one_or_none()
+    if user:
+        settings = get_app_settings()
+        token = create_purpose_token(user.id, "password_reset", expires_hours=1)
+        reset_url = f"{settings.public_app_url.rstrip('/')}/reset-password?token={token}"
+        try:
+            await send_email(
+                to=user.email,
+                subject="Reset your Onyx password",
+                html=password_reset_html(user.username, reset_url),
+            )
+        except Exception:
+            logger.exception("Failed to send password reset email to %s", user.email)
+    return {"status": "sent"}
+
+
+@router.post("/reset-password")
+async def reset_password(
+    data: ResetPasswordRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Consume a password-reset token and update the password."""
+    try:
+        user_id = decode_purpose_token(data.token, "password_reset")
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Reset link expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid reset link")
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User not found")
+
+    user.hashed_password = hash_password(data.new_password)
+    await db.flush()
+    return {"status": "reset"}

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,14 @@ class Settings(BaseSettings):
     usda_api_key: str = "DEMO_KEY"
     calorieninjas_api_key: str = ""
 
+    # Email (Resend) — no-op if unset; verification/reset emails still issue
+    # tokens and log a warning in dev/CI.
+    resend_api_key: str = ""
+    email_from: str = "Onyx <noreply@lethal.dev>"
+
+    # Public base URL — used to build links in emails (e.g. verify email).
+    public_app_url: str = "http://localhost:5173"
+
     # Database (PostgreSQL)
     database_url: str = "postgresql+asyncpg://homegym:homegym_secret@localhost:5432/homegym"
     database_sync_url: str = "postgresql://homegym:homegym_secret@localhost:5432/homegym"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -20,7 +20,8 @@ class User(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     username: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
-    email: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    email_verified_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
 
     # Physical characteristics for exercise analysis

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -50,3 +50,31 @@ def create_refresh_token(user_id: int) -> str:
 def decode_token(token: str) -> dict:
     """Decode and validate a JWT token. Raises jwt.InvalidTokenError on failure."""
     return jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+
+
+# ── Purpose-scoped tokens (email verify, password reset) ────────────────────
+# Separate `type` from access/refresh so a stolen access token can't be
+# reused for verification, and vice versa.
+
+def create_purpose_token(user_id: int, purpose: str, *, expires_hours: int = 24) -> str:
+    """Create a short-lived JWT for an out-of-band action (email verify, password reset)."""
+    payload = {
+        "sub": str(user_id),
+        "type": "purpose",
+        "purpose": purpose,
+        "exp": datetime.now(timezone.utc) + timedelta(hours=expires_hours),
+        "iat": datetime.now(timezone.utc),
+    }
+    return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+
+
+def decode_purpose_token(token: str, expected_purpose: str) -> int:
+    """Decode a purpose token and return the user_id.
+
+    Raises jwt.InvalidTokenError (or a subclass) on any failure, including
+    wrong type or wrong purpose.
+    """
+    payload = jwt.decode(token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm])
+    if payload.get("type") != "purpose" or payload.get("purpose") != expected_purpose:
+        raise jwt.InvalidTokenError("Token purpose mismatch")
+    return int(payload["sub"])

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -1,0 +1,118 @@
+"""Transactional email via Resend — thin wrapper.
+
+All functions are safe to call without RESEND_API_KEY configured; they
+log a warning and silently no-op so dev/CI runs don't explode.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from app.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_RESEND_API_URL = "https://api.resend.com/emails"
+
+
+async def send_email(
+    to: str,
+    subject: str,
+    html: str,
+    *,
+    text: str | None = None,
+) -> dict[str, Any] | None:
+    """Send a transactional email.
+
+    Returns the Resend response on success, or None in dev/CI when
+    RESEND_API_KEY isn't configured.
+    """
+    settings = get_settings()
+    if not settings.resend_api_key:
+        logger.info("email: RESEND_API_KEY not set — would send '%s' to %s", subject, to)
+        return None
+
+    payload: dict[str, Any] = {
+        "from": settings.email_from or "Onyx <noreply@lethal.dev>",
+        "to": [to],
+        "subject": subject,
+        "html": html,
+    }
+    if text:
+        payload["text"] = text
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            _RESEND_API_URL,
+            headers={
+                "Authorization": f"Bearer {settings.resend_api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+    if resp.status_code >= 400:
+        logger.error("email: Resend API returned %s: %s", resp.status_code, resp.text)
+        return None
+    return resp.json()
+
+
+# ── Templates ────────────────────────────────────────────────────────────────
+# Kept inline for MVP simplicity; migrate to files if they grow.
+
+_BASE_STYLE = (
+    "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;"
+    "color:#111;line-height:1.5;max-width:520px;margin:0 auto;padding:24px"
+)
+_BTN_STYLE = (
+    "display:inline-block;background:#0170B9;color:#fff;text-decoration:none;"
+    "padding:12px 24px;border-radius:8px;font-weight:600;margin:16px 0"
+)
+
+
+def verification_email_html(username: str, verify_url: str) -> str:
+    return f"""
+    <div style="{_BASE_STYLE}">
+      <h2>Welcome to Onyx, {username}</h2>
+      <p>Click the button below to verify your email and finish setting up your account.</p>
+      <p><a href="{verify_url}" style="{_BTN_STYLE}">Verify email</a></p>
+      <p style="color:#666;font-size:13px">
+        Or paste this link into your browser:<br>
+        <code>{verify_url}</code>
+      </p>
+      <p style="color:#666;font-size:13px">This link expires in 24 hours.</p>
+    </div>
+    """
+
+
+def password_reset_html(username: str, reset_url: str) -> str:
+    return f"""
+    <div style="{_BASE_STYLE}">
+      <h2>Reset your Onyx password</h2>
+      <p>Hi {username}, someone (hopefully you) asked to reset your password.</p>
+      <p><a href="{reset_url}" style="{_BTN_STYLE}">Reset password</a></p>
+      <p style="color:#666;font-size:13px">
+        Or paste this link into your browser:<br>
+        <code>{reset_url}</code>
+      </p>
+      <p style="color:#666;font-size:13px">
+        This link expires in 1 hour.  If you didn't request this, you can ignore this email.
+      </p>
+    </div>
+    """
+
+
+def trial_ending_html(username: str, days_left: int, subscribe_url: str) -> str:
+    return f"""
+    <div style="{_BASE_STYLE}">
+      <h2>Your Onyx trial ends in {days_left} days</h2>
+      <p>Hi {username}, just a heads up — your free trial ends in {days_left} days.</p>
+      <p>Subscribe to keep logging:</p>
+      <p><a href="{subscribe_url}" style="{_BTN_STYLE}">Subscribe — $30/year</a></p>
+      <p style="color:#666;font-size:13px">
+        If you don't subscribe, your account stays put (you'll still see your history)
+        but new workouts won't save.
+      </p>
+    </div>
+    """

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -106,7 +106,7 @@ export interface AuthResponse {
   user: AuthUser;
 }
 
-export async function authRegister(data: { username: string; password: string; email?: string }): Promise<AuthResponse> {
+export async function authRegister(data: { username: string; email: string; password: string }): Promise<AuthResponse> {
   const response = await api.post('/auth/register', data);
   return response.data;
 }
@@ -118,6 +118,26 @@ export async function authLogin(data: { username: string; password: string }): P
 
 export async function authGetMe(): Promise<AuthUser> {
   const response = await api.get('/auth/me');
+  return response.data;
+}
+
+export async function verifyEmail(token: string): Promise<{ verified: boolean; email: string }> {
+  const response = await api.post('/auth/verify-email', { token });
+  return response.data;
+}
+
+export async function resendVerification(): Promise<{ status: string }> {
+  const response = await api.post('/auth/resend-verification');
+  return response.data;
+}
+
+export async function requestPasswordReset(email: string): Promise<{ status: string }> {
+  const response = await api.post('/auth/request-password-reset', { email });
+  return response.data;
+}
+
+export async function resetPassword(token: string, newPassword: string): Promise<{ status: string }> {
+  const response = await api.post('/auth/reset-password', { token, new_password: newPassword });
   return response.data;
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -24,7 +24,7 @@
   let authUser = $state<AuthUser | null>(null);
   let authChecked = $state(false);
 
-  const PUBLIC_PATHS = ['/login', '/signup'];
+  const PUBLIC_PATHS = ['/login', '/signup', '/verify-email', '/forgot-password', '/reset-password'];
 
   onMount(async () => {
     initLocale(); // load saved language preference

--- a/frontend/src/routes/forgot-password/+page.svelte
+++ b/frontend/src/routes/forgot-password/+page.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { requestPasswordReset } from '$lib/api';
+
+  let email = $state('');
+  let submitted = $state(false);
+  let loading = $state(false);
+  let error = $state('');
+
+  async function handleSubmit() {
+    error = '';
+    loading = true;
+    try {
+      await requestPasswordReset(email);
+      submitted = true;
+    } catch (e: any) {
+      error = e.response?.data?.detail || 'Something went wrong. Try again.';
+    }
+    loading = false;
+  }
+</script>
+
+<div class="min-h-screen flex items-center justify-center p-4">
+  <div class="w-full max-w-sm space-y-6">
+    <div class="text-center">
+      <h1 class="text-2xl font-bold text-primary-400">Onyx</h1>
+      <p class="text-sm text-zinc-500 mt-1">Reset your password</p>
+    </div>
+
+    {#if submitted}
+      <div class="card text-center space-y-3">
+        <p class="text-4xl">📬</p>
+        <p class="text-sm text-zinc-300">
+          If an account exists for <strong>{email}</strong>, a reset link has been sent.
+        </p>
+        <p class="text-xs text-zinc-500">The link expires in 1 hour.</p>
+        <a href="/login" class="btn-secondary block mt-4">Back to login</a>
+      </div>
+    {:else}
+      <form onsubmit={(e) => { e.preventDefault(); handleSubmit(); }} class="card space-y-4">
+        {#if error}
+          <div class="bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2 text-sm text-red-400">{error}</div>
+        {/if}
+        <div>
+          <label for="fp-email" class="text-xs text-zinc-400 block mb-1">Email</label>
+          <input id="fp-email" type="email" bind:value={email} required autocomplete="email"
+                 class="input" placeholder="you@example.com" />
+        </div>
+        <button type="submit" disabled={loading || !email} class="btn-primary w-full !py-3 disabled:opacity-50">
+          {loading ? 'Sending…' : 'Send reset link'}
+        </button>
+        <p class="text-center text-sm text-zinc-500">
+          <a href="/login" class="text-primary-400 hover:text-primary-300">Back to login</a>
+        </p>
+      </form>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -28,7 +28,7 @@
 <div class="min-h-screen flex items-center justify-center p-4">
   <div class="w-full max-w-sm space-y-6">
     <div class="text-center">
-      <h1 class="text-2xl font-bold text-primary-400">Onyx Expenditure</h1>
+      <h1 class="text-2xl font-bold text-primary-400">Onyx</h1>
       <p class="text-sm text-zinc-500 mt-1">Sign in to your account</p>
     </div>
 
@@ -53,6 +53,10 @@
               class="btn-primary w-full !py-3 disabled:opacity-50">
         {loading ? 'Signing in...' : 'Sign In'}
       </button>
+
+      <p class="text-center text-xs">
+        <a href="/forgot-password" class="text-zinc-500 hover:text-zinc-300">Forgot password?</a>
+      </p>
 
       <p class="text-center text-sm text-zinc-500">
         Don't have an account? <a href="/signup" class="text-primary-400 hover:text-primary-300">Sign up</a>

--- a/frontend/src/routes/reset-password/+page.svelte
+++ b/frontend/src/routes/reset-password/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { resetPassword } from '$lib/api';
+
+  let token = $state('');
+  let password = $state('');
+  let confirmPassword = $state('');
+  let loading = $state(false);
+  let done = $state(false);
+  let error = $state('');
+
+  onMount(() => {
+    const params = new URLSearchParams(window.location.search);
+    token = params.get('token') || '';
+    if (!token) error = 'No reset token in this link.';
+  });
+
+  async function handleSubmit() {
+    error = '';
+    if (password !== confirmPassword) {
+      error = 'Passwords do not match.';
+      return;
+    }
+    if (password.length < 6) {
+      error = 'Password must be at least 6 characters.';
+      return;
+    }
+    loading = true;
+    try {
+      await resetPassword(token, password);
+      done = true;
+    } catch (e: any) {
+      error = e.response?.data?.detail || 'Reset failed — the link may be expired.';
+    }
+    loading = false;
+  }
+</script>
+
+<div class="min-h-screen flex items-center justify-center p-4">
+  <div class="w-full max-w-sm space-y-6">
+    <div class="text-center">
+      <h1 class="text-2xl font-bold text-primary-400">Onyx</h1>
+      <p class="text-sm text-zinc-500 mt-1">Choose a new password</p>
+    </div>
+
+    {#if done}
+      <div class="card text-center space-y-3">
+        <p class="text-4xl">✅</p>
+        <p>Password updated</p>
+        <a href="/login" class="btn-primary block mt-4">Sign in</a>
+      </div>
+    {:else}
+      <form onsubmit={(e) => { e.preventDefault(); handleSubmit(); }} class="card space-y-4">
+        {#if error}
+          <div class="bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2 text-sm text-red-400">{error}</div>
+        {/if}
+        <div>
+          <label for="rp-password" class="text-xs text-zinc-400 block mb-1">New password</label>
+          <input id="rp-password" type="password" bind:value={password} required autocomplete="new-password"
+                 minlength="6" class="input" placeholder="At least 6 characters" />
+        </div>
+        <div>
+          <label for="rp-confirm" class="text-xs text-zinc-400 block mb-1">Confirm password</label>
+          <input id="rp-confirm" type="password" bind:value={confirmPassword} required autocomplete="new-password"
+                 class="input" placeholder="Repeat password" />
+        </div>
+        <button type="submit" disabled={loading || !token || !password || password.length < 6 || password !== confirmPassword}
+                class="btn-primary w-full !py-3 disabled:opacity-50">
+          {loading ? 'Saving…' : 'Reset password'}
+        </button>
+      </form>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/routes/signup/+page.svelte
+++ b/frontend/src/routes/signup/+page.svelte
@@ -3,6 +3,7 @@
   import { onMount } from 'svelte';
 
   let username = $state('');
+  let email = $state('');
   let password = $state('');
   let confirmPassword = $state('');
   let error = $state('');
@@ -24,7 +25,7 @@
     }
     loading = true;
     try {
-      const auth = await authRegister({ username, password });
+      const auth = await authRegister({ username, email, password });
       saveAuthTokens(auth);
       window.location.href = '/';
     } catch (e: any) {
@@ -37,7 +38,7 @@
 <div class="min-h-screen flex items-center justify-center p-4">
   <div class="w-full max-w-sm space-y-6">
     <div class="text-center">
-      <h1 class="text-2xl font-bold text-primary-400">Onyx Expenditure</h1>
+      <h1 class="text-2xl font-bold text-primary-400">Onyx</h1>
       <p class="text-sm text-zinc-500 mt-1">Create your account</p>
     </div>
 
@@ -50,6 +51,13 @@
         <label for="signup-username" class="text-xs text-zinc-400 block mb-1">Username</label>
         <input id="signup-username" type="text" bind:value={username} required autocomplete="username"
                class="input" placeholder="Choose a username" />
+      </div>
+
+      <div>
+        <label for="signup-email" class="text-xs text-zinc-400 block mb-1">Email</label>
+        <input id="signup-email" type="email" bind:value={email} required autocomplete="email"
+               class="input" placeholder="you@example.com" />
+        <p class="text-xs text-zinc-500 mt-1">We'll send a verification link.</p>
       </div>
 
       <div>
@@ -72,7 +80,7 @@
         <p class="text-xs text-red-400">Passwords do not match</p>
       {/if}
 
-      <button type="submit" disabled={loading || !username || !password || password.length < 6 || !confirmPassword || password !== confirmPassword}
+      <button type="submit" disabled={loading || !username || !email || !password || password.length < 6 || !confirmPassword || password !== confirmPassword}
               class="btn-primary w-full !py-3 disabled:opacity-50">
         {loading ? 'Creating account...' : 'Create Account'}
       </button>

--- a/frontend/src/routes/verify-email/+page.svelte
+++ b/frontend/src/routes/verify-email/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { verifyEmail } from '$lib/api';
+
+  let status = $state<'pending' | 'success' | 'error'>('pending');
+  let error = $state('');
+
+  onMount(async () => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('token');
+    if (!token) {
+      status = 'error';
+      error = 'No verification token in this link.';
+      return;
+    }
+    try {
+      await verifyEmail(token);
+      status = 'success';
+    } catch (e: any) {
+      status = 'error';
+      error = e.response?.data?.detail || 'Verification failed. The link may be expired.';
+    }
+  });
+</script>
+
+<div class="min-h-screen flex items-center justify-center p-4">
+  <div class="w-full max-w-sm space-y-6 text-center">
+    <h1 class="text-2xl font-bold text-primary-400">Onyx</h1>
+
+    {#if status === 'pending'}
+      <p class="text-zinc-400">Verifying your email…</p>
+    {:else if status === 'success'}
+      <div class="card space-y-4">
+        <p class="text-4xl">✅</p>
+        <p class="font-medium">Email verified</p>
+        <a href="/" class="btn-primary block">Continue to app</a>
+      </div>
+    {:else}
+      <div class="card space-y-4">
+        <p class="text-4xl">⚠️</p>
+        <p class="text-sm text-red-400">{error}</p>
+        <a href="/login" class="btn-secondary block">Back to login</a>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/tests/test_auth_flows.py
+++ b/tests/test_auth_flows.py
@@ -1,0 +1,156 @@
+"""Tests for the new auth flows — email verification + password reset.
+
+These cover:
+- signup requires email
+- verify-email consumes a valid token and sets email_verified_at
+- verify-email rejects bad/expired tokens
+- request-password-reset always 200s (no user enumeration)
+- reset-password rotates the password
+"""
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.services.auth import create_purpose_token
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def _client() -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class TestRegisterRequiresEmail:
+    async def test_register_without_email_rejected(self):
+        async with await _client() as c:
+            r = await c.post(
+                "/api/auth/register",
+                json={"username": "no_email_user", "password": "testpass123"},
+            )
+            assert r.status_code == 422, r.text
+
+    async def test_register_with_invalid_email_rejected(self):
+        async with await _client() as c:
+            r = await c.post(
+                "/api/auth/register",
+                json={"username": "bad_email_user", "email": "not-an-email", "password": "testpass123"},
+            )
+            assert r.status_code == 422, r.text
+
+    async def test_register_duplicate_email_rejected(self):
+        async with await _client() as c:
+            r1 = await c.post(
+                "/api/auth/register",
+                json={"username": "dup_a", "email": "dup@test.com", "password": "testpass123"},
+            )
+            assert r1.status_code == 201, r1.text
+            r2 = await c.post(
+                "/api/auth/register",
+                json={"username": "dup_b", "email": "dup@test.com", "password": "testpass123"},
+            )
+            assert r2.status_code == 409, r2.text
+
+
+class TestVerifyEmail:
+    async def test_verify_email_with_valid_token(self):
+        async with await _client() as c:
+            r = await c.post(
+                "/api/auth/register",
+                json={"username": "verifier", "email": "verify@test.com", "password": "testpass123"},
+            )
+            assert r.status_code == 201
+            user_id = r.json()["user"]["id"]
+            assert r.json()["user"]["email_verified"] is False
+
+            token = create_purpose_token(user_id, "email_verification")
+            r2 = await c.post("/api/auth/verify-email", json={"token": token})
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["verified"] is True
+
+            # Subsequent /me should show verified
+            access = r.json()["access_token"]
+            r3 = await c.get("/api/auth/me", headers={"Authorization": f"Bearer {access}"})
+            assert r3.json()["email_verified"] is True
+
+    async def test_verify_email_with_wrong_purpose_rejected(self):
+        async with await _client() as c:
+            r = await c.post(
+                "/api/auth/register",
+                json={"username": "wrong_purpose", "email": "wp@test.com", "password": "testpass123"},
+            )
+            user_id = r.json()["user"]["id"]
+            # Wrong purpose
+            bad_token = create_purpose_token(user_id, "password_reset")
+            r2 = await c.post("/api/auth/verify-email", json={"token": bad_token})
+            assert r2.status_code == 400
+
+    async def test_verify_email_with_garbage_token_rejected(self):
+        async with await _client() as c:
+            r = await c.post("/api/auth/verify-email", json={"token": "not-a-jwt"})
+            assert r.status_code == 400
+
+
+class TestPasswordReset:
+    async def test_request_reset_returns_ok_even_for_unknown_email(self):
+        """Must not leak which emails have accounts."""
+        async with await _client() as c:
+            r = await c.post(
+                "/api/auth/request-password-reset",
+                json={"email": "nobody@test.com"},
+            )
+            assert r.status_code == 200
+            assert r.json()["status"] == "sent"
+
+    async def test_full_reset_flow(self):
+        async with await _client() as c:
+            # Register
+            r = await c.post(
+                "/api/auth/register",
+                json={"username": "reset_user", "email": "reset@test.com", "password": "oldpass123"},
+            )
+            assert r.status_code == 201
+            user_id = r.json()["user"]["id"]
+
+            # Request reset (200 regardless)
+            r2 = await c.post(
+                "/api/auth/request-password-reset",
+                json={"email": "reset@test.com"},
+            )
+            assert r2.status_code == 200
+
+            # Simulate the email link's token
+            token = create_purpose_token(user_id, "password_reset", expires_hours=1)
+            r3 = await c.post(
+                "/api/auth/reset-password",
+                json={"token": token, "new_password": "newpass456"},
+            )
+            assert r3.status_code == 200, r3.text
+
+            # Old password rejected
+            r4 = await c.post(
+                "/api/auth/login",
+                json={"username": "reset_user", "password": "oldpass123"},
+            )
+            assert r4.status_code == 401
+
+            # New password works
+            r5 = await c.post(
+                "/api/auth/login",
+                json={"username": "reset_user", "password": "newpass456"},
+            )
+            assert r5.status_code == 200
+
+    async def test_reset_with_wrong_purpose_token_rejected(self):
+        async with await _client() as c:
+            r = await c.post(
+                "/api/auth/register",
+                json={"username": "rpw_user", "email": "rpw@test.com", "password": "testpass123"},
+            )
+            user_id = r.json()["user"]["id"]
+            # email_verification token used for reset — should fail
+            bad_token = create_purpose_token(user_id, "email_verification")
+            r2 = await c.post(
+                "/api/auth/reset-password",
+                json={"token": bad_token, "new_password": "whatever"},
+            )
+            assert r2.status_code == 422 or r2.status_code == 400


### PR DESCRIPTION
Closes #867 and #868 together — they're functionally coupled since verification needs email sending.

## Summary
- Email is now **required** on signup and verified via a link
- Password reset flow: request → emailed link → consume → new password
- Resend integration that's a safe no-op without \`RESEND_API_KEY\`

## New endpoints
- \`POST /api/auth/verify-email\` — consumes token, sets \`email_verified_at\`
- \`POST /api/auth/resend-verification\` — reissues the email
- \`POST /api/auth/request-password-reset\` — always 200s (no user enumeration)
- \`POST /api/auth/reset-password\` — consumes token, updates password

## Schema changes (migration h2i3j4k5l6m7)
- \`users.email_verified_at TIMESTAMP NULL\` — added
- \`users.email\` — backfilled with \`<username>@local.invalid\` for existing rows, then flipped NOT NULL

## Frontend
- Signup now asks for email
- New pages: \`/verify-email\`, \`/forgot-password\`, \`/reset-password\`
- Login links to forgot-password
- Dropped "Expenditure" from product name on auth screens

## Deploy notes
- Set \`RESEND_API_KEY\` on prod (template \`.env.production.example\` already documents it)
- Set \`PUBLIC_APP_URL=https://lethal.dev\` so emailed links point to the right host
- Existing users will have placeholder \`<username>@local.invalid\` emails — they should be prompted to update in a later PR (#875 account controls handles change-email)

## Tests
- 9 new tests in \`tests/test_auth_flows.py\` — all pass
- 48 existing prefill tests still pass