### PR TITLE
feat: subscription data model (trial + Stripe fields + webhook log)

### DIFF
--- a/alembic/versions/i3j4k5l6m7n8_subscription_fields_and_stripe_events.py
+++ b/alembic/versions/i3j4k5l6m7n8_subscription_fields_and_stripe_events.py
@@ -1,0 +1,107 @@
+"""add subscription fields to users + stripe_events table
+
+Revision ID: i3j4k5l6m7n8
+Revises: h2i3j4k5l6m7
+Create Date: 2026-04-16
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'i3j4k5l6m7n8'
+down_revision: Union[str, Sequence[str], None] = 'h2i3j4k5l6m7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    # ── 1. Add subscription columns to users ───────────────────────────────
+    if dialect == 'sqlite':
+        cols = [c[1] for c in conn.execute(sa.text("PRAGMA table_info(users)")).fetchall()]
+        with op.batch_alter_table('users', schema=None) as batch_op:
+            if 'stripe_customer_id' not in cols:
+                batch_op.add_column(sa.Column('stripe_customer_id', sa.String(255), nullable=True))
+                batch_op.create_unique_constraint('uq_users_stripe_customer_id', ['stripe_customer_id'])
+            if 'subscription_status' not in cols:
+                batch_op.add_column(sa.Column('subscription_status', sa.String(32), nullable=True))
+            if 'subscription_current_period_end' not in cols:
+                batch_op.add_column(sa.Column('subscription_current_period_end', sa.DateTime(), nullable=True))
+            if 'trial_ends_at' not in cols:
+                batch_op.add_column(sa.Column('trial_ends_at', sa.DateTime(), nullable=True))
+    else:
+        conn.execute(sa.text("""
+            ALTER TABLE users
+              ADD COLUMN IF NOT EXISTS stripe_customer_id VARCHAR(255) UNIQUE,
+              ADD COLUMN IF NOT EXISTS subscription_status VARCHAR(32),
+              ADD COLUMN IF NOT EXISTS subscription_current_period_end TIMESTAMP,
+              ADD COLUMN IF NOT EXISTS trial_ends_at TIMESTAMP
+        """))
+
+    # ── 2. Backfill trial_ends_at — give every existing user a 30-day trial ─
+    # starting from now.  Using created_at could be retroactively stingy for
+    # old accounts.  Newly-registered users get their trial set in register().
+    if dialect == 'sqlite':
+        conn.execute(sa.text(
+            "UPDATE users SET trial_ends_at = datetime('now', '+30 days') "
+            "WHERE trial_ends_at IS NULL"
+        ))
+    else:
+        conn.execute(sa.text(
+            "UPDATE users SET trial_ends_at = NOW() + INTERVAL '30 days' "
+            "WHERE trial_ends_at IS NULL"
+        ))
+
+    # ── 3. Create stripe_events table ──────────────────────────────────────
+    if dialect == 'sqlite':
+        existing = [r[0] for r in conn.execute(sa.text(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='stripe_events'"
+        )).fetchall()]
+        if 'stripe_events' not in existing:
+            op.create_table(
+                'stripe_events',
+                sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+                sa.Column('event_id', sa.String(255), nullable=False, unique=True),
+                sa.Column('event_type', sa.String(128), nullable=False),
+                sa.Column('payload_json', sa.Text(), nullable=False),
+                sa.Column('received_at', sa.DateTime(), nullable=False,
+                          server_default=sa.text('CURRENT_TIMESTAMP')),
+                sa.Column('processed_at', sa.DateTime(), nullable=True),
+            )
+    else:
+        conn.execute(sa.text("""
+            CREATE TABLE IF NOT EXISTS stripe_events (
+                id SERIAL PRIMARY KEY,
+                event_id VARCHAR(255) NOT NULL UNIQUE,
+                event_type VARCHAR(128) NOT NULL,
+                payload_json TEXT NOT NULL,
+                received_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                processed_at TIMESTAMP NULL
+            )
+        """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+
+    if dialect == 'sqlite':
+        with op.batch_alter_table('users', schema=None) as batch_op:
+            batch_op.drop_constraint('uq_users_stripe_customer_id', type_='unique')
+            batch_op.drop_column('trial_ends_at')
+            batch_op.drop_column('subscription_current_period_end')
+            batch_op.drop_column('subscription_status')
+            batch_op.drop_column('stripe_customer_id')
+        op.drop_table('stripe_events')
+    else:
+        conn.execute(sa.text("""
+            ALTER TABLE users
+              DROP COLUMN IF EXISTS trial_ends_at,
+              DROP COLUMN IF EXISTS subscription_current_period_end,
+              DROP COLUMN IF EXISTS subscription_status,
+              DROP COLUMN IF EXISTS stripe_customer_id
+        """))
+        conn.execute(sa.text("DROP TABLE IF EXISTS stripe_events"))

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -97,7 +97,25 @@ def serialize_user(user: User) -> dict:
         "username": user.username,
         "email": user.email,
         "created_at": user.created_at.isoformat(),
+        # Subscription (#869).  has_access is a convenience for the frontend.
+        "subscription_status": user.subscription_status,
+        "subscription_current_period_end": (
+            user.subscription_current_period_end.isoformat()
+            if user.subscription_current_period_end else None
+        ),
+        "trial_ends_at": user.trial_ends_at.isoformat() if user.trial_ends_at else None,
+        "has_access": _user_has_access(user),
     }
+
+
+def _user_has_access(user: User) -> bool:
+    """Quick inline check — formalised in app/services/access.py in #871."""
+    now = datetime.utcnow()
+    if user.trial_ends_at and user.trial_ends_at > now:
+        return True
+    if user.subscription_status in ("trialing", "active"):
+        return True
+    return False
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -118,10 +136,13 @@ async def register(
             detail="Username already taken",
         )
 
+    from datetime import timedelta
     user = User(
         username=data.username,
         email=data.email,
         hashed_password=hash_password(data.password),
+        # 30-day free trial starts on signup (#869)
+        trial_ends_at=datetime.utcnow() + timedelta(days=30),
     )
     db.add(user)
     await db.flush()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.body_weight import BodyWeightEntry
 from app.models.exercise import Exercise
 from app.models.exercise_note import ExerciseNote
 from app.models.nutrition import DietPhase, FoodItem, MacroGoal, NutritionEntry, Recipe, RecipeIngredient
+from app.models.stripe_event import StripeEvent
 from app.models.template import WorkoutTemplate
 from app.models.user import User
 from app.models.workout import ExerciseSet, WorkoutPlan, WorkoutSession, WorkoutSessionAudit, WorkoutStatus
@@ -15,6 +16,7 @@ __all__ = [
     "NutritionEntry",
     "Recipe",
     "RecipeIngredient",
+    "StripeEvent",
     "User",
     "WorkoutTemplate",
     "Exercise",

--- a/app/models/stripe_event.py
+++ b/app/models/stripe_event.py
@@ -1,0 +1,25 @@
+"""Stripe webhook event log — used for idempotency.
+
+Every `customer.subscription.*` / `invoice.*` event Stripe sends lands
+here first.  The webhook handler (#870) inserts by event_id with
+ON CONFLICT DO NOTHING so replays are safe.
+"""
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import Base
+
+
+class StripeEvent(Base):
+    __tablename__ = "stripe_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_id: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(128), nullable=False)
+    payload_json: Mapped[str] = mapped_column(Text, nullable=False)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime, default=lambda: datetime.utcnow(), nullable=False
+    )
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -23,6 +23,19 @@ class User(Base):
     email: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
 
+    # ── Subscription (#869) ────────────────────────────────────────────────
+    # Populated via the Stripe webhook (/api/billing/webhook).  A user has
+    # access if either trial_ends_at is in the future OR subscription_status
+    # is trialing/active.  See app/services/access.py (#871).
+    stripe_customer_id: Mapped[str | None] = mapped_column(
+        String(255), unique=True, nullable=True
+    )
+    subscription_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    subscription_current_period_end: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
+    trial_ends_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
     # Physical characteristics for exercise analysis
     height_cm: Mapped[float | None] = mapped_column(Float, nullable=True)
     weight_kg: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/tests/test_subscription_model.py
+++ b/tests/test_subscription_model.py
@@ -1,0 +1,108 @@
+"""Tests for the subscription data model (#869).
+
+Covers:
+- new users get trial_ends_at set 30 days out on register
+- /me returns subscription_status, trial_ends_at, has_access
+- has_access computation matches trial + subscription_status logic
+- stripe_events table exists and enforces event_id uniqueness
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.main import app
+from app.models.stripe_event import StripeEvent
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio(loop_scope="function")
+
+
+async def _register(c: AsyncClient, username: str) -> dict:
+    r = await c.post(
+        "/api/auth/register",
+        json={"username": username, "email": f"{username}@test.com", "password": "testpass123"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestTrialInitialization:
+    async def test_new_user_gets_30_day_trial(self):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            auth = await _register(c, "trial_user")
+            user = auth["user"]
+            assert user["trial_ends_at"] is not None
+            assert user["subscription_status"] is None
+            assert user["has_access"] is True
+            # Parse ISO and confirm it's ~30 days out (tolerate a day of slop)
+            trial = datetime.fromisoformat(user["trial_ends_at"])
+            expected = datetime.utcnow() + timedelta(days=30)
+            delta = abs((trial - expected).total_seconds())
+            assert delta < 60 * 60 * 24, f"trial_ends_at off by {delta}s"
+
+
+class TestHasAccess:
+    async def test_has_access_during_trial(self):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            auth = await _register(c, "access_user")
+            token = auth["access_token"]
+            r = await c.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+            assert r.status_code == 200
+            assert r.json()["has_access"] is True
+
+    async def test_no_access_when_trial_expired_and_no_subscription(self, db):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            auth = await _register(c, "expired_user")
+            # Force-expire the trial
+            result = await db.execute(select(User).where(User.username == "expired_user"))
+            user = result.scalar_one()
+            user.trial_ends_at = datetime.utcnow() - timedelta(days=1)
+            await db.commit()
+
+            token = auth["access_token"]
+            r = await c.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+            assert r.json()["has_access"] is False
+
+    async def test_has_access_when_subscription_active(self, db):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            auth = await _register(c, "sub_user")
+            result = await db.execute(select(User).where(User.username == "sub_user"))
+            user = result.scalar_one()
+            # Expire trial but activate subscription
+            user.trial_ends_at = datetime.utcnow() - timedelta(days=1)
+            user.subscription_status = "active"
+            user.subscription_current_period_end = datetime.utcnow() + timedelta(days=30)
+            await db.commit()
+
+            token = auth["access_token"]
+            r = await c.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
+            assert r.json()["has_access"] is True
+            assert r.json()["subscription_status"] == "active"
+
+
+class TestStripeEventsTable:
+    async def test_stripe_events_enforces_event_id_uniqueness(self, db):
+        db.add(StripeEvent(event_id="evt_dup_123", event_type="test", payload_json="{}"))
+        await db.commit()
+
+        db.add(StripeEvent(event_id="evt_dup_123", event_type="test", payload_json="{}"))
+        with pytest.raises(Exception):
+            await db.commit()
+        await db.rollback()
+
+    async def test_stripe_events_can_be_inserted_and_queried(self, db):
+        db.add(StripeEvent(
+            event_id="evt_unique_456",
+            event_type="customer.subscription.created",
+            payload_json='{"hello":"world"}',
+        ))
+        await db.commit()
+
+        result = await db.execute(
+            select(StripeEvent).where(StripeEvent.event_id == "evt_unique_456")
+        )
+        row = result.scalar_one()
+        assert row.event_type == "customer.subscription.created"
+        assert row.processed_at is None


### PR DESCRIPTION
Closes #869. Groundwork for #870-872. Depends on #885 (email verification migration) — this one chains after h2i3j4k5l6m7.

## Summary
Adds the fields Stripe's webhook will populate, plus a dedupe log for webhook replays. No access-gating logic yet (that's #871).

## Schema (migration \`i3j4k5l6m7n8\`)
- \`users.stripe_customer_id\` — unique, nullable
- \`users.subscription_status\` — trialing / active / past_due / canceled / incomplete
- \`users.subscription_current_period_end\` — timestamp
- \`users.trial_ends_at\` — timestamp
- New table \`stripe_events\` with unique \`event_id\` — webhook idempotency

## Behavior
- New users: \`trial_ends_at\` = now + 30 days, set in \`register()\`
- Existing users: same 30-day window starting from migration run — fresh trial for everyone at rollout rather than retroactive based on signup date
- \`/api/auth/me\` now includes \`subscription_status\`, \`trial_ends_at\`, \`subscription_current_period_end\`, and a computed \`has_access\` bool

## Tests (6 new)
- trial_ends_at is 30 days out after register
- has_access=True during trial, False after expiry, True again with active subscription
- stripe_events event_id uniqueness enforced
- stripe_events row can be inserted + queried

## Merge order
- #882 (secrets), #883 (observability), #884 (backups) — independent, merge anytime
- #885 (email verification) — must merge first since this migration depends on \`h2i3j4k5l6m7\`
- **this PR**
- #870 (Stripe checkout/portal) — depends on this PR's fields